### PR TITLE
Update changelog with comfyui v0.3.40

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -3,3 +3,44 @@ title: "Changelog"
 description: "Track ComfyUI's latest features, improvements, and bug fixes"
 icon: "clock-rotate-left"
 ---
+
+<Update label="v0.3.40" description="December 27, 2024">
+
+## What's Changed
+
+- Cleanup BFL API nodes for Kontext [pro] and [max] by @Kosinkadink in https://github.com/comfyanonymous/ComfyUI/pull/8337
+- Add node for regex replace(sub) operation by @JettHu in https://github.com/comfyanonymous/ComfyUI/pull/8340
+- Put ROCm version in tuple to make it easier to enable stuff based on it. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8348
+- Remove huchenlei from CODEOWNERS by @huchenlei in https://github.com/comfyanonymous/ComfyUI/pull/8350
+- fix: custom comfy-api-base works with subpath by @BennyKok in https://github.com/comfyanonymous/ComfyUI/pull/8332
+- use fused multiply-add pointwise ops in chroma by @drhead in https://github.com/comfyanonymous/ComfyUI/pull/8279
+- Bump template to 0.1.23 by @comfyui-wiki in https://github.com/comfyanonymous/ComfyUI/pull/8353
+- Make it easier to pass lists of tensors to models. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8358
+- Update frontend to 1.21 by @webfiltered in https://github.com/comfyanonymous/ComfyUI/pull/8366
+- [feat] Add ImageStitch node for concatenating images by @christian-byrne in https://github.com/comfyanonymous/ComfyUI/pull/8369
+- Add Help Menu in NodeLibrarySidebarTab by @benceruleanlu in https://github.com/comfyanonymous/ComfyUI/pull/8179
+- Make the casting in lists the same as regular inputs. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8373
+- Bump template to 0.1.25 by @comfyui-wiki in https://github.com/comfyanonymous/ComfyUI/pull/8372
+- [BugFix] Update frontend to 1.21.4 by @webfiltered in https://github.com/comfyanonymous/ComfyUI/pull/8377
+- [feat] Add custom node testing requirement to issue templates by @christian-byrne in https://github.com/comfyanonymous/ComfyUI/pull/8374
+- [BugFix] Update frontend to 1.21.5 by @webfiltered in https://github.com/comfyanonymous/ComfyUI/pull/8382
+- [BugFix] Update frontend to 1.21.6 by @webfiltered in https://github.com/comfyanonymous/ComfyUI/pull/8383
+- Update fix for potential XSS on /view by @jessegonyou in https://github.com/comfyanonymous/ComfyUI/pull/8384
+- Style fix. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8390
+- [feat] Add GetImageSize node by @christian-byrne in https://github.com/comfyanonymous/ComfyUI/pull/8386
+- Add api nodes to readme. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8402
+- add support to read pyproject.toml from custom node by @jtydhr88 in https://github.com/comfyanonymous/ComfyUI/pull/8357
+- Update frontend to 1.21.7 by @webfiltered in https://github.com/comfyanonymous/ComfyUI/pull/8410
+- [Fix] Replace call to deprecated pillow API Image.ANTIALIAS by @soudfl in https://github.com/comfyanonymous/ComfyUI/pull/8415
+- Add batch to GetImageSize node. by @comfyanonymous in https://github.com/comfyanonymous/ComfyUI/pull/8419
+- [refactor] remove version prefixes from Ideogram node categories by @christian-byrne in https://github.com/comfyanonymous/ComfyUI/pull/8418
+
+## New Contributors
+
+- @BennyKok made their first contribution in https://github.com/comfyanonymous/ComfyUI/pull/8332
+- @jessegonyou made their first contribution in https://github.com/comfyanonymous/ComfyUI/pull/8384
+- @soudfl made their first contribution in https://github.com/comfyanonymous/ComfyUI/pull/8415
+
+**Full Changelog**: https://github.com/comfyanonymous/ComfyUI/compare/v0.3.39...v0.3.40
+
+</Update>

--- a/zh-CN/changelog/index.mdx
+++ b/zh-CN/changelog/index.mdx
@@ -3,3 +3,68 @@ title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复"
 icon: "clock-rotate-left"
 ---
+
+<Update label="0.3.40" description="2025年1月14日">
+
+**更新内容**
+
+清理 Kontext [pro] 和 [max] 的 BFL API 节点，由 @Kosinkadink 提交 https://github.com/comfyanonymous/ComfyUI/pull/8337
+
+为正则表达式替换(sub)操作添加节点，由 @JettHu 提交 https://github.com/comfyanonymous/ComfyUI/pull/8340
+
+将 ROCm 版本放入元组中，以便更容易根据版本启用功能，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8348
+
+从 CODEOWNERS 中移除 huchenlei，由 @huchenlei 提交 https://github.com/comfyanonymous/ComfyUI/pull/8350
+
+修复：自定义 comfy-api-base 支持子路径，由 @BennyKok 提交 https://github.com/comfyanonymous/ComfyUI/pull/8332
+
+在色度中使用融合乘加逐点操作，由 @drhead 提交 https://github.com/comfyanonymous/ComfyUI/pull/8279
+
+将模板升级到 0.1.23，由 @comfyui-wiki 提交 https://github.com/comfyanonymous/ComfyUI/pull/8353
+
+使向模型传递张量列表更容易，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8358
+
+将前端更新到 1.21，由 @webfiltered 提交 https://github.com/comfyanonymous/ComfyUI/pull/8366
+
+[功能] 添加用于连接图像的 ImageStitch 节点，由 @christian-byrne 提交 https://github.com/comfyanonymous/ComfyUI/pull/8369
+
+在 NodeLibrarySidebarTab 中添加帮助菜单，由 @benceruleanlu 提交 https://github.com/comfyanonymous/ComfyUI/pull/8179
+
+使列表中的类型转换与常规输入相同，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8373
+
+将模板升级到 0.1.25，由 @comfyui-wiki 提交 https://github.com/comfyanonymous/ComfyUI/pull/8372
+
+[错误修复] 将前端更新到 1.21.4，由 @webfiltered 提交 https://github.com/comfyanonymous/ComfyUI/pull/8377
+
+[功能] 在问题模板中添加自定义节点测试要求，由 @christian-byrne 提交 https://github.com/comfyanonymous/ComfyUI/pull/8374
+
+[错误修复] 将前端更新到 1.21.5，由 @webfiltered 提交 https://github.com/comfyanonymous/ComfyUI/pull/8382
+
+[错误修复] 将前端更新到 1.21.6，由 @webfiltered 提交 https://github.com/comfyanonymous/ComfyUI/pull/8383
+
+更新 /view 上潜在 XSS 的修复，由 @jessegonyou 提交 https://github.com/comfyanonymous/ComfyUI/pull/8384
+
+样式修复，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8390
+
+[功能] 添加 GetImageSize 节点，由 @christian-byrne 提交 https://github.com/comfyanonymous/ComfyUI/pull/8386
+
+在 readme 中添加 api 节点，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8402
+
+添加从自定义节点读取 pyproject.toml 的支持，由 @jtydhr88 提交 https://github.com/comfyanonymous/ComfyUI/pull/8357
+
+将前端更新到 1.21.7，由 @webfiltered 提交 https://github.com/comfyanonymous/ComfyUI/pull/8410
+
+[修复] 替换对已弃用的 pillow API Image.ANTIALIAS 的调用，由 @soudfl 提交 https://github.com/comfyanonymous/ComfyUI/pull/8415
+
+为 GetImageSize 节点添加批处理功能，由 @comfyanonymous 提交 https://github.com/comfyanonymous/ComfyUI/pull/8419
+
+[重构] 从 Ideogram 节点类别中移除版本前缀，由 @christian-byrne 提交 https://github.com/comfyanonymous/ComfyUI/pull/8418
+
+**新贡献者**
+@BennyKok 在 https://github.com/comfyanonymous/ComfyUI/pull/8332 中首次贡献
+@jessegonyou 在 https://github.com/comfyanonymous/ComfyUI/pull/8384 中首次贡献
+@soudfl 在 https://github.com/comfyanonymous/ComfyUI/pull/8415 中首次贡献
+
+完整更新日志：https://github.com/comfyanonymous/ComfyUI/compare/v0.3.39...v0.3.40
+
+</Update>


### PR DESCRIPTION
Update changelog with comfyui version 0.3.40

This PR updates the existing changelog by prepending the new release notes.

Files updated:
changelog/index.mdx
- zh-CN/changelog/index.mdx

Generated from GitHub release webhook and processed with Anthropic AI.

Strapi Draft ID: 29