### PR TITLE
Fixes "client side code" link in the custom nodes walkthrough

### DIFF
--- a/custom-nodes/custom_node_walkthrough.mdx
+++ b/custom-nodes/custom_node_walkthrough.mdx
@@ -10,7 +10,7 @@ it to have a range of selection criteria, and then finally add some client side 
 This page assumes very little knowledge of Python or Javascript.
 
 After this walkthrough, dive into the details of [server side code](./custom_node_server_overview), 
-[client side code](./custom_node_javascript_overview), or [client-server comms](./comms_overview).
+[client side code](./javascript_overview), or [client-server comms](./comms_overview).
 
 ## The Basic Node
 


### PR DESCRIPTION
The link for client side code was pointing to the server overview page