### PR TITLE
Add custom node markdown documentation feature

### DIFF
--- a/custom-nodes/backend/interface.mdx
+++ b/custom-nodes/backend/interface.mdx
@@ -108,6 +108,8 @@ Custom nodes can have custom UI.
 
 This attribute sets the web directory. Any `.js` file in that directory will be loaded as a frontend extension.
 
+Custom nodes can also include markdown documentation in the `WEB_DIRECTORY/docs` folder. See the [Help Page](/custom-nodes/help-page) section for details on how to add rich documentation for your nodes.
+
 #### NODE_CLASS_MAPPINGS
 
 A dictionary that contains all nodes you want to export along with their class names. Class names should be unique. This also means you can define multiple nodes in one "custom node" and export them all together.

--- a/custom-nodes/help-page.mdx
+++ b/custom-nodes/help-page.mdx
@@ -1,0 +1,65 @@
+---
+title: "Help Page"
+description: "How to create rich documentation for your custom nodes"
+---
+
+## Node Documentation with Markdown
+
+Custom nodes can include rich markdown documentation that will be displayed in the UI instead of the generic node description. This provides users with detailed information about your node's functionality, parameters, and usage examples.
+
+## Setup
+
+To add documentation for your nodes:
+
+1. Create a `docs` folder inside your `WEB_DIRECTORY`
+2. Add markdown files named after your nodes:
+   - `WEB_DIRECTORY/docs/NodeName.md` - Default documentation
+   - `WEB_DIRECTORY/docs/NodeName/en.md` - English documentation
+   - `WEB_DIRECTORY/docs/NodeName/zh.md` - Chinese documentation
+   - Add other locales as needed (e.g., `fr.md`, `de.md`, etc.)
+
+The system will automatically load the appropriate documentation based on the user's locale, falling back to `NodeName.md` if a localized version is not available.
+
+## Supported Markdown Features
+
+- Standard markdown syntax (headings, lists, code blocks, etc.)
+- Images using markdown syntax: `![alt text](image.png)`
+- HTML media elements with specific attributes:
+  - `<video>` and `<source>` tags
+  - Allowed attributes: `controls`, `autoplay`, `loop`, `muted`, `preload`, `poster`
+
+## Example Structure
+
+```
+my-custom-node/
+├── __init__.py
+├── web/              # WEB_DIRECTORY
+│   ├── js/
+│   │   └── my-node.js
+│   └── docs/
+│       ├── MyNode.md           # Fallback documentation
+│       └── MyNode/
+│           ├── en.md           # English version
+│           └── zh.md           # Chinese version
+```
+
+## Example Markdown File
+
+```markdown
+# My Custom Node
+
+This node processes images using advanced algorithms.
+
+## Parameters
+
+- **image**: Input image to process
+- **strength**: Processing strength (0.0 - 1.0)
+
+## Usage
+
+![example usage](example.png)
+
+<video controls loop muted>
+  <source src="demo.mp4" type="video/mp4">
+</video>
+```

--- a/docs.json
+++ b/docs.json
@@ -400,6 +400,7 @@
                       "custom-nodes/js/javascript_examples"
                     ]
                   },
+                  "custom-nodes/help-page",
                   "custom-nodes/workflow_templates",
                   "custom-nodes/tips"
                 ]
@@ -826,6 +827,7 @@
                       "zh-CN/custom-nodes/js/javascript_examples"
                     ]
                   },
+                  "zh-CN/custom-nodes/help-page",
                   "zh-CN/custom-nodes/workflow_templates",
                   "zh-CN/custom-nodes/tips"
                 ]

--- a/zh-CN/custom-nodes/help-page.mdx
+++ b/zh-CN/custom-nodes/help-page.mdx
@@ -1,0 +1,65 @@
+---
+title: "帮助页面"
+description: "如何为自定义节点创建富文本文档"
+---
+
+## 使用 Markdown 创建节点文档
+
+自定义节点可以包含富文本 Markdown 文档，这些文档将在 UI 中显示，取代通用的节点描述。这为用户提供了关于节点功能、参数和使用示例的详细信息。
+
+## 设置
+
+为您的节点添加文档：
+
+1. 在您的 `WEB_DIRECTORY` 中创建 `docs` 文件夹
+2. 添加以节点命名的 Markdown 文件：
+   - `WEB_DIRECTORY/docs/NodeName.md` - 默认文档
+   - `WEB_DIRECTORY/docs/NodeName/en.md` - 英文文档
+   - `WEB_DIRECTORY/docs/NodeName/zh.md` - 中文文档
+   - 根据需要添加其他语言版本（例如 `fr.md`、`de.md` 等）
+
+系统将根据用户的语言设置自动加载相应的文档，如果没有本地化版本，则回退到 `NodeName.md`。
+
+## 支持的 Markdown 功能
+
+- 标准 Markdown 语法（标题、列表、代码块等）
+- 使用 Markdown 语法的图片：`![替代文本](image.png)`
+- 具有特定属性的 HTML 媒体元素：
+  - `<video>` 和 `<source>` 标签
+  - 允许的属性：`controls`、`autoplay`、`loop`、`muted`、`preload`、`poster`
+
+## 示例结构
+
+```
+my-custom-node/
+├── __init__.py
+├── web/              # WEB_DIRECTORY
+│   ├── js/
+│   │   └── my-node.js
+│   └── docs/
+│       ├── MyNode.md           # 默认文档
+│       └── MyNode/
+│           ├── en.md           # 英文版本
+│           └── zh.md           # 中文版本
+```
+
+## 示例 Markdown 文件
+
+```markdown
+# 我的自定义节点
+
+此节点使用高级算法处理图像。
+
+## 参数
+
+- **image**: 要处理的输入图像
+- **strength**: 处理强度 (0.0 - 1.0)
+
+## 用法
+
+![使用示例](example.png)
+
+<video controls loop muted>
+  <source src="demo.mp4" type="video/mp4">
+</video>
+```

--- a/zh-CN/custom-nodes/help-page.mdx
+++ b/zh-CN/custom-nodes/help-page.mdx
@@ -1,17 +1,17 @@
 ---
 title: "帮助页面"
-description: "如何为自定义节点创建富文本文档"
+description: "如何为自定义节点创建帮助文档"
 ---
 
 ## 使用 Markdown 创建节点文档
 
-自定义节点可以包含富文本 Markdown 文档，这些文档将在 UI 中显示，取代通用的节点描述。这为用户提供了关于节点功能、参数和使用示例的详细信息。
+自定义节点可以使用 Markdown 来创建富文本文档，这些文档信息将在 UI 中显示，取代常见的节点描述信息。可以为用户提供关于节点功能、参数和使用示例的详细信息。
 
 ## 设置
 
-为您的节点添加文档：
+为你的节点添加节点文档：
 
-1. 在您的 `WEB_DIRECTORY` 中创建 `docs` 文件夹
+1. 在你的 `WEB_DIRECTORY` 中创建 `docs` 文件夹
 2. 添加以节点命名的 Markdown 文件：
    - `WEB_DIRECTORY/docs/NodeName.md` - 默认文档
    - `WEB_DIRECTORY/docs/NodeName/en.md` - 英文文档


### PR DESCRIPTION
Added documentation for a new feature that allows custom node authors to include rich markdown documentation in their WEB_DIRECTORY/docs folder. The documentation will be displayed in the UI instead of generic node descriptions, supporting localization and multimedia content.

Could the Chinese translation be reviewed? It was generated.

Related Frontend PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/3922
Related Core PR: https://github.com/comfyanonymous/ComfyUI/pull/8179