### PR TITLE
fixed link to hidream_i1_fast_bf16.safetensors

### DIFF
--- a/tutorials/image/hidream/hidream-i1.mdx
+++ b/tutorials/image/hidream/hidream-i1.mdx
@@ -164,7 +164,7 @@ Complete the workflow execution step by step
 Please select the appropriate version based on your hardware, click the link and download the corresponding model file to save to the `ComfyUI/models/diffusion_models/` folder.
 
 - FP8 version: [hidream_i1_fast_fp8.safetensors](https://huggingface.co/Comfy-Org/HiDream-I1_ComfyUI/resolve/main/split_files/diffusion_models/hidream_i1_fast_fp8.safetensors?download=true) requires more than 16GB of VRAM
-- Full version: [hidream_i1_fast_bf16.safetensors](https://huggingface.co/Comfy-Org/HiDream-I1_ComfyUI/resolve/main/split_files/diffusion_models/hidream_i1_fast_fp8.safetensors?download=true) requires more than 27GB of VRAM
+- Full version: [hidream_i1_fast_bf16.safetensors](https://huggingface.co/Comfy-Org/HiDream-I1_ComfyUI/resolve/main/split_files/diffusion_models/hidream_i1_fast_bf16.safetensors?download=true) requires more than 27GB of VRAM
 
 #### 2. Workflow File Download
 Please download the image below and drag it into ComfyUI to load the corresponding workflow


### PR DESCRIPTION
The link previously pointed to the fp8 variant.