### PR TITLE
Update shortcut descriptions and workflow clearing keys

### DIFF
--- a/interface/shortcuts.mdx
+++ b/interface/shortcuts.mdx
@@ -24,8 +24,8 @@ Below is the current list of shortcuts for ComfyUI, which you can customize as n
 <Tab title="Windows/Linux">
 | Shortcut                           | Command                                                                                                        |
 |------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| Ctrl + Enter                       | Execute prompt                                                                                                      |
-| Ctrl + Shift + Enter               | Execute prompt (frontend)                                                                                          |
+| Ctrl + Enter                       | Queue prompt                                                                                                      |
+| Ctrl + Shift + Enter               | Queue prompt (Front)                                                                                          |
 | Ctrl + Alt + Enter                 | Interrupt                                                                                                          |
 | Ctrl + Z / Ctrl + Y                | Undo/Redo                                                                                                          |
 | Ctrl + S                           | Save workflow                                                                                                      |
@@ -35,7 +35,7 @@ Below is the current list of shortcuts for ComfyUI, which you can customize as n
 | Ctrl + M                           | Mute/unmute selected nodes                                                                                         |
 | Ctrl + B                           | Bypass/unbypass selected nodes                                                                                     |
 | Delete<br/>Backspace               | Delete selected nodes                                                                                              |
-| Ctrl + Delete<br/>Ctrl + Backspace | Clear workflow                                                                                                     |
+| Backspace                          | Clear workflow                                                                                                     |
 | Space                              | Move canvas when holding and moving cursor                                                                         |
 | Ctrl + Click<br/>Shift + Click     | Add clicked node to selection                                                                                      |
 | Ctrl + C/Ctrl + V                  | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |
@@ -52,16 +52,16 @@ Below is the current list of shortcuts for ComfyUI, which you can customize as n
 | N                                  | Toggle node library sidebar                                                                                        |
 | M                                  | Toggle model library sidebar                                                                                       |
 | Ctrl + `                           | Toggle log bottom panel                                                                                            |
-| F                                  | Toggle focus mode (full screen)                                                                                                  |
+| F                                  | Toggle focus mode (full screen)                                                                                    |
 | R                                  | Refresh node definitions                                                                                           |
 | Double-Click LMB                   | Quick search for nodes to add                                                                                      |
 </Tab>
 
 <Tab title="MacOS">
-| Shortcut                              | Command                                                                                                        |
+| Shortcut                              | Command                                                                                                           |
 |--------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| Cmd ⌘ + Enter                        | Execute prompt                                                                                                      |
-| Cmd ⌘ + Shift + Enter                | Execute prompt (frontend)                                                                                          |
+| Cmd ⌘ + Enter                        | Queue prompt                                                                                                       |
+| Cmd ⌘ + Shift + Enter                | Queue prompt (Front)                                                                                               |
 | Cmd ⌘ + Alt + Enter                  | Interrupt                                                                                                          |
 | Cmd ⌘ + Z/Cmd ⌘ + Y                  | Undo/Redo                                                                                                          |
 | Cmd ⌘ + S                            | Save workflow                                                                                                      |
@@ -71,7 +71,7 @@ Below is the current list of shortcuts for ComfyUI, which you can customize as n
 | Cmd ⌘ + M                            | Mute/unmute selected nodes                                                                                         |
 | Cmd ⌘ + B                            | Bypass/unbypass selected nodes                                                                                     |
 | Delete<br/>Backspace                 | Delete selected nodes                                                                                              |
-| Cmd ⌘ + Delete<br/>Cmd ⌘ + Backspace | Clear workflow                                                                                                     |
+| Backspace                            | Clear workflow                                                                                                     |
 | Space                                | Move canvas when holding and moving cursor                                                                         |
 | Cmd ⌘ + Click<br/>Shift + Click      | Add clicked node to selection                                                                                      |
 | Cmd ⌘ + C / Cmd ⌘ + V                | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |

--- a/zh-CN/interface/shortcuts.mdx
+++ b/zh-CN/interface/shortcuts.mdx
@@ -28,7 +28,7 @@ icon: "keyboard"
 | Ctrl + M                           | 静音/取消静音选定节点                                          |
 | Ctrl + B                           | 忽略/取消忽略选定节点                                          |
 | Delete<br/>Backspace               | 删除选定节点                                                  |
-| Ctrl + Delete<br/>Ctrl + Backspace | 清除工作流                                                    |
+| Backspace                          | 清除工作流                                                    |
 | Space                              | 按住并移动光标时移动画布                                        |
 | Ctrl + Click<br/>Shift + Click     | 将点击的节点添加到选择中                                        |
 | Ctrl + C/Ctrl + V                  | 复制并粘贴选定节点（不保持与未选定节点输出的连接）                |
@@ -64,7 +64,7 @@ icon: "keyboard"
 | Cmd ⌘ + M                            | 静音/取消静音选定节点                                 |
 | Cmd ⌘ + B                            | 忽略/取消忽略选定节点                                 |
 | Delete<br/>Backspace                 | 删除选定节点                                         |
-| Cmd ⌘ + Delete<br/>Cmd ⌘ + Backspace | 清除工作流                                          |
+| Backspace                            | 清除工作流                                          |
 | Space                                | 按住并移动光标时移动画布                               |
 | Cmd ⌘ + Click<br/>Shift + Click      | 将点击的节点添加到选择中                               |
 | Cmd ⌘ + C / Cmd ⌘ + V                | 复制并粘贴选定节点（不保持与未选定节点输出的连接）         |


### PR DESCRIPTION
Revised shortcut descriptions to use 'Queue prompt' instead of 'Execute prompt' and updated the workflow clearing shortcut to use only Backspace instead of Ctrl/Cmd + Delete/Backspace in both English and Chinese documentation.