### PR TITLE
Fix typo in `beforeRegisterNodeDef` hook example

### DIFF
--- a/custom-nodes/js/javascript_hooks.mdx
+++ b/custom-nodes/js/javascript_hooks.mdx
@@ -52,7 +52,7 @@ And play nicely - isolate your changes wherever possible.</Tip>
 A very common idiom in `beforeRegisterNodeDef` is to 'hijack' an existing method:
 ```Javascript
 async beforeRegisterNodeDef(nodeType, nodeData, app) {
-	if (nodeType.ComfyClass=="MyNodeClass") { 
+	if (nodeType.comfyClass=="MyNodeClass") { 
 		const onConnectionsChange = nodeType.prototype.onConnectionsChange;
 		nodeType.prototype.onConnectionsChange = function (side,slot,connect,link_info,output) {     
 			const r = onConnectionsChange?.apply(this, arguments);   


### PR DESCRIPTION
Use `nodeType.comfyClass` instead of `nodeType.ComfyClass`.