### PR TITLE
Remove note about 50 series GPU

### DIFF
--- a/installation/comfyui_portable_windows.mdx
+++ b/installation/comfyui_portable_windows.mdx
@@ -6,9 +6,6 @@ sidebarTitle: "Portable(Windows)"
 ---
 
 import FirstGeneration from "/snippets/install/first-generation.mdx"
-import NvidiaBlackwell from "/snippets/install/nvidia-blackwell.mdx"
-
-<NvidiaBlackwell/>
 
 **ComfyUI Portable** is a standalone packaged complete ComfyUI Windows version that has integrated an independent **Python (python_embeded)** required for ComfyUI to run. You only need to extract it to use it. Currently, the portable version supports running through **Nvidia GPU** or **CPU**.
 

--- a/zh-CN/installation/comfyui_portable_windows.mdx
+++ b/zh-CN/installation/comfyui_portable_windows.mdx
@@ -5,14 +5,10 @@ icon: "box"
 ---
 
 import FirstGeneration from "/snippets/zh/install/first-generation.mdx"
-import NvidiaBlackwell from "/snippets/zh/install/nvidia-blackwell.mdx"
-
 
 **ComfyUI Portable(便携版)** 是一个独立封装完整的 ComfyUI Windows 版本，内部已经整合了 ComfyUI 运行所需的独立的 **Python(python_embeded)**,只需要解压即可使用,目前便携版本支持通过 **Nvidia** 显卡或者 **CPU** 运行。
 
 本部分指南将引导你完成对应的安装。
-
-<NvidiaBlackwell/>
 
 ## 下载 ComfyUI Portable(便携版)
 


### PR DESCRIPTION
Since the portable version now supports PyTorch 3.7, there is no need for additional explanation regarding the 50 series graphics cards. 

But we may need to improve the part of the dependency-related instructions. Currently, this part is still in a very preliminary state and will take some time to complete.