### PR TITLE
Update Icon requirements and add Banner field to registry specifications

### DIFF
--- a/registry/specifications.mdx
+++ b/registry/specifications.mdx
@@ -161,10 +161,22 @@ URL to your custom node's icon.
 
 **Requirements:**
 - File types: SVG, PNG, JPG, or GIF
-- Maximum resolution: 800px × 400px
+- Maximum resolution: 400px × 400px
+- Aspect ratio should be square
 
 ```toml
 Icon = "https://raw.githubusercontent.com/username/repo/main/icon.png"
+```
+
+### Banner (optional)
+URL to a larger banner image that will be shown in ComfyUI manager and the registry website.
+
+**Requirements:**
+- File types: SVG, PNG, JPG, or GIF
+- Aspect ratio: 21:9
+
+```toml
+Banner = "https://raw.githubusercontent.com/username/repo/main/banner.png"
 ```
 
 ### requires-comfyui (optional)
@@ -215,5 +227,6 @@ Documentation = "https://github.com/username/super-resolution-node/wiki"
 PublisherId = "image-wizard"
 DisplayName = "Super Resolution Node"
 Icon = "https://raw.githubusercontent.com/username/super-resolution-node/main/icon.png"
+Banner = "https://raw.githubusercontent.com/username/super-resolution-node/main/banner.png"
 requires-comfyui = ">=1.0.0"  # ComfyUI version compatibility
 ```

--- a/zh-CN/registry/specifications.mdx
+++ b/zh-CN/registry/specifications.mdx
@@ -163,10 +163,22 @@ DisplayName = "Super Resolution Node"
 
 **要求：**
 - 文件类型：SVG, PNG, JPG, 或 GIF
-- 最大分辨率：800px × 400px
+- 最大分辨率：400px × 400px
+- 长宽比应该是正方形
 
 ```toml
 Icon = "https://raw.githubusercontent.com/username/repo/main/icon.png"
+```
+
+### Banner（可选）
+URL 指向一个较大的横幅图像，将在 ComfyUI 管理器和注册表网站中显示。
+
+**要求：**
+- 文件类型：SVG, PNG, JPG, 或 GIF
+- 长宽比：21:9
+
+```toml
+Banner = "https://raw.githubusercontent.com/username/repo/main/banner.png"
 ```
 
 ### requires-comfyui（可选）
@@ -218,5 +230,6 @@ Documentation = "https://github.com/username/super-resolution-node/wiki"
 PublisherId = "image-wizard"
 DisplayName = "Super Resolution Node"
 Icon = "https://raw.githubusercontent.com/username/super-resolution-node/main/icon.png"
+Banner = "https://raw.githubusercontent.com/username/super-resolution-node/main/banner.png"
 requires-comfyui = ">=1.0.0"  # ComfyUI 版本兼容性
 ```


### PR DESCRIPTION
## Summary
- Updated Icon field requirements to specify 400x400 max resolution and square aspect ratio
- Added new optional Banner field for 21:9 aspect ratio images

## Changes
- Modified Icon maximum resolution from 800x400 to 400x400
- Added requirement for square aspect ratio for icons
- Added new optional Banner field with specifications
- Updated example to include the Banner field
- Applied same changes to both English and Chinese documentation