### PR TITLE
Fix Typo in Elementwise Operations Documentation

### DIFF
--- a/custom-nodes/backend/tensors.mdx
+++ b/custom-nodes/backend/tensors.mdx
@@ -69,7 +69,7 @@ torch.Size([1, 2])
 
 ### Elementwise operations
 
-Many binary on `torch.Tensor` (including '+', '-', '*', '/' and '==') are applied elementwise (independantly applied to each element). 
+Many binary on `torch.Tensor` (including '+', '-', '*', '/' and '==') are applied elementwise (independently applied to each element). 
 The operands must be _either_ two tensors of the same shape, _or_ a tensor and a scalar. So:
 
 ```python


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the documentation for elementwise operations in tensors. The word "independantly" has been replaced with the correct spelling "independently" in the file custom-nodes/backend/tensors.mdx. No functional code changes were made; this update is purely for documentation clarity and accuracy.