### PR TITLE
Update License File Naming

### DIFF
--- a/registry/overview.mdx
+++ b/registry/overview.mdx
@@ -62,7 +62,7 @@ This command will generate the following metadata:
 name = "" # Unique identifier for your node. Immutable after creation.
 description = ""
 version = "1.0.0" # Custom Node version. Must be semantically versioned.
-license = "LICENSE.txt"
+license = { file = "LICENSE.txt" }
 dependencies  = [] # Filled in from requirements.txt
 
 [project.urls]

--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -10,7 +10,7 @@ The node id ("name" field in toml file) uniquely identifies the custom node, and
 `comfy node install <node-id>`
 
 The node id must be less than 50 characters and can only contain alphanumeric lowercase characters, hyphens, underscores, and periods. There should not be consequtive special characters and the id cannot start with a number or special character.
-
+ 
 # Version Number
 
 The registry uses [semantic versioning](https://semver.org/) which indicates the specific release of a custom node through a three-digit version number X.Y.Z.  
@@ -23,7 +23,9 @@ Z - **PATCH** change that fixes a bug
 
 # License
 
-An optional field that expects a path to the license file. It accepts extensions TXT, MD, or no extension. Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
+An optional field that expects a path to the license file. The path should be relative to the pyproject.toml file and should be in the format `license = { file = "LICENSE.txt" }`. 
+
+It accepts extensions TXT, MD, or no extension. Common licenses include [MIT](https://opensource.org/license/mit), [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html), or [Apache](https://www.apache.org/licenses/LICENSE-2.0).
 
 # Publisher ID
 


### PR DESCRIPTION
- based on convo with DoctorPangloss we realized that there was an error in the way we were asking people to specify License paths
- should be license = {file = "LICENSE.txt" } , not license = "LICENSE.txt"