### PR TITLE
Add security standard: No use of `requests` to download Python code/libraries for use in modules

### DIFF
--- a/registry/standards.mdx
+++ b/registry/standards.mdx
@@ -71,3 +71,15 @@ Code obfuscation is prohibited in custom nodes.
 Obfuscated code:
 - Impossible to review and likely to be malicious
 
+#### Use of `requests` or direct downloading to populate Python code or libraries for use in modules
+The use of the `requests` library to download Python code from other repositories is not permitted.
+
+#### Policy
+Runtime package and library installation through `requests` calls, similar to `subprocess` calls to run `pip` installs and such, is not permitted.
+
+#### Reasoning
+The use of `requests` and other downloading libraries to directly download files can lead to injection of bad URLs via memory manipulation or by hijacked URLs. This leads to situations where insecure and unvetted code are downloaded and executed in your environment, including:
+ - Keyloggers
+ - Ransomware
+ - Data exfiltration and theft through unaudited code.
+ - Other malicious code execution


### PR DESCRIPTION
This is in the same spirit as the restriction of not allowing `pip` calls via `subprocess` calls.

The reason this is being suggested now is due to this observation of a module in the ComfyUI registry doing just this - using `requests` to download Python code from a separate repository and then write those files and then in the same module usage, import that library.  This is dangerous because it is unvetted / unauditable code.  https://github.com/1038lab/ComfyUI-OmniGen/blob/4f9d6a945e3fa7aaf4485c4e7c5292c9b4826ab7/ailab_OmniGen.py#L76