### PR TITLE
Update LiteGraph settings page titles

### DIFF
--- a/interface/settings/lite-graph.mdx
+++ b/interface/settings/lite-graph.mdx
@@ -1,8 +1,8 @@
 ---
-title: "ComfyUI Canvas (LiteGraph) Settings"
+title: "ComfyUI LiteGraph (Canvas) Settings"
 description: "Detailed description of ComfyUI graphics rendering engine LiteGraph setting options"
 icon: "diagram-project"
-sidebarTitle: "Canvas"
+sidebarTitle: "Lite Graph"
 ---
 
 LiteGraph is the underlying graphics rendering engine of ComfyUI. The settings in this category mainly control the behavior and appearance of graphical interfaces such as canvas, nodes, and links.


### PR DESCRIPTION
Changed the page title and sidebar title to clarify the relationship between ComfyUI, LiteGraph, and the Canvas. This improves clarity for users navigating the settings documentation.