### PR TITLE
style: Correct macOS capitalization in zh-CN macOS install guide

### DIFF
--- a/zh-CN/installation/desktop/macos.mdx
+++ b/zh-CN/installation/desktop/macos.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MacOs桌面版"
-description: "本文将介绍 ComfyUI Desktop MacOS 版本的下载以及安装使用"
+title: "macOS 桌面版"
+description: "本文将介绍 ComfyUI Desktop macOS 版本的下载以及安装使用。"
 icon: "apple"
 ---
 
@@ -11,35 +11,33 @@ import FirstGeneration from "/snippets/zh/install/first-generation.mdx"
 import TroubleshootingGpt from "/snippets/zh/install/troubleshooting-gpt.mdx"
 import TroubleshootingFeedback from "/snippets/zh/install/troubleshooting-feedback.mdx"
 
-**ComfyUI 桌面版（Desktop）** 是一个独立的安装版本，可以像常规软件一样安装，支持快捷安装自动配置 **Python环境及依赖** ，支持导入已有的 ComfyUI 设置、模型、工作流和文件
+**ComfyUI 桌面版（Desktop）** 是一个独立的安装版本，可以像常规软件一样安装，支持快捷安装、自动配置 **Python 环境及依赖**，并支持导入已有的 ComfyUI 设置、模型、工作流和文件。
 
-ComfyUI 桌面版是一个开源项目，完整代码请访问 [这里](https://github.com/Comfy-Org/desktop)
+ComfyUI 桌面版是一个开源项目，完整代码请访问[这里](https://github.com/Comfy-Org/desktop)。
 
-<Note>ComfyUI 桌面版（MacOS） 目前仅支持 Apple Silicon</Note>
+<Note>ComfyUI 桌面版（macOS）目前仅支持 Apple Silicon。</Note>
 
-本篇教程将引导你完成对应的软件安装，并说明相关安装配置说明。
+本篇教程将引导你完成对应的软件安装，并提供相关的安装配置说明。
 
-<Warning>由于 **ComfyUI 桌面版** 仍旧处于 **Beta** 状态，实际的安装过程可能会发生变化</Warning>
+<Warning>由于 **ComfyUI 桌面版** 仍处于 **Beta** 状态，实际的安装过程可能会发生变化。</Warning>
 
-## ComfyUI 桌面版（MacOS）下载
+## ComfyUI 桌面版（macOS）下载
 
-请点击下面的按钮下载对应的针对 MacOS 系统的 **ComfyUI 桌面版** 安装包
+请点击下面的按钮下载对应的 macOS 系统 **ComfyUI 桌面版** 安装包。
 
 <a className="prose" href="https://download.comfy.org/mac/dmg/arm64" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
-    <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download for MacOS</p>
+    <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download for macOS</p>
 </a>
 
 ## ComfyUI 桌面版安装步骤
 
-双击下载到的安装包文件，如图所示，请将**ComfyUI**程序，按键头所示拖入**Applications**文件夹
-
-![ComfyUI 安装包](/images/desktop/mac-comfyui-desktop-0.png)
-
-如果打开安装包后你的文件夹显示如下，在图标上出现禁止符号，说明你当前的系统版本与当前 **ComfyUI 桌面版**并不兼容
-![ComfyUI logo](/images/desktop/mac-comfyui-desktop-0-1.png)
-
-然后在 **启动台(Lanchpad)** 找到对应的 **ComfyUI 图标** 点击将进入 ComfyUI 的初始化设置
-![ComfyUI Lanchpad](/images/desktop/mac-comfyui-desktop-1.jpg)
+1.  双击下载到的安装包文件。
+2.  如图所示，请将 **ComfyUI** 程序按箭头所示拖入 **Applications** 文件夹。
+    ![ComfyUI 安装包](/images/desktop/mac-comfyui-desktop-0.png)
+3.  如果在打开安装包后，文件夹显示如下（图标上出现禁止符号），则说明你当前的系统版本与 **ComfyUI 桌面版** 不兼容。
+    ![ComfyUI logo](/images/desktop/mac-comfyui-desktop-0-1.png)
+4.  然后在 **启动台 (Launchpad)** 中找到对应的 **ComfyUI 图标**，点击它即可进入 ComfyUI 的初始化设置。
+    ![ComfyUI Launchpad](/images/desktop/mac-comfyui-desktop-1.jpg)
 
 ## ComfyUI 桌面版初始化流程
 
@@ -48,75 +46,76 @@ ComfyUI 桌面版是一个开源项目，完整代码请访问 [这里](https://
   <Tabs>
       <Tab title="正常启动">
       ![ComfyUI 安装步骤 - 起始](/images/desktop/mac-comfyui-desktop-2.png)
-      点击 **Get Started** 开始初始化步骤
+      点击 **Get Started** 开始初始化步骤。
       </Tab>
       <Tab title="维护页">
       <MaintenancePage/>
       </Tab>
       </Tabs>
 </Step>
-<Step title="Select GPU(GPU选择)">
+<Step title="Select GPU（GPU 选择）">
 ![ComfyUI 安装步骤 - GPU 选择](/images/desktop/mac-comfyui-desktop-3.png)
-对应三个选项为：
-1. **MPS（推荐）:**  Metal Performance Shaders (MPS) 是苹果的优化框架，让开发者能在苹果设备上利用 GPU 加速包括机器学习在内的高性能计算任务，且支持 PyTorch 等框架使用 GPU 提升模型训练和推理效率。
-2. **Manual Configuration 手动配置:** 你需要手动安装和配置 python 运行环境，除非你知道应该如何配置，否则请不要选择
-3. **Enable CPU Mode 启用 CPU 模式:** 仅适用于开发人员和特殊情况，除非你确定你需要使用这个模式，否则请不要选择
+对应三个选项：
+1. **MPS（推荐）：** Metal Performance Shaders (MPS) 是苹果的优化框架，让开发者能在苹果设备上利用 GPU 加速包括机器学习在内的高性能计算任务，且支持 PyTorch 等框架使用 GPU 提升模型训练和推理效率。
+2. **Manual Configuration（手动配置）：** 你需要手动安装和配置 Python 运行环境。除非你知道应该如何配置，否则请不要选择。
+3. **Enable CPU Mode（启用 CPU 模式）：** 仅适用于开发人员和特殊情况。除非你确定需要使用此模式，否则请不要选择。
   
-如无特殊情况，请按截图所示选择 **MPS**，并点击 **Next** 进入下一步
+如无特殊情况，请按截图所示选择 **MPS**，然后点击 **Next** 进入下一步。
 </Step>
-<Step title="Install location（安装位置）">
+<Step title="Install Location（安装位置）">
 ![ComfyUI 安装步骤 - 安装位置设置](/images/desktop/mac-comfyui-desktop-4.png)
-在这一步将选择 ComfyUI 以下相关内容的安装位置：
+在这一步选择 ComfyUI 以下相关内容的安装位置：
 - **Python 环境**
-- **Models 模型文件**
-- **Custom Nodes 自定义节点**
-建议：
-- 请新建一个单独的空白文件夹作为 ComfyUI 的安装目录
-- 请保证磁盘至少有 **5G** 左右的磁盘空间，以保证 **ComfyUI桌面版** 的正常安装
+- **Models（模型文件）**
+- **Custom Nodes（自定义节点）**
 
-<Note>ComfyUI 并非所有文件都安装在此目录下，部分文件将会位于 MacOS 的系统目录下，你可以参考本篇指南的卸载部分完成完整的 ComfyUI 桌面版的卸载</Note>
-完成后点击 **Next** 进入下一步
+建议：
+- 请新建一个单独的空白文件夹作为 ComfyUI 的安装目录。
+- 请确保磁盘至少有 **5GB** 左右的可用空间，以保证 **ComfyUI 桌面版** 的正常安装。
+
+<Note>ComfyUI 并非所有文件都安装在此目录下，部分文件将会位于 macOS 的系统目录下。你可以参考本篇指南的卸载部分，了解如何完全卸载 ComfyUI 桌面版。</Note>
+
+完成后点击 **Next** 进入下一步。
 </Step>
 <Step title="Migrate from Existing Installation（从已有安装迁移 - 可选）">
 ![ComfyUI 安装步骤 - 文件迁移](/images/desktop/mac-comfyui-desktop-5.png)
-在这一步你可以将你已有的 ComfyUI 安装内容迁移到 ComfyUI 桌面版中，选择你电脑上已有的 **ComfyUI** 安装目录，安装程序会自动识别对应目录下的：
-- **User Files 用户文件**
-- **Models 模型文件:** 不会进行复制，只是与桌面版进行关联
-- **Custom Nodes 自定义节点:** 节点将会重新进行安装
+在这一步，你可以将已有的 ComfyUI 安装内容迁移到 ComfyUI 桌面版中。选择你电脑上已有的 **ComfyUI** 安装目录，安装程序会自动识别对应目录下的：
+- **User Files（用户文件）**
+- **Models（模型文件）：** 不会进行复制，只是与桌面版进行关联。
+- **Custom Nodes（自定义节点）：** 节点将会重新进行安装。
 
-不要担心，这个步骤并不会复制模型文件，你可以按你的需要勾选或者取消勾选对应的选项，点击 **Next** 进入下一步
+不用担心，此步骤不会复制模型文件。你可以按需勾选或取消勾选对应的选项，然后点击 **Next** 进入下一步。
 </Step>
-<Step title="Desktop Setting(桌面版设置)">
+<Step title="Desktop Settings（桌面版设置）">
 ![ComfyUI 安装步骤 - 桌面版设置](/images/desktop/mac-comfyui-desktop-6.png)
-这一步是偏好设置
-1. **Automatic Updates 自动更新:** 是否设置在 ComfyUI 更新可用时自动更新
-2. **Usage Metrics 使用情况分析:** 如果启用，我们将收集**匿名的使用数据** 用于帮助我们改进 ComfyUI
-3. **Mirror Settings 镜像设置:** 由于程序需要联网下载 Python 完成相关环境安装，如果你在安装时候也如图所示出现了红色的❌，提示这可能会导致后续安装过程的失败，则请参考下面步骤进行处理
-![ComfyUI 安装步骤 - 镜像设置](/images/desktop/mac-comfyui-desktop-7.png)
-展开对应的镜像设置，找到具体失败的镜像，在当前截图中错误为 **Python Install Mirror** 镜像失败。
-<MirrorLinks/>  
+这一步是偏好设置：
+1. **Automatic Updates（自动更新）：** 设置是否在 ComfyUI 更新可用时自动更新。
+2. **Usage Metrics（使用情况分析）：** 如果启用，我们将收集**匿名的使用数据**，用于帮助我们改进 ComfyUI。
+3. **Mirror Settings（镜像设置）：** 由于程序需要联网下载 Python 以完成相关环境安装，如果你在安装时也如图所示出现红色的 ❌，这可能导致后续安装失败。请参考下面步骤进行处理：
+   ![ComfyUI 安装步骤 - 镜像设置](/images/desktop/mac-comfyui-desktop-7.png)
+   展开对应的镜像设置，找到具体失败的镜像。在当前截图中，错误为 **Python Install Mirror** 镜像下载失败。
+   <MirrorLinks/>  
 </Step>
 <Step title="完成安装">
-如果一切无误，安装程序将完成安装并自动进入 ComfyUI 桌面版界面, 则说明已经安装成功
+如果一切无误，安装程序将完成安装并自动进入 ComfyUI 桌面版界面，这说明已经安装成功。
 ![ComfyUI 桌面版界面](/images/desktop/comfyui-interface.jpg)
 </Step>
 </Steps>
-
 
 <FirstGeneration/>
 <UpdateComfyui/>
 
 ## 如何卸载 ComfyUI 桌面版
 
-对于 **ComfyUI 桌面版** 的卸载你可以直接在 **Application** 文件夹内删除 **ComfyUI**
+要卸载 **ComfyUI 桌面版**，你可以直接在 **Applications** 文件夹内删除 **ComfyUI** 程序。
 
-如果你想要完全删除 **ComfyUI 桌面版** 的所有文件，你可以手动删除以下文件夹：
-- /Users/Library/Application Support/ComfyUI
+如果你想要**完全删除** **ComfyUI 桌面版** 的所有文件，可以手动删除以下文件夹：
+- `~/Library/Application Support/ComfyUI`
 
-以上的操作并不会删除以下你的以下文件夹，如果你需要删除对应文件的话，请手动删除：
-- models 模型文件
-- custom nodes 自定义节点
-- input/output directories. 图片输入/输出目录
+以上操作**不会**删除你的以下文件夹。如果需要，请手动删除：
+- Models（模型文件）
+- Custom Nodes（自定义节点）
+- Input/Output 目录（图片输入/输出目录）
 
 
 ## 故障排除


### PR DESCRIPTION
- Corrected "MacOS" to "macOS" within the Chinese translation (`zh-CN/installation/desktop/macos.mdx`) per Apple style guide.
- Applied minor punctuation and wording fixes for clarity within the same file.