### PR TITLE
Fix: Chinese Translation Sync Check always fails

### DIFF
--- a/.github/workflows/zh-cn-sync-check.yml
+++ b/.github/workflows/zh-cn-sync-check.yml
@@ -45,8 +45,8 @@ jobs:
           fi
           
           # Check for moved files - these would be deleted and added in the same PR
-          MOVED_FILES=()
-          MOVE_DESTINATIONS=()
+          MOVED_FILES=""
+          MOVE_DESTINATIONS=""
           
           if [ ! -z "$DELETED_FILES" ] && [ ! -z "$ADDED_FILES" ]; then
             echo "Potential file moves detected:"
@@ -81,12 +81,12 @@ jobs:
                   echo "✅ Found redirect for moved file: ${deleted_file}"
                 else
                   echo "❌ Missing redirect in docs.json for: ${deleted_file}"
-                  MOVED_FILES+=("${deleted_file}")
+                  MOVED_FILES="$MOVED_FILES ${deleted_file}"
                 fi
               done
             else
               # If docs.json wasn't changed, all deleted files are suspect
-              MOVED_FILES=($DELETED_FILES)
+              MOVED_FILES="$DELETED_FILES"
             fi
           fi
           
@@ -95,7 +95,7 @@ jobs:
           echo "------------------------"
           
           # Check each file for corresponding zh-CN updates
-          MISSING_TRANSLATIONS=()
+          MISSING_TRANSLATIONS=""
           for file in $CHANGED_FILES; do
             # The expected zh-CN path
             zh_file="zh-CN/${file}"
@@ -107,10 +107,10 @@ jobs:
               # Check if the zh-CN file exists at all
               if [ -f "${zh_file}" ]; then
                 echo "❌ Missing update to existing file: ${zh_file}"
-                MISSING_TRANSLATIONS+=("${zh_file}")
+                MISSING_TRANSLATIONS="$MISSING_TRANSLATIONS ${zh_file}"
               else
                 echo "❌ Missing equivalent file: ${zh_file}"
-                MISSING_TRANSLATIONS+=("${zh_file}")
+                MISSING_TRANSLATIONS="$MISSING_TRANSLATIONS ${zh_file}"
               fi
             fi
           done
@@ -125,7 +125,7 @@ jobs:
               echo "✅ Found corresponding added file: ${zh_file}"
             else
               echo "❌ Missing equivalent for added file: ${zh_file}"
-              MISSING_TRANSLATIONS+=("${zh_file}")
+              MISSING_TRANSLATIONS="$MISSING_TRANSLATIONS ${zh_file}"
             fi
           done
           
@@ -133,21 +133,21 @@ jobs:
           SHOULD_FAIL="false"
           
           # Check for missing translations
-          if [ ${#MISSING_TRANSLATIONS[@]} -gt 0 ]; then
+          if [ "$MISSING_TRANSLATIONS" != "" ]; then
             SHOULD_FAIL="true"
             echo "------------------------"
             echo "❌ The following translations need to be updated:"
-            for missing in "${MISSING_TRANSLATIONS[@]}"; do
+            for missing in $MISSING_TRANSLATIONS; do
               echo "- $missing"
             done
           fi
           
           # Check for moved files without redirects
-          if [ ${#MOVED_FILES[@]} -gt 0 ]; then
+          if [ "$MOVED_FILES" != "" ]; then
             SHOULD_FAIL="true"
             echo "------------------------"
             echo "❌ The following files were moved but missing redirects in docs.json:"
-            for moved in "${MOVED_FILES[@]}"; do
+            for moved in $MOVED_FILES; do
               echo "- $moved"
             done
             echo "------------------------"

--- a/.github/workflows/zh-cn-sync-check.yml
+++ b/.github/workflows/zh-cn-sync-check.yml
@@ -30,13 +30,13 @@ jobs:
         id: check-translations
         run: |
           # Get list of changed MDX files
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/")
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/" || true)
           
           # Get list of deleted MDX files (potentially moved)
-          DELETED_FILES=$(git diff --name-only --diff-filter=D ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/")
+          DELETED_FILES=$(git diff --name-only --diff-filter=D ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/" || true)
           
           # Get list of added MDX files (potentially destinations of moves)
-          ADDED_FILES=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/")
+          ADDED_FILES=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.mdx$" | grep -v "^zh-CN/" || true)
           
           # Exit if no MDX files were changed, deleted or added
           if [ -z "$CHANGED_FILES" ] && [ -z "$DELETED_FILES" ] && [ -z "$ADDED_FILES" ]; then


### PR DESCRIPTION
Don't exit with status code > 0 if grep/diff fails and fix issue described below:

> Looking at the debug logs, I can see the issue. The
>   problem is in the way shell arrays are being used in
>   GitHub Actions. The main issue is:
> 
>   1. Array initialization syntax: Lines like
>   MOVED_FILES=() and MISSING_TRANSLATIONS=() work in bash,
>    but there are additional issues with how the arrays are
>    being handled in the GitHub Actions environment.
>   2. The specific error: Looking at the debug logs, I can
>   see that the script is failing because when GitHub
>   Actions processes the workflow, it's having trouble with
>    the double curly braces ${{}} syntax when it's mixed
>   with shell array operations.
> 
>   The issue is that GitHub Actions is trying to evaluate
>   ${{#MISSING_TRANSLATIONS[@]}} as GitHub Actions syntax
>   rather than shell syntax. Let me fix this:
> 