### PR TITLE
[docs] Fix invalid color palette JSON example

### DIFF
--- a/interface/appearance.mdx
+++ b/interface/appearance.mdx
@@ -52,24 +52,35 @@ The color palette allows you to modify many specific properties. Here are some o
 
 ```json
 {
-  "comfy_base": "#222222",          // Base background color
-  "comfy_primary": "#4F6AA8",       // Primary accent color
-  "comfy_secondary": "#A87732",     // Secondary accent color
-  "comfy_text": "#EFEFEF",          // Text color
-  "comfy_input_bg": "#111111",      // Input background color
-  "node_slot": {                    // Node connection slot colors
-    "float": "#88DD66",
-    "image": "#6688FF",
-    // (other data types)
-  },
-  "litegraph": {                    // Canvas and graph appearance
-    "node_title": {
-      "color": "#CCCCCC"            // Node title text color
+  "id": "my-custom-theme",          // Unique identifier for the theme
+  "name": "My Custom Theme",        // Display name for the theme
+  "colors": {
+    "node_slot": {                  // Node connection slot colors by data type
+      "CLIP": "#FFD500",            // CLIP model connections
+      "IMAGE": "#64B5F6",           // Image data connections
+      "LATENT": "#FF9CF9",          // Latent space connections
+      "MODEL": "#B39DDB",           // Model connections
+      "VAE": "#FF6E6E"              // VAE connections
+      // (other ComfyUI data types)
     },
-    "node_selected": {
-      "color": "#FFFFFF"            // Color of selected nodes
+    "litegraph_base": {             // Canvas and graph appearance
+      "CLEAR_BACKGROUND_COLOR": "#222",      // Main canvas background
+      "NODE_TITLE_COLOR": "#999",            // Node title text color
+      "NODE_SELECTED_TITLE_COLOR": "#FFF",   // Selected node title color
+      "NODE_DEFAULT_BGCOLOR": "#353535",     // Default node background
+      "WIDGET_BGCOLOR": "#222",              // Widget background color
+      "LINK_COLOR": "#9A9"                   // Connection link color
+      // (other LiteGraph properties)
+    },
+    "comfy_base": {                 // ComfyUI interface colors
+      "fg-color": "#fff",           // Primary text color
+      "bg-color": "#202020",        // Main background color
+      "comfy-menu-bg": "#353535",   // Menu background color
+      "comfy-input-bg": "#222",     // Input field background
+      "input-text": "#ddd",         // Input text color
+      "border-color": "#4e4e4e"     // Border color
+      // (other ComfyUI base properties)
     }
-    // (other UI elements)
   }
 }
 ```

--- a/zh-CN/interface/appearance.mdx
+++ b/zh-CN/interface/appearance.mdx
@@ -52,24 +52,35 @@ ComfyUI 自带几个内置主题：
 
 ```json
 {
-  "comfy_base": "#222222",          // 基础背景颜色
-  "comfy_primary": "#4F6AA8",       // 主要强调色
-  "comfy_secondary": "#A87732",     // 次要强调色
-  "comfy_text": "#EFEFEF",          // 文本颜色
-  "comfy_input_bg": "#111111",      // 输入框背景色
-  "node_slot": {                    // 节点连接槽颜色
-    "float": "#88DD66",
-    "image": "#6688FF",
-    // (其他数据类型)
-  },
-  "litegraph": {                    // 画布和图表外观
-    "node_title": {
-      "color": "#CCCCCC"            // 节点标题文本颜色
+  "id": "my-custom-theme",          // 主题的唯一标识符
+  "name": "My Custom Theme",        // 主题的显示名称
+  "colors": {
+    "node_slot": {                  // 按数据类型的节点连接槽颜色
+      "CLIP": "#FFD500",            // CLIP 模型连接
+      "IMAGE": "#64B5F6",           // 图像数据连接
+      "LATENT": "#FF9CF9",          // 潜在空间连接
+      "MODEL": "#B39DDB",           // 模型连接
+      "VAE": "#FF6E6E"              // VAE 连接
+      // (其他 ComfyUI 数据类型)
     },
-    "node_selected": {
-      "color": "#FFFFFF"            // 选中节点的颜色
+    "litegraph_base": {             // 画布和图表外观
+      "CLEAR_BACKGROUND_COLOR": "#222",      // 主画布背景
+      "NODE_TITLE_COLOR": "#999",            // 节点标题文本颜色
+      "NODE_SELECTED_TITLE_COLOR": "#FFF",   // 选中节点标题颜色
+      "NODE_DEFAULT_BGCOLOR": "#353535",     // 默认节点背景
+      "WIDGET_BGCOLOR": "#222",              // 小部件背景颜色
+      "LINK_COLOR": "#9A9"                   // 连接线颜色
+      // (其他 LiteGraph 属性)
+    },
+    "comfy_base": {                 // ComfyUI 界面颜色
+      "fg-color": "#fff",           // 主要文本颜色
+      "bg-color": "#202020",        // 主背景颜色
+      "comfy-menu-bg": "#353535",   // 菜单背景颜色
+      "comfy-input-bg": "#222",     // 输入字段背景
+      "input-text": "#ddd",         // 输入文本颜色
+      "border-color": "#4e4e4e"     // 边框颜色
+      // (其他 ComfyUI 基础属性)
     }
-    // (其他 UI 元素)
   }
 }
 ```


### PR DESCRIPTION
Corrects the color palette JSON example in appearance.mdx to match the actual ComfyUI schema structure with proper id, name, colors wrapper, and accurate property names.

To verify, see actual examples of valid color palettes here: https://github.com/Comfy-Org/ComfyUI_frontend/tree/main/src/assets/palettes