### PR TITLE
Edited MASK section of docs

### DIFF
--- a/essentials/custom_node_images_and_masks.mdx
+++ b/essentials/custom_node_images_and_masks.mdx
@@ -90,9 +90,42 @@ for (batch_number, image) in enumerate(images):
 
 ## Masks
 
-A MASK is a `torch.Tensor` with shape `[B,C,H,W]` with `C=1`. However, it is not unusual for the `C` channel
-and/or the `B` channel to be squeezed. So it's always worth checking (I generally suggest dropping a breakpoint
-into the code)
+A MASK is a `torch.Tensor` with shape `[B,H,W]`. In computing contexts, masks have binary values (0 or 1) and are used to indicate which pixels should undergo specific operations. In digital photography, masks have values in a range from 0 to 1 and are often used to alter transparency, adjust filters, or composite layers. 
+
+### Masks from the Load Image Node
+
+The `LoadImage` node uses an image's alpha channel (the "A" in "RGBA") to create MASKs. The values from the alpha channel are normalized to the range [0,1] (torch.float32) and then inverted. The `LoadImage` node always produces a MASK output when loading an image. Many images (like JPEGs) don't have an alpha channel. In these cases, `LoadImage` creates a default mask with the shape `[1, 64, 64]`.
+
+### Understanding Mask Shapes
+
+In libraries like `numpy`, `PIL`, and many others, single-channel images (like masks) are typically represented as 2D arrays. This means the `C` (channel) dimension is implicit, and thus unlike IMAGE types, MASKs have only three dimensions: `[B, H, W]`. 
+
+To use a MASK with an IMAGE, you will often have to match shapes by unsqueezing. Keep in mind that you are unsqueezing the `C` dim, so you should `unsqueeze(3)`, or more easily: `unsqueeze(-1)`
+
+### Inverting Masks
+
+Inverting a mask is a straightforward process:
+
+```python
+mask = 1.0 - mask
+```
+
+Given the initial normalization of pixel values to the range [0,1] (torch.float32), and their subsequent or eventual conversion to binary (0 or 1), the operation `mask = 1.0 - mask` effectively inverts each pixel.
+
+### Using Masks as Transparency Layers
+
+When used for tasks like inpainting or segmentation, the MASK's values will eventually be rounded to the nearest integer so that they are binary — 0 indicating regions to be ignored and 1 indicating regions to be targeted. However, this doesn't happen until the MASK is passed to those nodes. This flexibility allows you to use MASKs as as you would in digital photography contexts as a transparency layer:
+
+```python
+# Invert mask back to original transparency layer
+mask = 1.0 - mask
+
+# Unsqueeze the `C` (channels) dimension
+mask = mask.unsqueeze(-1)
+
+# Concatenate ("cat") along the `C` dimension
+rgba_image = torch.cat((rgb_image, mask), dim=-1)
+```
 
 ## Latents
 


### PR DESCRIPTION
Appreciate the effort put into the documentation and site. It  deserves more visibility. I often see people on Reddit/Discord looking for good docs for creating nodes.

 I've suggested some edits for the MASK section.

There was some things that I thought might be slightly incorrect, but I could be wrong. The documentation states that masks have a default shape of `[B, H, W, C]`, but my understanding is that masks are created by calling `numpy.array()` on the alpha channel of a `PIL.Image.Image`, which creates a 2D array since it's a single channel. When it's then converted to a tensor, it will be `[B, H, W]`. 

Although I do remember at one point being in a scenario where I was getting `[B, H, W, C]` masks, so I understand why it was written. 

There's also note at the bottom of the page that also says MASKs are channel-first, but I don't believe MASKs have a channel dim by default and if we are to expand we should expand channel-last to match the expected type of IMAGE. 

In my suggested changes I added some snippets that can help people do common operations with masks. 

Thanks so much for making these docs! Everyone whose contributed did a great job explaining all the importatn stuff  concisely. Looking forward to your feedback on these changes.