### PR TITLE
Add Homebrew install instruction

### DIFF
--- a/installation/desktop/macos.mdx
+++ b/installation/desktop/macos.mdx
@@ -32,6 +32,14 @@ Please click the button below to download the installation package for MacOS **C
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download for MacOS</p>
 </a>
 
+## Install via Homebrew
+
+ComfyUI Desktop can also be installed via [Homebrew](https://brew.sh/):
+
+```
+brew install comfyui
+```
+
 ## ComfyUI Desktop Installation Steps
 
 Double-click the downloaded installation package file. As shown in the image, drag the **ComfyUI** application into the **Applications** folder following the arrow

--- a/zh-CN/installation/desktop/macos.mdx
+++ b/zh-CN/installation/desktop/macos.mdx
@@ -29,6 +29,14 @@ ComfyUI 桌面版是一个开源项目，完整代码请访问[这里](https://g
     <p className="prose" style={{ margin: 0, fontSize: "0.8rem" }}>Download for macOS</p>
 </a>
 
+## 通过 Homebrew 安装
+
+ComfyUI 桌面版也可通过 [Homebrew](https://brew.sh/) 安装：
+
+```
+brew install comfyui
+```
+
 ## ComfyUI 桌面版安装步骤
 
 1.  双击下载到的安装包文件。


### PR DESCRIPTION
[I submitted ComfyUI Desktop to Homebrew](https://github.com/Homebrew/homebrew-cask/pull/207593) and it's been available there for some time, it would be awesome if this is also mentioned in the official docs, instead of having to be discovered by users themselves.