### PR TITLE
Update PyProject Toml Specs Page

### DIFF
--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -59,10 +59,10 @@ This command will generate the following metadata:
 ```toml
 # pyproject.toml
 [project]
-name = "" # Unique identifier for your node. Immutable after creation.
+name = "" # Node ID. Unique identifier for your node. Immutable after creation.
 description = ""
 version = "1.0.0" # Custom Node version. Must be semantically versioned.
-license = "LICENSE"
+license = "LICENSE.txt"
 dependencies  = [] # Filled in from requirements.txt
 
 [project.urls]

--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -62,6 +62,7 @@ This command will generate the following metadata:
 name = "" # Unique identifier for your node. Immutable after creation.
 description = ""
 version = "1.0.0" # Custom Node version. Must be semantically versioned.
+license = "LICENSE"
 dependencies  = [] # Filled in from requirements.txt
 
 [project.urls]

--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -59,7 +59,7 @@ This command will generate the following metadata:
 ```toml
 # pyproject.toml
 [project]
-name = "" # Node ID. Unique identifier for your node. Immutable after creation.
+name = "" # Unique identifier for your node. Immutable after creation.
 description = ""
 version = "1.0.0" # Custom Node version. Must be semantically versioned.
 license = "LICENSE.txt"

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -15,24 +15,20 @@ The node id must be less than 50 characters and can only contain alphanumeric lo
 
 The registry uses [semantic versioning](https://semver.org/) which indicates the specific release of a custom node through a three-digit version number X.Y.Z.  
 
-X - **major** changes that break previous updates
+X - **MAJOR** change that breaks previous updates
 
-Y - **minor** changes that add new features and are backwards compatible
+Y - **MINOR** change that adds new features and is backwards compatible
 
-Z - **patch** changes are backward compatible bug fixes 
+Z - **PATCH** change that fixes a bug  
 
 # License
 
-An optional field that expects a path to the license file. It accepts file types .txt, .md, or has no extension. Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
+An optional field that expects a path to the license file. It accepts extensions TXT, MD, or no extension. Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
 
 # Publisher ID
 
 The publisher id (also known as your registry username) uniquely identifies a publisher and can be found after the `@` symbol on their profile page. Ideally, the publisher id and github username should be the same. 
 
-# Display Name
-
-The display name of the custom node on the UI-Manager and Registry.
-
 # Icon
 
-An optional field that expects a icon URL. It accepts file types SVG, PNG, JPG or GIF with a maximum resolution of 800px by 400px.
+An optional field that expects a icon URL. It accepts extensions SVG, PNG, JPG or GIF with a maximum resolution of 800px by 400px.

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -27,6 +27,10 @@ The license field expects a path to the license file (LICENSE.txt, LICENSE.md, L
 
 The publisher id uniquely identifies a custom node author's registry account. It appears after the `@` symbol on their registry profile page. During registry sign up it is is also referred to as the username.
 
+# Display Name
+
+The display name is what users will see when they install the custom node on the UI-Manager and Registry.
+
 # Icon
 
 The icon field expects a URL. It accepts file types SVG, PNG, JPG or GIF with a maximum resolution of 800 by  (MAX. 800x400px)

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -13,7 +13,7 @@ The node id must be less than 50 characters and can only contain alphanumeric lo
 
 # Version Number
 
-The registry uses semantic versioning which indicates the specific release of your custom node through a three-digit format X.Y.Z (e.g., 1.2.3). The numbers represent major 
+The registry uses [semantic versioning](https://semver.org/) which indicates the specific release of your custom node through a three-digit format X.Y.Z (e.g., 1.2.3). The numbers represent major 
 
 X - major changes for breaking updates
 Y - minor changes for new features which don't break previous versions

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -27,7 +27,7 @@ An optional field that expects a path to the license file. It accepts extensions
 
 # Publisher ID
 
-The publisher id (also known as your registry username) uniquely identifies a publisher and can be found after the `@` symbol on their profile page. Ideally, the publisher id and github username should be the same. 
+The publisher id uniquely identifies a publisher and is ideally the same as your github username. It is also referred to as the username on the registry and can be found after the `@` symbol on the profile page. 
 
 # Icon
 

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -5,8 +5,28 @@ title: "pyproject.toml"
 
 # Node ID
 
-The node id uniquely identifies the custom node, and will be used in URLs from the registry. Users can also install the node by referencing the name.
+The node id ("name" field in toml file) uniquely identifies the custom node, and will be used in URLs from the registry. Users can also install the node by referencing the name.
 
 `comfy node install <node-id>`
 
 The node id must be less than 50 characters and can only contain alphanumeric lowercase characters, hyphens, underscores, and periods. There should not be consequtive special characters and the id cannot start with a number or special character.
+
+# Version Number
+
+The registry uses semantic versioning which indicates the specific release of your custom node through a three-digit format X.Y.Z (e.g., 1.2.3). The numbers represent major 
+
+X - major changes for breaking updates
+Y - minor changes for new features which don't break previous versions
+Z - patch changes for bug fixes and small improvements
+
+# License
+
+The license field expects a path to the license file (LICENSE.txt, LICENSE.md, LICENSE). Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
+
+# Publisher ID
+
+The publisher id uniquely identifies a custom node author's registry account. It appears after the `@` symbol on their registry profile page. During registry sign up it is is also referred to as the username.
+
+# Icon
+
+The icon field expects a URL. It accepts file types SVG, PNG, JPG or GIF with a maximum resolution of 800 by  (MAX. 800x400px)

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -13,24 +13,26 @@ The node id must be less than 50 characters and can only contain alphanumeric lo
 
 # Version Number
 
-The registry uses [semantic versioning](https://semver.org/) which indicates the specific release of your custom node through a three-digit format X.Y.Z (e.g., 1.2.3). The numbers represent major 
+The registry uses [semantic versioning](https://semver.org/) which indicates the specific release of a custom node through a three-digit version number X.Y.Z.  
 
-X - major changes for breaking updates
-Y - minor changes for new features which don't break previous versions
-Z - patch changes for bug fixes and small improvements
+X - **major** changes that break previous updates
+
+Y - **minor** changes that add new features and are backwards compatible
+
+Z - **patch** changes are backward compatible bug fixes 
 
 # License
 
-The license field expects a path to the license file (LICENSE.txt, LICENSE.md, LICENSE). Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
+An optional field that expects a path to the license file. It accepts file types .txt, .md, or has no extension. Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
 
 # Publisher ID
 
-The publisher id uniquely identifies a custom node author's registry account. It appears after the `@` symbol on their registry profile page. During registry sign up it is is also referred to as the username.
+The publisher id (also known as your registry username) uniquely identifies a publisher and can be found after the `@` symbol on their profile page. Ideally, the publisher id and github username should be the same. 
 
 # Display Name
 
-The display name is what users will see when they install the custom node on the UI-Manager and Registry.
+The display name of the custom node on the UI-Manager and Registry.
 
 # Icon
 
-The icon field expects a URL. It accepts file types SVG, PNG, JPG or GIF with a maximum resolution of 800 by  (MAX. 800x400px)
+An optional field that expects a icon URL. It accepts file types SVG, PNG, JPG or GIF with a maximum resolution of 800px by 400px.


### PR DESCRIPTION
# Changes Made 
- specified .txt in LICENSE field
- added semver examples in version number 
- explicitly labelled what we expect [FILE PATHS, URLS, etc.] for more ambiguous fields [LICENSE, ICON] 

# Screenshot
![image](https://github.com/Comfy-Org/docs/assets/162922985/7395a463-745f-413c-9f38-c4247519d465)
