### PR TITLE
Remove autoplay from iframe allow attributes

### DIFF
--- a/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/tutorials/flux/flux-1-kontext-dev.mdx
@@ -12,7 +12,7 @@ import UpdateReminder from '/snippets/tutorials/update-reminder.mdx'
   src="https://www.youtube.com/embed/Y7L_cbNJHj0?si=zuaRiU3qJYMNW2uv"
   title="ComfyUI Selection Toolbox New Features"
   frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
 
@@ -153,7 +153,7 @@ You can watch the video demo below. When you select the `Load Image` node, you c
   src="https://www.youtube.com/embed/X7ArunILYBw?si=2iNo9ESsyE8zsQV3"
   title="ComfyUI Selection Toolbox New Features"
   frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
 

--- a/zh-CN/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/zh-CN/tutorials/flux/flux-1-kontext-dev.mdx
@@ -12,7 +12,7 @@ import UpdateReminder from '/snippets/zh/tutorials/update-reminder.mdx'
   src="//player.bilibili.com/player.html?isOutside=true&aid=114750419636159&bvid=BV14MKfzCELz&cid=30712923473&p=1"
   title="ComfyUI Selection Toolbox New Features"
   frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
 
@@ -149,7 +149,7 @@ FLUX.1 Kontext 是 Black Forest Labs 推出的突破性多模态图像编辑模�
   src="//player.bilibili.com/player.html?isOutside=true&aid=114758506253384&bvid=BV1tCK1zGENB&cid=30735339422&p=1"
   title="ComfyUI 选择工具箱新增功能"
   frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
 


### PR DESCRIPTION
The 'autoplay' permission was removed from the 'allow' attribute of embedded iframes in both English and Chinese Flux tutorials to prevent videos from auto-playing.