### PR TITLE
[docs] Add ControlNet architecture mismatch error to troubleshooting

### DIFF
--- a/troubleshooting/model-issues.mdx
+++ b/troubleshooting/model-issues.mdx
@@ -15,6 +15,7 @@ sidebarTitle: "Model Issues"
 - `Given groups=1, weight of size [320, 4, 3, 3], expected input[2, 16, 192, 128] to have 4 channels, but got 16 channels instead`
 - `The size of tensor a (49) must match the size of tensor b (16) at non-singleton dimension 1`
 - `Tensors must have same number of dimensions: got 2 and 3`
+- `mat1 and mat2 shapes cannot be multiplied (154x2048 and 768x320)`
 
 **Root cause:** Using models from different architecture families together
 
@@ -25,6 +26,7 @@ sidebarTitle: "Model Issues"
    - **SD1.5 models** use 4-channel latent space with single CLIP ViT-L/14 text encoder
    - **SDXL models** use 4-channel latent space with dual text encoders (CLIP ViT-L/14 + OpenCLIP ViT-bigG/14)
    - **SD3 models** use 16-channel latent space with triple text encoder conditioning (CLIP-L + OpenCLIP bigG + T5-XXL)
+   - **ControlNet models** must match the architecture of the base checkpoint (SD1.5 ControlNets only work with SD1.5 checkpoints, SDXL ControlNets only work with SDXL checkpoints, etc.)
 
 2. **Common mismatch scenarios and fixes:**
 
@@ -42,8 +44,11 @@ sidebarTitle: "Model Issues"
 
    **ControlNet architecture mismatch:**
    ```
-   Problem: SD1.5 ControlNet with different architecture checkpoint
+   Problem: SD1.5 ControlNet with SDXL checkpoint (or vice versa)
+   Error: "mat1 and mat2 shapes cannot be multiplied (154x2048 and 768x320)"
    Fix: Use ControlNet models designed for your checkpoint architecture
+        - SD1.5 checkpoints require SD1.5 ControlNets
+        - SDXL checkpoints require SDXL ControlNets
    ```
 
 3. **Quick diagnostics:**

--- a/zh-CN/troubleshooting/model-issues.mdx
+++ b/zh-CN/troubleshooting/model-issues.mdx
@@ -13,6 +13,9 @@ sidebarTitle: "模型问题"
 - `Given groups=1, weight of size [64, 4, 3, 3], expected input[1, 16, 128, 128] to have 4 channels, but got 16 channels instead`
 - `Given groups=1, weight of size [4, 4, 1, 1], expected input[1, 16, 144, 112] to have 4 channels, but got 16 channels instead`
 - `Given groups=1, weight of size [320, 4, 3, 3], expected input[2, 16, 192, 128] to have 4 channels, but got 16 channels instead`
+- `The size of tensor a (49) must match the size of tensor b (16) at non-singleton dimension 1`
+- `Tensors must have same number of dimensions: got 2 and 3`
+- `mat1 and mat2 shapes cannot be multiplied (154x2048 and 768x320)`
 
 **根本原因：** 将来自不同架构系列的模型混合使用
 
@@ -23,6 +26,7 @@ sidebarTitle: "模型问题"
    - **SD1.5 模型**使用 4 通道潜在空间，配合单个 CLIP ViT-L/14 文本编码器
    - **SDXL 模型**使用 4 通道潜在空间，配合双文本编码器（CLIP ViT-L/14 + OpenCLIP ViT-bigG/14）
    - **SD3 模型**使用 16 通道潜在空间，配合三重文本编码器调节（CLIP-L + OpenCLIP bigG + T5-XXL）
+   - **ControlNet 模型**必须与基础检查点的架构匹配（SD1.5 ControlNet 仅适用于 SD1.5 检查点，SDXL ControlNet 仅适用于 SDXL 检查点，等等）
 
 2. **常见不匹配场景和修复：**
 
@@ -40,8 +44,11 @@ sidebarTitle: "模型问题"
 
    **ControlNet 架构不匹配：**
    ```
-   问题：SD1.5 ControlNet 与不同架构检查点
+   问题：SD1.5 ControlNet 与 SDXL 检查点（或反之）
+   错误："mat1 and mat2 shapes cannot be multiplied (154x2048 and 768x320)"
    修复：使用为您的检查点架构设计的 ControlNet 模型
+        - SD1.5 检查点需要 SD1.5 ControlNet
+        - SDXL 检查点需要 SDXL ControlNet
    ```
 
 3. **快速诊断：**


### PR DESCRIPTION
Adds the common tensor multiplication error that occurs when mixing ControlNet architectures. Updates both English and Chinese docs to help users diagnose SD1.5/SDXL ControlNet compatibility issues.