### PR TITLE
Fix typo in CI/CD documentation 

### DIFF
--- a/registry/cicd.mdx
+++ b/registry/cicd.mdx
@@ -12,6 +12,6 @@ When making changes to custom nodes, it's not uncommon to break things in Comfy 
 
 ### Results
 
-Output files are uploaded to the [CI/CD Dashboard](https://comfyci.org) and can be viewed as a last step before commiting new changes or publishing new versions of the custom node.
+Output files are uploaded to the [CI/CD Dashboard](https://comfyci.org) and can be viewed as a last step before committing new changes or publishing new versions of the custom node.
 
 ![ComfyCI](/images/comfyci.png)


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the `registry/cicd.mdx` file, changing "commiting" to the correct spelling "committing" in the documentation. No other content was modified. This improves the clarity and professionalism of the documentation.