### PR TITLE
[docs] fix external model paths configuration examples

### DIFF
--- a/get_started/first_generation.mdx
+++ b/get_started/first_generation.mdx
@@ -82,7 +82,7 @@ Most ComfyUI installations don't include base models by default. After loading t
 
 ![Missing Models](/images/tutorial/gettingstarted/first-image-generation-3-missing-models.jpg)
 
-All models are stored in `<your ComfyUI installation>/ComfyUI/models/` with subfolders like `checkpoints`, `embeddings`, `vae`, `lora`, `upscale_model`, etc. ComfyUI detects models in these folders and paths configured in `extra_models_config.yaml` at startup.
+All models are stored in `<your ComfyUI installation>/ComfyUI/models/` with subfolders like `checkpoints`, `embeddings`, `vae`, `lora`, `upscale_model`, etc. ComfyUI detects models in these folders and paths configured in `extra_model_paths.yaml` at startup.
 
 ![ComfyUI Models Folder](/images/tutorial/gettingstarted/first-image-generation-4-models-folder.jpg)
 

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -10,7 +10,7 @@ You need to add a motion LoRA and your model is located in `C:\Users\YourUsernam
 2. Restart ComfyUI
 
 ```yaml
-additional_model_paths:
+my_custom_config:
   loras: C:\Users\YourUsername\models\animatediff_motion_lora/
 ```
 
@@ -26,7 +26,7 @@ additional_model_paths:
 
 For example, to add checkpoint models:
 ```yaml
-additional_model_paths:
+my_custom_config:
   checkpoints: C:\Users\YourUsername\models\checkpoints/
 ```
 

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -36,11 +36,13 @@ my_custom_config:
 - On Linux: `~/.config/ComfyUI/extra_model_paths.yaml`
 
 #### Desktop Application Instructions
-If you're using the ComfyUI Desktop application, you can locate the config file at:
+If you're using the ComfyUI Desktop application, the config file has a different name:
 
-- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
+- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
   - You can quickly navigate to this by typing `%APPDATA%\ComfyUI` in File Explorer address bar
-- On macOS: Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`
-- On Linux: Open your file manager and navigate to the hidden folder `~/.config/ComfyUI`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
+  - Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`
+- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
+  - Open your file manager and navigate to the hidden folder `~/.config/ComfyUI`
 
 If the file doesn't exist yet, you can create it yourself with any text editor.

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -36,7 +36,7 @@ For standard ComfyUI installations, create the `extra_model_paths.yaml` file dir
 #### Desktop Application Instructions
 If you're using the ComfyUI Desktop application, the config file has a different name and location:
 
-- On Windows: `%APPDATA%\ComfyUI\extra_models_config.yaml`
+- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
   - You can quickly navigate to this by typing `%APPDATA%\ComfyUI` in File Explorer address bar
 - On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
   - Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -30,15 +30,13 @@ my_custom_config:
   checkpoints: C:\Users\YourUsername\models\checkpoints/
 ```
 
-#### YAML config file locations
-- On Windows: `%APPDATA%\ComfyUI\extra_model_paths.yaml`
-- On macOS: `~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
-- On Linux: `~/.config/ComfyUI/extra_model_paths.yaml`
+#### YAML config file location
+For standard ComfyUI installations, create the `extra_model_paths.yaml` file directly in your ComfyUI folder (where `main.py` is located).
 
 #### Desktop Application Instructions
-If you're using the ComfyUI Desktop application, the config file has a different name:
+If you're using the ComfyUI Desktop application, the config file has a different name and location:
 
-- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+- On Windows: `%APPDATA%\ComfyUI\extra_models_config.yaml`
   - You can quickly navigate to this by typing `%APPDATA%\ComfyUI` in File Explorer address bar
 - On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
   - Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`

--- a/snippets/install/add-external-models.mdx
+++ b/snippets/install/add-external-models.mdx
@@ -6,23 +6,39 @@ If you downloaded a model but ComfyUI cannot find it, you may need to add an add
 You need to add a motion LoRA and your model is located in `C:\Users\YourUsername\models\animatediff_motion_lora`.
 
 #### Solution
-1. Add the below line to the `extra_model_config.yaml` file
+1. Add the below configuration to the `extra_model_paths.yaml` file using the correct model type property name
 2. Restart ComfyUI
 
 ```yaml
 additional_model_paths:
-  animatediff_motion_lora: C:\Users\YourUsername\models\animatediff_motion_lora/
+  loras: C:\Users\YourUsername\models\animatediff_motion_lora/
+```
+
+**Important:** Use the correct property names for different model types:
+- `loras` - for LoRA models
+- `checkpoints` - for checkpoint models  
+- `vae` - for VAE models
+- `controlnet` - for ControlNet models
+- `clip` - for CLIP models
+- `upscale_models` - for upscaling models
+- `embeddings` - for textual inversion embeddings
+- `configs` - for configuration files
+
+For example, to add checkpoint models:
+```yaml
+additional_model_paths:
+  checkpoints: C:\Users\YourUsername\models\checkpoints/
 ```
 
 #### YAML config file locations
-- On Windows: `%APPDATA%\ComfyUI\extra_models_config.yaml`
-- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
-- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
+- On Windows: `%APPDATA%\ComfyUI\extra_model_paths.yaml`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
+- On Linux: `~/.config/ComfyUI/extra_model_paths.yaml`
 
 #### Desktop Application Instructions
 If you're using the ComfyUI Desktop application, you can locate the config file at:
 
-- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+- On Windows: `C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
   - You can quickly navigate to this by typing `%APPDATA%\ComfyUI` in File Explorer address bar
 - On macOS: Open Finder, press `Cmd+Shift+G` and enter `~/Library/Application Support/ComfyUI`
 - On Linux: Open your file manager and navigate to the hidden folder `~/.config/ComfyUI`

--- a/snippets/install/external-models-desktop.mdx
+++ b/snippets/install/external-models-desktop.mdx
@@ -1,10 +1,10 @@
 ## Adding External Model Paths
 
-If you have models stored in other locations on your computer outside the ComfyUI installation directory, you can add them to ComfyUI by configuring the `extra_model_paths.yaml` file.
+If you have models stored in other locations on your computer outside the ComfyUI installation directory, you can add them to ComfyUI by configuring the `extra_models_config.yaml` file.
 
 For ComfyUI Desktop, this file is located at:
-- On Windows: `C:\Users\<your username>\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
-- On macOS: `~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
-- On Linux: `~/.config/ComfyUI/extra_model_paths.yaml`
+- On Windows: `C:\Users\<your username>\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
+- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
 
 For detailed instructions, see [Models documentation](/development/core-concepts/models#adding-external-model-paths)

--- a/snippets/install/external-models-desktop.mdx
+++ b/snippets/install/external-models-desktop.mdx
@@ -1,10 +1,10 @@
 ## Adding External Model Paths
 
-If you have models stored in other locations on your computer outside the ComfyUI installation directory, you can add them to ComfyUI by configuring the `extra_model_config.yaml` file.
+If you have models stored in other locations on your computer outside the ComfyUI installation directory, you can add them to ComfyUI by configuring the `extra_model_paths.yaml` file.
 
 For ComfyUI Desktop, this file is located at:
-- On Windows: `C:\Users\<your username>\AppData\Roaming\ComfyUI\extra_models_config.yaml`
-- On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
-- On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
+- On Windows: `C:\Users\<your username>\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
+- On macOS: `~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
+- On Linux: `~/.config/ComfyUI/extra_model_paths.yaml`
 
 For detailed instructions, see [Models documentation](/development/core-concepts/models#adding-external-model-paths)

--- a/snippets/install/troubleshooting-feedback.mdx
+++ b/snippets/install/troubleshooting-feedback.mdx
@@ -20,7 +20,7 @@ When submitting error reports, please ensure you include the following logs and 
 
 | Filename                 | Description                                                                     | Location          |
 |--------------------------|---------------------------------------------------------------------------------|-------------------|
-| extra_models_config.yaml | Contains additional paths where ComfyUI will search for models and custom nodes | {config_path}     |
+| extra_model_paths.yaml | Contains additional paths where ComfyUI will search for models and custom nodes | {config_path}     |
 | config.json              | Contains application configuration. This file should not be edited directly     | {config_path}     |
 
 ![ComfyUI Config Files Location](/images/desktop/win-comfyui-desktop-11-config.jpg)

--- a/snippets/zh/install/troubleshooting-feedback.mdx
+++ b/snippets/zh/install/troubleshooting-feedback.mdx
@@ -20,7 +20,7 @@
 
 | 文件名                     | 描述                                                      | 位置                                                   |
 |---------------------------|----------------------------------------------------------|--------------------------------------------------------|
-| extra_models_config.yaml  | 包含 ComfyUI 将搜索模型和自定义节点的额外路径。                 | {config_path}           |
+| extra_model_paths.yaml  | 包含 ComfyUI 将搜索模型和自定义节点的额外路径。                 | {config_path}           |
 | config.json               | 包含应用配置。此文件通常不应直接编辑。                          | {config_path}           |
 
 ![ComfyUI 配置文件位置](/images/desktop/win-comfyui-desktop-11-config.jpg)

--- a/zh-CN/get_started/first_generation.mdx
+++ b/zh-CN/get_started/first_generation.mdx
@@ -86,7 +86,7 @@ import InstallLink from "/snippets/zh/install/install-link.mdx"
 
 你可以直接选择点击 `Download` 按钮，让 ComfyUI 自动完成对应的模型的下载，但由于在有些地区不能够顺利访问对应模型的下载源，所以在这个步骤中，我将说明几种不同的模型安装方法。
 
-无论使用哪种方法，模型都会被保存到 `<你的 ComfyUI 安装位置>/ComfyUI/models/` 文件夹下，你可以在你的电脑上尝试找到这个文件夹位置，你可以看到许多文件夹比如 `checkpoints`、`embeddings`、`vae`、`lora`、`upscale_model` 等，这些都是不同的模型保存的文件夹，通常以文件夹名称区分，ComfyUI 在启动时会检测这些文件夹下的模型文件，以及`extra_models_config.yaml` 文件中配置的文件路径
+无论使用哪种方法，模型都会被保存到 `<你的 ComfyUI 安装位置>/ComfyUI/models/` 文件夹下，你可以在你的电脑上尝试找到这个文件夹位置，你可以看到许多文件夹比如 `checkpoints`、`embeddings`、`vae`、`lora`、`upscale_model` 等，这些都是不同的模型保存的文件夹，通常以文件夹名称区分，ComfyUI 在启动时会检测这些文件夹下的模型文件，以及`extra_model_paths.yaml` 文件中配置的文件路径
 
 ![ComfyUI 模型文件夹](/images/tutorial/gettingstarted/first-image-generation-4-models-folder.jpg)
 

--- a/zh-CN/snippets/install/add-external-models.mdx
+++ b/zh-CN/snippets/install/add-external-models.mdx
@@ -1,0 +1,46 @@
+### 添加外部模型路径
+
+如果你下载了模型但 ComfyUI 无法找到它，你可能需要在 yaml 文件中添加额外的模型搜索路径。
+
+#### 示例场景
+你需要添加一个动态 LoRA，你的模型位于 `C:\Users\YourUsername\models\animatediff_motion_lora`。
+
+#### 解决方案
+1. 使用正确的模型类型属性名称在 `extra_model_paths.yaml` 文件中添加以下配置
+2. 重启 ComfyUI
+
+```yaml
+additional_model_paths:
+  loras: C:\Users\YourUsername\models\animatediff_motion_lora/
+```
+
+**重要提示：** 针对不同模型类型使用正确的属性名称：
+- `loras` - 用于 LoRA 模型
+- `checkpoints` - 用于检查点模型  
+- `vae` - 用于 VAE 模型
+- `controlnet` - 用于 ControlNet 模型
+- `clip` - 用于 CLIP 模型
+- `upscale_models` - 用于放大模型
+- `embeddings` - 用于文本反转嵌入
+- `configs` - 用于配置文件
+
+例如，添加检查点模型：
+```yaml
+additional_model_paths:
+  checkpoints: C:\Users\YourUsername\models\checkpoints/
+```
+
+#### YAML 配置文件位置
+- Windows：`%APPDATA%\ComfyUI\extra_model_paths.yaml`
+- macOS：`~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
+- Linux：`~/.config/ComfyUI/extra_model_paths.yaml`
+
+#### 桌面应用程序说明
+如果你使用的是 ComfyUI 桌面应用程序，可以在以下位置找到配置文件：
+
+- Windows：`C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
+  - 你可以在文件资源管理器地址栏中输入 `%APPDATA%\ComfyUI` 快速导航到此位置
+- macOS：打开 Finder，按 `Cmd+Shift+G` 并输入 `~/Library/Application Support/ComfyUI`
+- Linux：打开文件管理器并导航到隐藏文件夹 `~/.config/ComfyUI`
+
+如果该文件尚不存在，你可以使用任何文本编辑器自己创建它。

--- a/zh-CN/snippets/install/add-external-models.mdx
+++ b/zh-CN/snippets/install/add-external-models.mdx
@@ -36,7 +36,7 @@ my_custom_config:
 #### 桌面应用程序说明
 如果你使用的是 ComfyUI 桌面应用程序，配置文件的名称和位置都不同：
 
-- Windows：`%APPDATA%\ComfyUI\extra_models_config.yaml`
+- Windows：`C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
   - 你可以在文件资源管理器地址栏中输入 `%APPDATA%\ComfyUI` 快速导航到此位置
 - macOS：`~/Library/Application Support/ComfyUI/extra_models_config.yaml`
   - 打开 Finder，按 `Cmd+Shift+G` 并输入 `~/Library/Application Support/ComfyUI`

--- a/zh-CN/snippets/install/add-external-models.mdx
+++ b/zh-CN/snippets/install/add-external-models.mdx
@@ -36,11 +36,13 @@ my_custom_config:
 - Linux：`~/.config/ComfyUI/extra_model_paths.yaml`
 
 #### 桌面应用程序说明
-如果你使用的是 ComfyUI 桌面应用程序，可以在以下位置找到配置文件：
+如果你使用的是 ComfyUI 桌面应用程序，配置文件的名称不同：
 
-- Windows：`C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
+- Windows：`C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
   - 你可以在文件资源管理器地址栏中输入 `%APPDATA%\ComfyUI` 快速导航到此位置
-- macOS：打开 Finder，按 `Cmd+Shift+G` 并输入 `~/Library/Application Support/ComfyUI`
-- Linux：打开文件管理器并导航到隐藏文件夹 `~/.config/ComfyUI`
+- macOS：`~/Library/Application Support/ComfyUI/extra_models_config.yaml`
+  - 打开 Finder，按 `Cmd+Shift+G` 并输入 `~/Library/Application Support/ComfyUI`
+- Linux：`~/.config/ComfyUI/extra_models_config.yaml`
+  - 打开文件管理器并导航到隐藏文件夹 `~/.config/ComfyUI`
 
 如果该文件尚不存在，你可以使用任何文本编辑器自己创建它。

--- a/zh-CN/snippets/install/add-external-models.mdx
+++ b/zh-CN/snippets/install/add-external-models.mdx
@@ -10,7 +10,7 @@
 2. 重启 ComfyUI
 
 ```yaml
-additional_model_paths:
+my_custom_config:
   loras: C:\Users\YourUsername\models\animatediff_motion_lora/
 ```
 
@@ -26,7 +26,7 @@ additional_model_paths:
 
 例如，添加检查点模型：
 ```yaml
-additional_model_paths:
+my_custom_config:
   checkpoints: C:\Users\YourUsername\models\checkpoints/
 ```
 

--- a/zh-CN/snippets/install/add-external-models.mdx
+++ b/zh-CN/snippets/install/add-external-models.mdx
@@ -31,14 +31,12 @@ my_custom_config:
 ```
 
 #### YAML 配置文件位置
-- Windows：`%APPDATA%\ComfyUI\extra_model_paths.yaml`
-- macOS：`~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
-- Linux：`~/.config/ComfyUI/extra_model_paths.yaml`
+对于标准 ComfyUI 安装，请直接在 ComfyUI 文件夹（`main.py` 所在的位置）中创建 `extra_model_paths.yaml` 文件。
 
 #### 桌面应用程序说明
-如果你使用的是 ComfyUI 桌面应用程序，配置文件的名称不同：
+如果你使用的是 ComfyUI 桌面应用程序，配置文件的名称和位置都不同：
 
-- Windows：`C:\Users\YourUsername\AppData\Roaming\ComfyUI\extra_models_config.yaml`
+- Windows：`%APPDATA%\ComfyUI\extra_models_config.yaml`
   - 你可以在文件资源管理器地址栏中输入 `%APPDATA%\ComfyUI` 快速导航到此位置
 - macOS：`~/Library/Application Support/ComfyUI/extra_models_config.yaml`
   - 打开 Finder，按 `Cmd+Shift+G` 并输入 `~/Library/Application Support/ComfyUI`

--- a/zh-CN/snippets/install/external-models-desktop.mdx
+++ b/zh-CN/snippets/install/external-models-desktop.mdx
@@ -1,0 +1,10 @@
+## 添加外部模型路径
+
+如果你在计算机上的 ComfyUI 安装目录之外的其他位置存储了模型，可以通过配置 `extra_model_paths.yaml` 文件将它们添加到 ComfyUI 中。
+
+对于 ComfyUI 桌面版，此文件位于：
+- Windows：`C:\Users\<你的用户名>\AppData\Roaming\ComfyUI\extra_model_paths.yaml`
+- macOS：`~/Library/Application Support/ComfyUI/extra_model_paths.yaml`
+- Linux：`~/.config/ComfyUI/extra_model_paths.yaml`
+
+详细说明请参见[模型文档](/zh-CN/development/core-concepts/models#adding-external-model-paths)

--- a/zh-CN/snippets/install/troubleshooting-feedback.mdx
+++ b/zh-CN/snippets/install/troubleshooting-feedback.mdx
@@ -1,0 +1,26 @@
+### 反馈安装错误
+
+如果在安装过程中遇到任何错误，请通过以下方式检查是否有类似的错误报告或向我们提交错误：
+
+- Github Issues：https://github.com/Comfy-Org/desktop/issues
+- Comfy 官方论坛：https://forum.comfy.org/
+
+提交错误报告时，请确保包含以下日志和配置文件，以帮助我们定位和调查问题：
+
+1. 日志文件
+
+| 文件名 | 描述 | 位置 |
+|--------|------|------|
+| main.log | 包含来自 Electron 进程的桌面应用程序和服务器启动相关日志 | {log_path} |
+| comfyui.log | 包含 ComfyUI 正常运行相关日志，如核心 ComfyUI 进程终端输出 | {log_path} |
+
+![ComfyUI 日志文件位置](/images/desktop/win-comfyui-desktop-10-logs.jpg)
+
+2. 配置文件
+
+| 文件名 | 描述 | 位置 |
+|--------|------|------|
+| extra_model_paths.yaml | 包含 ComfyUI 将搜索模型和自定义节点的额外路径 | {config_path} |
+| config.json | 包含应用程序配置。此文件不应直接编辑 | {config_path} |
+
+![ComfyUI 配置文件位置](/images/desktop/win-comfyui-desktop-11-config.jpg)

--- a/zh-CN/snippets/zh/install/troubleshooting-feedback.mdx
+++ b/zh-CN/snippets/zh/install/troubleshooting-feedback.mdx
@@ -1,0 +1,26 @@
+### 反馈错误
+
+如果在安装过程中，你发生了任何错误，请通过以下任意方式查看是否有类似错误反馈，或者向我们提交错误
+
+- Github Issues: https://github.com/Comfy-Org/desktop/issues
+- Comfy 官方论坛: https://forum.comfy.org/
+
+请在提交错误时确保提交了以下日志以及配置文件，方便我们进行问题的定位和查找
+
+1. 日志文件
+
+| 文件名         | 描述                                                              | 位置             |
+|---------------|------------------------------------------------------------------|------------------|
+| main.log      | 包含与桌面应用和服务器启动相关的日志，来自桌面的 Electron 进程。          | {log_path}       |
+| comfyui.log   | 包含与 ComfyUI 正常运行相关的日志，例如核心 ComfyUI 进程的终端输出。      | {log_path}       |
+
+![ComfyUI 日志文件输出位置](/images/desktop/win-comfyui-desktop-10-logs.jpg)
+
+2. 配置文件
+
+| 文件名                     | 描述                                                      | 位置                                                   |
+|---------------------------|----------------------------------------------------------|--------------------------------------------------------|
+| extra_model_paths.yaml  | 包含 ComfyUI 将搜索模型和自定义节点的额外路径。                 | {config_path}           |
+| config.json               | 包含应用配置。此文件通常不应直接编辑。                          | {config_path}           |
+
+![ComfyUI 配置文件位置](/images/desktop/win-comfyui-desktop-11-config.jpg)


### PR DESCRIPTION
Fixes incorrect YAML property names in model path configuration docs. Changes custom property names to standard ComfyUI model type names (loras, checkpoints, etc.) so models are properly recognized. Fixes #166