### PR TITLE
Add section on new selection toolbox feature in Flux.1 tutorial

### DIFF
--- a/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/tutorials/flux/flux-1-kontext-dev.mdx
@@ -130,8 +130,6 @@ You can refer to the numbers in the image to complete the workflow run:
 4. Since other models and related nodes are packaged in the group node, you need to follow the reference in the step diagram to ensure that the corresponding models are correctly loaded and write prompts
 5. Click the `Queue` button, or use the shortcut `Ctrl(cmd) + Enter` to run the workflow
 
-<PromptTechniques/>
-
 ## New Flux.1 Kontext Dev Selection Toolbox Feature
 
 To make it easier for users to edit with Flux.1 Kontext Dev, we have added a selection toolbox feature. This feature allows users to quickly and conveniently add the `FLUX.1 Kontext Image Edit` group node.
@@ -149,3 +147,5 @@ You can watch the video demo below. When you select the `Load Image` node, you c
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
+
+<PromptTechniques/>

--- a/zh-CN/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/zh-CN/tutorials/flux/flux-1-kontext-dev.mdx
@@ -131,9 +131,6 @@ FLUX.1 Kontext 是 Black Forest Labs 推出的突破性多模态图像编辑模�
 4. 由于其它模型和相关节点都被组节点打包，你需要按照步骤图中的参考同样确保对应的模型已经正确加载，并书写提示词
 5. 点击 `Queue` 按钮，或者使用快捷键 `Ctrl(cmd) + Enter(回车)` 来运行工作流
 
-
-<PromptTechniques/>
-
 ## 新增的 Flux.1 Kontext Dev 选择工具箱功能
 
 此次为了方便用户使用 Flux.1 Kontext 进行编辑，我们新增了选择工具箱功能，用户可以更加方便地快速添加 `FLUX.1 Kontext Image Edit` 组节点，具体可以查看下面的视频演示，当你选中 `Load Image` 节点时，就可以在选择工具箱中找到新增的编辑按钮
@@ -146,3 +143,5 @@ FLUX.1 Kontext 是 Black Forest Labs 推出的突破性多模态图像编辑模�
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
+
+<PromptTechniques/>


### PR DESCRIPTION
Updated both English and Chinese Flux.1 Kontext Dev tutorials to introduce the new selection toolbox feature, including a description, usage instructions, and embedded video demos. This feature allows users to quickly add the 'FLUX.1 Kontext Image Edit' group node and is currently experimental.