### PR TITLE
[fix] Fix user directory snippet import syntax and improve layout

### DIFF
--- a/interface/appearance.mdx
+++ b/interface/appearance.mdx
@@ -5,6 +5,8 @@ sidebarTitle: "Appearance"
 icon: "paintbrush"
 ---
 
+import UserDirectory from "/snippets/install/user-directory.mdx"
+
 ComfyUI offers flexible appearance customization options that allow you to personalize the interface to your preferences.
 
 ## Color Palette System
@@ -128,7 +130,7 @@ For cases where the color palette doesn't provide enough control, you can use cu
 
 ### User Directory Location
 
-<Snippet file="install/user-directory.mdx" />
+<UserDirectory/>
 
 ### CSS Specificity Note
 

--- a/snippets/install/user-directory.mdx
+++ b/snippets/install/user-directory.mdx
@@ -1,22 +1,35 @@
-The ComfyUI user directory is where your personal settings, workflows, and customizations are stored. The location depends on whether you're using the desktop application or the standard installation:
+The ComfyUI user directory is where your personal settings, workflows, and customizations are stored. The location depends on your installation type:
 
-## Desktop Application
-
-### Windows
-- `C:\Users\<your username>\AppData\Roaming\ComfyUI`
-
-### macOS
-- `~/Library/Application Support/ComfyUI`
-
-### Linux
-- `~/.config/ComfyUI`
-
-## Standard Installation (Non-Desktop)
-
-The user directory is located in the main ComfyUI installation folder:
-
-- `<ComfyUI installation path>/user`
+<Tabs>
+<Tab title="Desktop - Windows">
+```
+C:\Users\<your username>\AppData\Roaming\ComfyUI
+```
+</Tab>
+<Tab title="Desktop - macOS">
+```
+~/Library/Application Support/ComfyUI
+```
+</Tab>
+<Tab title="Desktop - Linux">
+```
+~/.config/ComfyUI
+```
+</Tab>
+<Tab title="Manual Install">
+The user directory is located in your ComfyUI installation folder:
+```
+<ComfyUI installation path>/user
+```
 
 For example, if you cloned ComfyUI to `C:\ComfyUI`, your user directory would be `C:\ComfyUI\user`.
+</Tab>
+<Tab title="Portable">
+The user directory is located in your ComfyUI portable folder:
+```
+<ComfyUI_windows_portable>/ComfyUI/user
+```
+</Tab>
+</Tabs>
 
 This location contains your workflows, settings, and other user-specific files.

--- a/zh-CN/interface/appearance.mdx
+++ b/zh-CN/interface/appearance.mdx
@@ -5,6 +5,8 @@ sidebarTitle: "外观"
 icon: "paintbrush"
 ---
 
+import UserDirectory from "/snippets/install/user-directory.mdx"
+
 ComfyUI 提供灵活的外观自定义选项，允许您根据个人喜好来个性化界面。
 
 ## 调色板系统
@@ -128,7 +130,7 @@ ComfyUI 允许您为画布设置自定义背景图片，提供更加个性化的
 
 ### 用户目录位置
 
-<Snippet file="install/user-directory.mdx" />
+<UserDirectory/>
 
 ### CSS 特异性说明
 


### PR DESCRIPTION
Fixes broken snippet imports in appearance pages that were using deprecated syntax instead of proper import statements. Also improves the user directory snippet by organizing paths into clear tabs by installation type for better user experience.

Before:

![Selection_1452](https://github.com/user-attachments/assets/cfc5fd92-2a18-4cf2-99f7-6a95ddfe18b4)

After:

![Selection_1453](https://github.com/user-attachments/assets/c0bb3a0d-fb87-40f3-b40f-6b58efb750e6)



Fixes #135