### PR TITLE
Add `AUDIO` for Tensor datatype

### DIFF
--- a/custom-nodes/backend/datatypes.mdx
+++ b/custom-nodes/backend/datatypes.mdx
@@ -108,6 +108,16 @@ Other entries in the dictionary contain things like latent masks.
 
 * Python datatype `torch.Tensor` with *shape* \[H,W] or \[B,C,H,W]
 
+### AUDIO
+
+* No additional parameters in `INPUT_TYPES`
+
+* Python datatype `dict`, containing a `torch.Tensor` with *shape* \[B, C, T] and a sample rate.
+
+The `dict` passed contains the key `waveform`, which is a `torch.Tensor` with *shape* \[B, C, T] representing a batch of `B` audio samples, with `C` channels (`C=2` for stereo and `C=1` for mono), and `T` time steps (i.e., the number of audio samples).
+
+The `dict` contains another key `sample_rate`, which indicates the sampling rate of the audio.
+
 ## Custom Sampling datatypes
 
 ### Noise


### PR DESCRIPTION
- Edited Part: https://docs.comfy.org/custom-nodes/backend/datatypes#tensor-datatypes

Added `AUDIO` for Tensor datatype.

The AUDIO format looks like this:
```python
{"sample_rate": 16000, "waveform": <torch.Tensor>}
```
It would be helpful to include this in the doc for nodes that involve audio (e.g. TTS nodes)


