### PR TITLE
Fix typo in backend snippets doc

### DIFF
--- a/custom-nodes/backend/snippets.mdx
+++ b/custom-nodes/backend/snippets.mdx
@@ -52,7 +52,7 @@ elif len(mask.shape)==3:                      # we have [B,H,W]
 
 ### Using Masks as Transparency Layers
 
-When used for tasks like inpainting or segmentation, the MASK's values will eventually be rounded to the nearest integer so that they are binary — 0 indicating regions to be ignored and 1 indicating regions to be targeted. However, this doesn't happen until the MASK is passed to those nodes. This flexibility allows you to use MASKs as as you would in digital photography contexts as a transparency layer:
+When used for tasks like inpainting or segmentation, the MASK's values will eventually be rounded to the nearest integer so that they are binary — 0 indicating regions to be ignored and 1 indicating regions to be targeted. However, this doesn't happen until the MASK is passed to those nodes. This flexibility allows you to use MASKs as you would in digital photography contexts as a transparency layer:
 
 ```python
 # Invert mask back to original transparency layer


### PR DESCRIPTION
## Summary
- fix repeated word in custom nodes snippets doc

## Testing
- `npm run dev` *(fails: command aborted due to environment)*