### PR TITLE
Windows sidebar style nit

### DIFF
--- a/installation/desktop/windows.mdx
+++ b/installation/desktop/windows.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Windows Desktop Version"
 description: "This article introduces how to download, install and use ComfyUI Desktop for Windows"
-icon: "network-wired"
-sidebarTitle: "windows"
+icon: "windows"
+sidebarTitle: "Windows"
 ---
 
 import MirrorLinks from "/snippets/install/mirror-links.mdx"


### PR DESCRIPTION
This PR capitalizes Windows and replaces the network wired icon with the windows logo, aligning with MacOS and Linux.

Before:
![image](https://github.com/user-attachments/assets/4900b50e-44c4-4943-80c7-41a0bf68414e)

After:
![image](https://github.com/user-attachments/assets/e3840852-c9f3-4606-9563-7040ba14a1f5)
