### PR TITLE
Add documentation for external model paths

### DIFF
--- a/essentials/core-concepts/models.mdx
+++ b/essentials/core-concepts/models.mdx
@@ -3,6 +3,8 @@ title: "Models"
 icon: "file"
 ---
 
+import ExternalModels from "/snippets/install/add-external-models.mdx"
+
 {/*
 description: "Understand AI models and their role in ComfyUI"
 */}
@@ -29,6 +31,8 @@ Model files are absolutely required for generative media production. Nothing can
 2. In your workflow, create the node appropriate to the model type, e.g. **Load Checkpoint**, **Load LoRA**, **Load VAE**
 3. In the loader node, choose the model you wish to use
 4. Connect the loader node to other nodes in your workflow
+
+<ExternalModels />
 
 ### File size
 

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -5,4 +5,10 @@ sidebarTitle: "Linux"
 icon: "linux"
 ---
 
+import ExternalModelsDesktop from "/snippets/install/external-models-desktop.mdx"
+
 <Warning>Linux pre-built packages are not yet available. Please try [manual installation.](/installation/manual_install)</Warning>
+
+When Linux desktop packages become available, you can configure external model paths:
+
+<ExternalModelsDesktop/>

--- a/installation/desktop/macos.mdx
+++ b/installation/desktop/macos.mdx
@@ -11,6 +11,7 @@ import UpdateComfyui from "/snippets/install/update-comfyui.mdx"
 import FirstGeneration from "/snippets/install/first-generation.mdx"
 import TroubleshootingGpt from "/snippets/install/troubleshooting-gpt.mdx"
 import TroubleshootingFeedback from "/snippets/install/troubleshooting-feedback.mdx"
+import ExternalModelsDesktop from "/snippets/install/external-models-desktop.mdx"
 
 **ComfyUI Desktop** is a standalone installation version that can be installed like regular software.
 It supports quick installation and automatic configuration of the **Python environment and dependencies**, and supports one-click import of existing ComfyUI settings, models, workflows, and files.
@@ -117,6 +118,7 @@ Then find the **ComfyUI icon** in **Launchpad** and click it to enter ComfyUI in
 
 <FirstGeneration/>
 <UpdateComfyui/>
+<ExternalModelsDesktop/>
 
 ## How to Uninstall ComfyUI Desktop
 

--- a/installation/desktop/windows.mdx
+++ b/installation/desktop/windows.mdx
@@ -11,6 +11,7 @@ import UpdateComfyui from "/snippets/install/update-comfyui.mdx"
 import FirstGeneration from "/snippets/install/first-generation.mdx"
 import TroubleshootingGpt from "/snippets/install/troubleshooting-gpt.mdx"
 import TroubleshootingFeedback from "/snippets/install/troubleshooting-feedback.mdx"
+import ExternalModelsDesktop from "/snippets/install/external-models-desktop.mdx"
 
 
 **ComfyUI Desktop** is a standalone installation version that can be installed like regular software. It supports quick installation and automatic configuration of the **Python environment and dependencies**, and supports one-click import of existing ComfyUI settings, models, workflows, and files. You can quickly migrate from an existing [ComfyUI Portable version](/installation/comfyui_portable_windows) to the Desktop version.
@@ -117,6 +118,7 @@ Double-click the corresponding shortcut to enter ComfyUI initialization settings
 
 <FirstGeneration/>
 <UpdateComfyui/>
+<ExternalModelsDesktop/>
 
 ## How to Uninstall ComfyUI Desktop
 

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -1,0 +1,30 @@
+### Adding External Model Paths
+
+If you downloaded a model but ComfyUI cannot find it, you may need to add an additional model search path to the yaml file.
+
+#### Example scenario
+You need to add a motion LoRA and your model is located in `C:\Users\YourUsername\models\animatediff_motion_lora`.
+
+#### Solution
+1. Add the below line to the `extra_model_config.yaml` file
+2. Restart ComfyUI
+
+```yaml
+additional_model_paths:
+  animatediff_motion_lora: C:\Users\YourUsername\models\animatediff_motion_lora/
+```
+
+#### YAML config file locations
+- On Windows: `%APPDATA%\ComfyUI\extra_models_config.yaml`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
+- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
+
+#### Desktop Application Instructions
+If you're using the ComfyUI Desktop application, you can locate the config file at:
+
+- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+  - You can quickly navigate to this by typing `%APPDATA%\ComfyUI` in File Explorer address bar
+- On macOS: Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`
+- On Linux: Open your file manager and navigate to the hidden folder `~/.config/ComfyUI`
+
+If the file doesn't exist yet, you can create it yourself with any text editor.

--- a/snippets/install/external-models-desktop.mdx
+++ b/snippets/install/external-models-desktop.mdx
@@ -1,0 +1,10 @@
+## Adding External Model Paths
+
+If you have models stored in other locations on your computer outside the ComfyUI installation directory, you can add them to ComfyUI by configuring the `extra_model_config.yaml` file.
+
+For ComfyUI Desktop, this file is located at:
+- On Windows: `C:\Users\<your username>\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
+- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
+
+For detailed instructions, see [Models documentation](/essentials/core-concepts/models#adding-external-model-paths)


### PR DESCRIPTION
## Summary
- Add new documentation for configuring external model paths
- Create reusable component for desktop platform-specific instructions
- Update models documentation to include external paths configuration
- Add external paths instructions to all desktop installation pages

## Test plan
- Verify documentation links work correctly
- Ensure instructions are clear and platform-specific paths are correct
- Check formatting and rendering of code examples and paths

🤖 Generated with [Claude Code](https://claude.ai/code)