### PR TITLE
Update ACE-Step workflow links

### DIFF
--- a/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -23,7 +23,7 @@ Click the button below to download the corresponding workflow file. Drag it into
 
 Click the button below to download the corresponding workflow file. Drag it into ComfyUI to load the workflow information. The workflow includes model download information.
 
-<a className="prose"  download href="https://raw.githubusercontent.com/Comfy-Org/example_workflows/main/audio/ace-step/ace_step_1_t2m.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/ace_step_1_t2m.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download Json Format Workflow File</p>
 </a>
 
@@ -46,13 +46,13 @@ Similar to image-to-image workflows, you can input a piece of music and use the 
 
 Click the button below to download the corresponding workflow file. Drag it into ComfyUI to load the workflow information.
 
-<a className="prose"  download href="https://raw.githubusercontent.com/Comfy-Org/example_workflows/main/audio/ace-step/ace_step_1_m2m_editing.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/ace_step_1_m2m_editing.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download Json Format Workflow File</p>
 </a>
 
 Download the following audio file as the input audio:
 
-<a className="prose"  download href="https://github.com/Comfy-Org/example_workflows/raw/refs/heads/main/audio/ace-step/input.mp3" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/input.mp3" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download Example Audio File for Input</p>
 </a>
 

--- a/zh-CN/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/zh-CN/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -20,7 +20,7 @@ ACE-Step 作为一个强大的音乐生成基座，提供了丰富的扩展能�
 
 点击下面的按钮下载对应的工作流文件，拖入 ComfyUI 中即可加载对应的工作流信息，对应工作流已包含模型下载信息。
 
-<a className="prose"  download href="https://raw.githubusercontent.com/Comfy-Org/example_workflows/main/audio/ace-step/ace_step_1_t2m.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/ace_step_1_t2m.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>下载 Json 格式工作流文件</p>
 </a>
 
@@ -45,14 +45,14 @@ ACE-Step 作为一个强大的音乐生成基座，提供了丰富的扩展能�
 
 点击下面的按钮下载对应的工作流文件，拖入 ComfyUI 中即可加载对应的工作流信息
 
-<a className="prose"  download href="https://raw.githubusercontent.com/Comfy-Org/example_workflows/main/audio/ace-step/ace_step_1_m2m_editing.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/ace_step_1_m2m_editing.json" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>下载 Json 格式工作流文件</p>
 </a>
 
 下载下面的音频作为输入音频
 
 
-<a className="prose"  download href="https://github.com/Comfy-Org/example_workflows/raw/refs/heads/main/audio/ace-step/input.mp3" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff!important', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
+<a className="prose" href="https://github.com/Comfy-Org/example_workflows/raw/main/audio/ace-step/input.mp3" style={{ display: 'inline-block', backgroundColor: '#0078D6', color: '#ffffff!important', padding: '10px 20px', borderRadius: '8px', borderColor: "transparent", textDecoration: 'none', fontWeight: 'bold'}}>
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>下载示例音频文件用于输入</p>
 </a>
 


### PR DESCRIPTION
Some download links in the ACE-Step docs page don't actually start a download, it just opens the raw JSON in the browser.

This PR aims to address that by starting the download in the user's browser.