### PR TITLE
Clarify custom node installation and security levels

### DIFF
--- a/installation/install_custom_node.mdx
+++ b/installation/install_custom_node.mdx
@@ -55,7 +55,12 @@ Tip: Before installing custom nodes, check the plugin's README file to understan
       ![Click Install button for the node](/images/installation/custom_nodes/install-custom-nodes-by-manager-5.jpg)
       Find the node you want to install and click the `Install` button
       ![Click Install button for the node](/images/installation/custom_nodes/install-custom-nodes-by-manager-6.jpg)
-      A popup will ask you to choose a version - `nightly` is the latest version, while `latest` is the most recent stable version. Choose based on your needs.
+      - 在这一步，如果你选择 `nightly` 版本，这会从 Github 直接下载对应的插件源码最新版本，但同时如果你的 Manager `security_level` 为 `normal` 将不允许你直接从 Github 下载源码，因为对应代码没有经过扫描
+      - 如果你选择了其它版本如 `latest` 或者带有数字的稳定版本，对应的代码将会从 https://registry.comfy.org/ 进行下载，这意味着对应的代码经过审查，不会触发安全检查
+      <Tip>
+        `nightly` 版本通常是最新的版本，但因为它直接从 github 下载没有经过审查的版本，存在一定的代码风险，如果你一定需要安装`nightly`版本，请将 Manager 的 `security_level` 设置为 `weak`
+        对应配置文件路径为 `ComfyUI/user/default/ComfyUI-Manager/config.ini`,但请注意这并不是我们推荐的配置，请只临时使用这个配置
+      </Tip>
     </Step>
     <Step title="Wait for dependencies to install and restart ComfyUI">
       Manager will automatically install dependencies and prompt you to restart ComfyUI when complete

--- a/zh-CN/installation/install_custom_node.mdx
+++ b/zh-CN/installation/install_custom_node.mdx
@@ -55,7 +55,14 @@ icon: "puzzle-piece"
       ![点击对应节点的 `Install` 按钮](/images/installation/custom_nodes/install-custom-nodes-by-manager-5.jpg)
       找到需要安装的节点，点击`Install`按钮
       ![点击对应节点的 `Install` 按钮](/images/installation/custom_nodes/install-custom-nodes-by-manager-6.jpg)
-      弹窗会提示要求选择版本，对应的 `nightly` 版本为最新版本，`latest` 版本为最新稳定版本，请根据你的需求选择版本
+      
+      在弹出的窗口中会要求选择版本：
+      - `nightly` 版本: 直接从 Github 下载最新源码，但在 `security_level` 为 `normal` 时，会提示当前的安全等级设置不允许下载该插件
+      - `latest` 或带数字的稳定版本（推荐）: 从 https://registry.comfy.org/ 下载经过审查的代码，不会触发安全检查
+      <Tip>
+        `nightly` 版本通常是最新的版本，但因为它直接从 github 下载没有经过审查的版本，存在一定的代码风险，如果你一定需要安装`nightly`版本，请将 Manager 的 `security_level` 设置为 `weak`
+        对应配置文件路径为 `ComfyUI/user/default/ComfyUI-Manager/config.ini`,但请注意这并不是我们推荐的配置，请只临时使用这个配置
+      </Tip>
     </Step>
     <Step title="等待依赖安装完成后重启ComfyUI">
       点击安装后 Manager 会自动完成依赖的安装，并会在安装完成后提示你重启 ComfyUI


### PR DESCRIPTION
Expanded instructions for installing custom nodes, detailing the differences between 'nightly' and stable versions, their download sources, and the impact of Manager's 'security_level' setting. Added tips and warnings about using 'nightly' versions and modifying security configurations in both English and Chinese documentation.