### PR TITLE
Add GitHub Action to automatically delete merged branches

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,41 @@
+name: Delete Merged Branches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-merged-branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branchName = context.payload.pull_request.head.ref;
+            
+            // Skip if it's the default branch
+            if (branchName === 'main' || branchName === 'master') {
+              console.log(`Skipping deletion of protected branch: ${branchName}`);
+              return;
+            }
+            
+            // Skip if it's from a fork
+            if (context.payload.pull_request.head.repo.full_name !== context.payload.pull_request.base.repo.full_name) {
+              console.log(`Skipping deletion of branch from fork: ${branchName}`);
+              return;
+            }
+            
+            try {
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${branchName}`
+              });
+              console.log(`Successfully deleted branch: ${branchName}`);
+            } catch (error) {
+              console.log(`Failed to delete branch ${branchName}: ${error.message}`);
+            }


### PR DESCRIPTION
This action will automatically delete feature branches after they are merged into the main branch, helping to keep the repository clean. It includes safeguards to:
- Only delete branches from the same repository (not forks)
- Skip protected branches like main/master
- Only run when PRs are actually merged (not just closed)

🤖 Generated with [Claude Code](https://claude.ai/code)