### PR TITLE
Add documentation for frontend developer APIs

### DIFF
--- a/custom-nodes/js/javascript_about_panel_badges.mdx
+++ b/custom-nodes/js/javascript_about_panel_badges.mdx
@@ -1,0 +1,78 @@
+---
+title: "About Panel Badges"
+---
+
+The About Panel Badges API allows extensions to add custom badges to the ComfyUI about page. These badges can display information about your extension and contain links to documentation, source code, or other resources.
+
+## Basic Usage
+
+```javascript
+app.registerExtension({
+  name: "MyExtension",
+  aboutPageBadges: [
+    {
+      label: "Documentation",
+      url: "https://example.com/docs",
+      icon: "pi pi-file"
+    },
+    {
+      label: "GitHub",
+      url: "https://github.com/username/repo",
+      icon: "pi pi-github"
+    }
+  ]
+});
+```
+
+## Badge Configuration
+
+Each badge requires all of these properties:
+
+```javascript
+{
+  label: string,           // Text to display on the badge
+  url: string,             // URL to open when badge is clicked
+  icon: string             // Icon class (e.g., PrimeVue icon)
+}
+```
+
+## Icon Options
+
+Badge icons use PrimeVue's icon set. Here are some commonly used icons:
+
+- Documentation: `pi pi-file` or `pi pi-book`
+- GitHub: `pi pi-github`
+- External link: `pi pi-external-link`
+- Information: `pi pi-info-circle`
+- Download: `pi pi-download`
+- Website: `pi pi-globe`
+- Discord: `pi pi-discord`
+
+For a complete list of available icons, refer to the [PrimeVue Icons documentation](https://primevue.org/icons/).
+
+## Example
+
+```javascript
+app.registerExtension({
+  name: "BadgeExample",
+  aboutPageBadges: [
+    {
+      label: "Website",
+      url: "https://example.com",
+      icon: "pi pi-home"
+    },
+    {
+      label: "Donate",
+      url: "https://example.com/donate",
+      icon: "pi pi-heart"
+    },
+    {
+      label: "Documentation",
+      url: "https://example.com/docs",
+      icon: "pi pi-book"
+    }
+  ]
+});
+```
+
+Badges appear in the About panel of the Settings dialog, which can be accessed via the gear icon in the top-right corner of the ComfyUI interface.

--- a/custom-nodes/js/javascript_bottom_panel_tabs.mdx
+++ b/custom-nodes/js/javascript_bottom_panel_tabs.mdx
@@ -1,0 +1,130 @@
+---
+title: "Bottom Panel Tabs"
+---
+
+The Bottom Panel Tabs API allows extensions to add custom tabs to the bottom panel of the ComfyUI interface. This is useful for adding features like logs, debugging tools, or custom panels.
+
+## Basic Usage
+
+```javascript
+app.registerExtension({
+  name: "MyExtension",
+  bottomPanelTabs: [
+    {
+      id: "customTab",
+      title: "Custom Tab",
+      type: "custom",
+      render: (el) => {
+        el.innerHTML = '<div>This is my custom tab content</div>';
+      }
+    }
+  ]
+});
+```
+
+## Tab Configuration
+
+Each tab requires an `id`, `title`, and `type`, along with a render function:
+
+```javascript
+{
+  id: string,              // Unique identifier for the tab
+  title: string,           // Display title shown on the tab
+  type: string,            // Tab type (usually "custom")
+  icon?: string,           // Icon class (optional)
+  render: (element) => void // Function that populates the tab content
+}
+```
+
+The `render` function receives a DOM element where you should insert your tab's content.
+
+## Interactive Elements
+
+You can add interactive elements like buttons:
+
+```javascript
+app.registerExtension({
+  name: "InteractiveTabExample",
+  bottomPanelTabs: [
+    {
+      id: "controlsTab",
+      title: "Controls",
+      type: "custom",
+      render: (el) => {
+        el.innerHTML = `
+          <div style="padding: 10px;">
+            <button id="runBtn">Run Workflow</button>
+          </div>
+        `;
+        
+        // Add event listeners
+        el.querySelector('#runBtn').addEventListener('click', () => {
+          app.queuePrompt();
+        });
+      }
+    }
+  ]
+});
+```
+
+## Using React Components
+
+You can mount React components in bottom panel tabs:
+
+```javascript
+// Import React dependencies in your extension
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+// Simple React component
+function TabContent() {
+  const [count, setCount] = React.useState(0);
+  
+  return (
+    <div style={{ padding: "10px" }}>
+      <h3>React Component</h3>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  );
+}
+
+// Register the extension with React content
+app.registerExtension({
+  name: "ReactTabExample",
+  bottomPanelTabs: [
+    {
+      id: "reactTab",
+      title: "React Tab",
+      type: "custom",
+      render: (el) => {
+        const container = document.createElement("div");
+        container.id = "react-tab-container";
+        el.appendChild(container);
+        
+        // Mount React component
+        ReactDOM.createRoot(container).render(
+          <React.StrictMode>
+            <TabContent />
+          </React.StrictMode>
+        );
+      }
+    }
+  ]
+});
+```
+
+## Standalone Registration
+
+You can also register tabs outside of `registerExtension`:
+
+```javascript
+app.extensionManager.registerBottomPanelTab({
+  id: "standAloneTab",
+  title: "Stand-Alone Tab",
+  type: "custom",
+  render: (el) => {
+    el.innerHTML = '<div>This tab was registered independently</div>';
+  }
+});
+```

--- a/custom-nodes/js/javascript_commands_keybindings.mdx
+++ b/custom-nodes/js/javascript_commands_keybindings.mdx
@@ -1,0 +1,151 @@
+---
+title: "Commands and Keybindings"
+---
+
+The Commands and Keybindings API allows extensions to register custom commands and associate them with keyboard shortcuts. This enables users to quickly trigger actions without using the mouse.
+
+## Basic Usage
+
+```javascript
+app.registerExtension({
+  name: "MyExtension",
+  // Register commands
+  commands: [
+    {
+      id: "myCommand",
+      label: "My Command",
+      function: () => {
+        console.log("Command executed!");
+      }
+    }
+  ],
+  // Associate keybindings with commands
+  keybindings: [
+    {
+      combo: { key: "k", ctrl: true },
+      commandId: "myCommand"
+    }
+  ]
+});
+```
+
+## Command Configuration
+
+Each command requires an `id`, `label`, and `function`:
+
+```javascript
+{
+  id: string,              // Unique identifier for the command
+  label: string,           // Display name for the command
+  function: () => void     // Function to execute when command is triggered
+}
+```
+
+## Keybinding Configuration
+
+Each keybinding requires a `combo` and `commandId`:
+
+```javascript
+{
+  combo: {                 // Key combination
+    key: string,           // The main key (single character or special key)
+    ctrl?: boolean,        // Require Ctrl key (optional)
+    shift?: boolean,       // Require Shift key (optional)
+    alt?: boolean,         // Require Alt key (optional)
+    meta?: boolean         // Require Meta/Command key (optional)
+  },
+  commandId: string        // ID of the command to trigger
+}
+```
+
+### Special Keys
+
+For non-character keys, use one of these values:
+- Arrow keys: `"ArrowUp"`, `"ArrowDown"`, `"ArrowLeft"`, `"ArrowRight"`
+- Function keys: `"F1"` through `"F12"`
+- Other special keys: `"Escape"`, `"Tab"`, `"Enter"`, `"Backspace"`, `"Delete"`, `"Home"`, `"End"`, `"PageUp"`, `"PageDown"`
+
+## Command Examples
+
+```javascript
+app.registerExtension({
+  name: "CommandExamples",
+  commands: [
+    {
+      id: "runWorkflow",
+      label: "Run Workflow",
+      function: () => {
+        app.queuePrompt();
+      }
+    },
+    {
+      id: "clearWorkflow",
+      label: "Clear Workflow",
+      function: () => {
+        if (confirm("Clear the workflow?")) {
+          app.graph.clear();
+        }
+      }
+    },
+    {
+      id: "saveWorkflow",
+      label: "Save Workflow",
+      function: () => {
+        app.graphToPrompt().then(workflow => {
+          const blob = new Blob([JSON.stringify(workflow)], {type: "application/json"});
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "workflow.json";
+          a.click();
+          URL.revokeObjectURL(url);
+        });
+      }
+    }
+  ]
+});
+```
+
+## Keybinding Examples
+
+```javascript
+app.registerExtension({
+  name: "KeybindingExamples",
+  commands: [
+    /* Commands defined above */
+  ],
+  keybindings: [
+    // Ctrl+R to run workflow
+    {
+      combo: { key: "r", ctrl: true },
+      commandId: "runWorkflow"
+    },
+    // Ctrl+Shift+C to clear workflow
+    {
+      combo: { key: "c", ctrl: true, shift: true },
+      commandId: "clearWorkflow"
+    },
+    // Ctrl+S to save workflow
+    {
+      combo: { key: "s", ctrl: true },
+      commandId: "saveWorkflow"
+    },
+    // F5 to run workflow (alternative)
+    {
+      combo: { key: "F5" },
+      commandId: "runWorkflow"
+    }
+  ]
+});
+```
+
+## Notes and Limitations
+
+- Keybindings defined in the ComfyUI core cannot be overwritten by extensions. Check the core keybindings in these source files:
+  - [Core Commands](https://github.com/Comfy-Org/ComfyUI_frontend/blob/e76e9ec61a068fd2d89797762f08ee551e6d84a0/src/composables/useCoreCommands.ts)
+  - [Core Menu Commands](https://github.com/Comfy-Org/ComfyUI_frontend/blob/e76e9ec61a068fd2d89797762f08ee551e6d84a0/src/constants/coreMenuCommands.ts) 
+  - [Core Keybindings](https://github.com/Comfy-Org/ComfyUI_frontend/blob/e76e9ec61a068fd2d89797762f08ee551e6d84a0/src/constants/coreKeybindings.ts)
+  - [Reserved Key Combos](https://github.com/Comfy-Org/ComfyUI_frontend/blob/e76e9ec61a068fd2d89797762f08ee551e6d84a0/src/constants/reservedKeyCombos.ts)
+
+- Some key combinations are reserved by the browser (like Ctrl+F for search) and cannot be overridden
+- If multiple extensions register the same keybinding, the behavior is undefined

--- a/custom-nodes/js/javascript_dialog.mdx
+++ b/custom-nodes/js/javascript_dialog.mdx
@@ -1,0 +1,65 @@
+---
+title: "Dialog API"
+---
+
+The Dialog API provides standardized dialogs that work consistently across desktop and web environments. Extension authors will find the prompt and confirm methods most useful.
+
+## Basic Usage
+
+### Prompt Dialog
+
+```javascript
+// Show a prompt dialog
+app.extensionManager.dialog.prompt({
+  title: "User Input",
+  message: "Please enter your name:",
+  defaultValue: "User"
+}).then(result => {
+  if (result !== null) {
+    console.log(`Input: ${result}`);
+  }
+});
+```
+
+### Confirm Dialog
+
+```javascript
+// Show a confirmation dialog
+app.extensionManager.dialog.confirm({
+  title: "Confirm Action",
+  message: "Are you sure you want to continue?",
+  type: "default"
+}).then(result => {
+  console.log(result ? "User confirmed" : "User cancelled");
+});
+```
+
+## API Reference
+
+### Prompt
+
+```javascript
+app.extensionManager.dialog.prompt({
+  title: string,             // Dialog title
+  message: string,           // Message/question to display
+  defaultValue?: string      // Initial value in the input field (optional)
+}).then((result: string | null) => {
+  // result is the entered text, or null if cancelled
+});
+```
+
+### Confirm
+
+```javascript
+app.extensionManager.dialog.confirm({
+  title: string,             // Dialog title
+  message: string,           // Message to display
+  type?: "default" | "overwrite" | "delete" | "dirtyClose" | "reinstall", // Dialog type (optional)
+  itemList?: string[],       // List of items to display (optional)
+  hint?: string              // Hint text to display (optional)
+}).then((result: boolean | null) => {
+  // result is true if confirmed, false if denied, null if cancelled
+});
+```
+
+For other specialized dialogs available in ComfyUI, extension authors can refer to the `dialogService.ts` file in the source code.

--- a/custom-nodes/js/javascript_sidebar_tabs.mdx
+++ b/custom-nodes/js/javascript_sidebar_tabs.mdx
@@ -1,0 +1,178 @@
+---
+title: "Sidebar Tabs"
+---
+
+The Sidebar Tabs API allows extensions to add custom tabs to the sidebar of the ComfyUI interface. This is useful for adding features that require persistent visibility and quick access.
+
+## Basic Usage
+
+```javascript
+app.extensionManager.registerSidebarTab({
+  id: "customSidebar",
+  icon: "pi pi-compass",
+  title: "Custom Tab",
+  tooltip: "My Custom Sidebar Tab",
+  type: "custom",
+  render: (el) => {
+    el.innerHTML = '<div>This is my custom sidebar content</div>';
+  }
+});
+```
+
+## Tab Configuration
+
+Each tab requires several properties:
+
+```javascript
+{
+  id: string,              // Unique identifier for the tab
+  icon: string,            // Icon class for the tab button
+  title: string,           // Title text for the tab
+  tooltip?: string,        // Tooltip text on hover (optional)
+  type: string,            // Tab type (usually "custom")
+  render: (element) => void // Function that populates the tab content
+}
+```
+
+The `render` function receives a DOM element where you should insert your tab's content.
+
+## Icon Options
+
+Sidebar tab icons can use various icon sets:
+
+- PrimeVue icons: `pi pi-[icon-name]` (e.g., `pi pi-home`)
+- Material Design icons: `mdi mdi-[icon-name]` (e.g., `mdi mdi-robot`)
+- Font Awesome icons: `fa-[style] fa-[icon-name]` (e.g., `fa-solid fa-star`)
+
+Ensure the corresponding icon library is loaded before using these icons.
+
+## Stateful Tab Example
+
+You can create tabs that maintain state:
+
+```javascript
+app.extensionManager.registerSidebarTab({
+  id: "statefulTab",
+  icon: "pi pi-list",
+  title: "Notes",
+  type: "custom",
+  render: (el) => {
+    // Create elements
+    const container = document.createElement('div');
+    container.style.padding = '10px';
+    
+    const notepad = document.createElement('textarea');
+    notepad.style.width = '100%';
+    notepad.style.height = '200px';
+    notepad.style.marginBottom = '10px';
+    
+    // Load saved content if available
+    const savedContent = localStorage.getItem('comfyui-notes');
+    if (savedContent) {
+      notepad.value = savedContent;
+    }
+    
+    // Auto-save content
+    notepad.addEventListener('input', () => {
+      localStorage.setItem('comfyui-notes', notepad.value);
+    });
+    
+    // Assemble the UI
+    container.appendChild(notepad);
+    el.appendChild(container);
+  }
+});
+```
+
+## Using React Components
+
+You can mount React components in sidebar tabs:
+
+```javascript
+// Import React dependencies in your extension
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+// Register sidebar tab with React content
+app.extensionManager.registerSidebarTab({
+  id: "reactSidebar",
+  icon: "mdi mdi-react",
+  title: "React Tab",
+  type: "custom",
+  render: (el) => {
+    const container = document.createElement("div");
+    container.id = "react-sidebar-container";
+    el.appendChild(container);
+    
+    // Define a simple React component
+    function SidebarContent() {
+      const [count, setCount] = React.useState(0);
+      
+      return (
+        <div style={{ padding: "10px" }}>
+          <h3>React Sidebar</h3>
+          <p>Count: {count}</p>
+          <button onClick={() => setCount(count + 1)}>
+            Increment
+          </button>
+        </div>
+      );
+    }
+    
+    // Mount React component
+    ReactDOM.createRoot(container).render(
+      <React.StrictMode>
+        <SidebarContent />
+      </React.StrictMode>
+    );
+  }
+});
+```
+
+For a real-world example of a React application integrated as a sidebar tab, check out the [ComfyUI-Copilot project on GitHub](https://github.com/AIDC-AI/ComfyUI-Copilot).
+
+## Dynamic Content Updates
+
+You can update sidebar content in response to graph changes:
+
+```javascript
+app.extensionManager.registerSidebarTab({
+  id: "dynamicSidebar",
+  icon: "pi pi-chart-line",
+  title: "Stats",
+  type: "custom",
+  render: (el) => {
+    const container = document.createElement('div');
+    container.style.padding = '10px';
+    el.appendChild(container);
+    
+    // Function to update stats
+    function updateStats() {
+      const stats = {
+        nodes: app.graph._nodes.length,
+        connections: Object.keys(app.graph.links).length
+      };
+      
+      container.innerHTML = `
+        <h3>Workflow Stats</h3>
+        <ul>
+          <li>Nodes: ${stats.nodes}</li>
+          <li>Connections: ${stats.connections}</li>
+        </ul>
+      `;
+    }
+    
+    // Initial update
+    updateStats();
+    
+    // Listen for graph changes
+    const api = app.api;
+    api.addEventListener("graphChanged", updateStats);
+    
+    // Clean up listeners when tab is destroyed
+    return () => {
+      api.removeEventListener("graphChanged", updateStats);
+    };
+  }
+});
+```

--- a/custom-nodes/js/javascript_toast.mdx
+++ b/custom-nodes/js/javascript_toast.mdx
@@ -1,0 +1,87 @@
+---
+title: "Toast API"
+---
+
+The Toast API provides a way to display non-blocking notification messages to users. These are useful for providing feedback without interrupting workflow.
+
+## Basic Usage
+
+### Simple Toast
+
+```javascript
+// Display a simple info toast
+app.extensionManager.toast.add({
+  severity: "info",
+  summary: "Information",
+  detail: "Operation completed successfully",
+  life: 3000
+});
+```
+
+### Toast Types
+
+```javascript
+// Success toast
+app.extensionManager.toast.add({
+  severity: "success",
+  summary: "Success",
+  detail: "Data saved successfully",
+  life: 3000
+});
+
+// Warning toast
+app.extensionManager.toast.add({
+  severity: "warn",
+  summary: "Warning",
+  detail: "This action may cause problems",
+  life: 5000
+});
+
+// Error toast
+app.extensionManager.toast.add({
+  severity: "error",
+  summary: "Error",
+  detail: "Failed to process request",
+  life: 5000
+});
+```
+
+### Alert Helper
+
+```javascript
+// Shorthand for creating an alert toast
+app.extensionManager.toast.addAlert("This is an important message");
+```
+
+## API Reference
+
+### Toast Message
+
+```javascript
+app.extensionManager.toast.add({
+  severity?: "success" | "info" | "warn" | "error" | "secondary" | "contrast", // Message severity level (default: "info")
+  summary?: string,         // Short title for the toast
+  detail?: any,             // Detailed message content
+  closable?: boolean,       // Whether user can close the toast (default: true)
+  life?: number,            // Duration in milliseconds before auto-closing
+  group?: string,           // Group identifier for managing related toasts
+  styleClass?: any,         // Style class of the message
+  contentStyleClass?: any   // Style class of the content
+});
+```
+
+### Alert Helper
+
+```javascript
+app.extensionManager.toast.addAlert(message: string);
+```
+
+### Additional Methods
+
+```javascript
+// Remove a specific toast
+app.extensionManager.toast.remove(toastMessage);
+
+// Remove all toasts
+app.extensionManager.toast.removeAll();
+```

--- a/custom-nodes/js/javascript_topbar_menu.mdx
+++ b/custom-nodes/js/javascript_topbar_menu.mdx
@@ -1,0 +1,155 @@
+---
+title: "Topbar Menu"
+---
+
+The Topbar Menu API allows extensions to add custom menu items to the ComfyUI's top menu bar. This is useful for providing access to advanced features or less frequently used commands.
+
+## Basic Usage
+
+```javascript
+app.registerExtension({
+  name: "MyExtension",
+  // Define commands
+  commands: [
+    { 
+      id: "myCommand", 
+      label: "My Command", 
+      function: () => { alert("Command executed!"); } 
+    }
+  ],
+  // Add commands to menu
+  menuCommands: [
+    { 
+      path: ["Extensions", "My Extension"], 
+      commands: ["myCommand"] 
+    }
+  ]
+});
+```
+
+Command definitions follow the same pattern as in the [Commands and Keybindings API](./javascript_commands_keybindings). See that page for more detailed information about defining commands.
+
+## Command Configuration
+
+Each command requires an `id`, `label`, and `function`:
+
+```javascript
+{
+  id: string,              // Unique identifier for the command
+  label: string,           // Display name for the command
+  function: () => void     // Function to execute when command is triggered
+}
+```
+
+## Menu Configuration
+
+The `menuCommands` array defines where to place commands in the menu structure:
+
+```javascript
+{
+  path: string[],          // Array representing menu hierarchy
+  commands: string[]       // Array of command IDs to add at this location
+}
+```
+
+The `path` array specifies the menu hierarchy. For example, `["File", "Export"]` would add commands to the "Export" submenu under the "File" menu.
+
+## Menu Examples
+
+### Adding to Existing Menus
+
+```javascript
+app.registerExtension({
+  name: "MenuExamples",
+  commands: [
+    { 
+      id: "saveAsImage", 
+      label: "Save as Image", 
+      function: () => { 
+        // Code to save canvas as image
+      } 
+    },
+    { 
+      id: "exportWorkflow", 
+      label: "Export Workflow", 
+      function: () => { 
+        // Code to export workflow
+      } 
+    }
+  ],
+  menuCommands: [
+    // Add to File menu
+    { 
+      path: ["File"], 
+      commands: ["saveAsImage", "exportWorkflow"] 
+    }
+  ]
+});
+```
+
+### Creating Submenu Structure
+
+```javascript
+app.registerExtension({
+  name: "SubmenuExample",
+  commands: [
+    { 
+      id: "option1", 
+      label: "Option 1", 
+      function: () => { console.log("Option 1"); } 
+    },
+    { 
+      id: "option2", 
+      label: "Option 2", 
+      function: () => { console.log("Option 2"); } 
+    },
+    { 
+      id: "suboption1", 
+      label: "Sub-option 1", 
+      function: () => { console.log("Sub-option 1"); } 
+    }
+  ],
+  menuCommands: [
+    // Create a nested menu structure
+    { 
+      path: ["Extensions", "My Tools"], 
+      commands: ["option1", "option2"] 
+    },
+    { 
+      path: ["Extensions", "My Tools", "Advanced"], 
+      commands: ["suboption1"] 
+    }
+  ]
+});
+```
+
+### Multiple Menu Locations
+
+You can add the same command to multiple menu locations:
+
+```javascript
+app.registerExtension({
+  name: "MultiLocationExample",
+  commands: [
+    { 
+      id: "helpCommand", 
+      label: "Get Help", 
+      function: () => { window.open("https://docs.example.com", "_blank"); } 
+    }
+  ],
+  menuCommands: [
+    // Add to Help menu
+    { 
+      path: ["Help"], 
+      commands: ["helpCommand"] 
+    },
+    // Also add to Extensions menu
+    { 
+      path: ["Extensions"], 
+      commands: ["helpCommand"] 
+    }
+  ]
+});
+```
+
+Commands can work with other ComfyUI APIs like settings. For more information about the Settings API, see the [Settings API](./javascript_settings) documentation.

--- a/docs.json
+++ b/docs.json
@@ -384,6 +384,13 @@
                       "custom-nodes/js/javascript_hooks",
                       "custom-nodes/js/javascript_objects_and_hijacking",
                       "custom-nodes/js/javascript_settings",
+                      "custom-nodes/js/javascript_dialog",
+                      "custom-nodes/js/javascript_toast",
+                      "custom-nodes/js/javascript_about_panel_badges",
+                      "custom-nodes/js/javascript_bottom_panel_tabs",
+                      "custom-nodes/js/javascript_sidebar_tabs",
+                      "custom-nodes/js/javascript_commands_keybindings",
+                      "custom-nodes/js/javascript_topbar_menu",
                       "custom-nodes/js/javascript_examples"
                     ]
                   },

--- a/docs.json
+++ b/docs.json
@@ -798,6 +798,13 @@
                       "custom-nodes/js/javascript_hooks",
                       "custom-nodes/js/javascript_objects_and_hijacking",
                       "custom-nodes/js/javascript_settings",
+                      "custom-nodes/js/javascript_dialog",
+                      "custom-nodes/js/javascript_toast",
+                      "custom-nodes/js/javascript_about_panel_badges",
+                      "custom-nodes/js/javascript_bottom_panel_tabs",
+                      "custom-nodes/js/javascript_sidebar_tabs",
+                      "custom-nodes/js/javascript_commands_keybindings",
+                      "custom-nodes/js/javascript_topbar_menu",
                       "custom-nodes/js/javascript_examples"
                     ]
                   },


### PR DESCRIPTION
Add comprehensive documentation for 6 previously undocumented frontend JavaScript APIs including Dialog, Toast, About Panel Badges, Bottom Panel Tabs, Sidebar Tabs, and Commands/Keybindings. Each API page includes basic usage, configuration options, and practical examples.