### PR TITLE
Update javascript_objects_and_hijacking.mdx

### DIFF
--- a/essentials/javascript_objects_and_hijacking.mdx
+++ b/essentials/javascript_objects_and_hijacking.mdx
@@ -250,6 +250,6 @@ current graph into a prompt that can be sent to the server.
         - `links` - a list of the `link_id` of all links from this output (if there are no connections, may be an empty list, or null), 
         - `shape` - the shape used to draw the output (default 3 for a dot)
         - `slot_index` - the slot number of the output
-- `version` - the version number of the workflow (at time of writing, `0.4`)
+- `version` - the LiteGraph version number (at time of writing, `0.4`)
 
 <Tip>`nodes.output` is absent for nodes with no outputs, not an empty list.</Tip>


### PR DESCRIPTION
These new docs are really nice. Here is a small change. See [LGraph.prototype.serialize](https://github.com/comfyanonymous/ComfyUI/blob/374e093e09c94b528d7c9dfc337c65cc5c433ee3/web/lib/litegraph.core.js#L2150-L2159)

You could also specify that the `nodes` property doesn't include muted or virtual nodes.