### PR TITLE
Fix windows log paths not displayed correctly

### DIFF
--- a/installation/desktop/windows.mdx
+++ b/installation/desktop/windows.mdx
@@ -150,6 +150,6 @@ Since ComfyUI Desktop (Windows) only supports **NVIDIA GPUs with CUDA**, you may
 
 <TroubleshootingGpt/>
 <TroubleshootingFeedback
-log_path="C:\Users\ <your username> \AppData\Roaming\ComfyUI\logs"
-config_path="C:\Users\ <your username> \AppData\Roaming\ComfyUI"
+log_path="C:\\Users\\<your username>\\AppData\\Roaming\\ComfyUI\\logs"
+config_path="C:\\Users\\<your username>\\AppData\\Roaming\\ComfyUI"
 />

--- a/zh-CN/installation/desktop/windows.mdx
+++ b/zh-CN/installation/desktop/windows.mdx
@@ -144,7 +144,7 @@ ComfyUI 桌面版(Windows)硬件要求：
 
 <TroubleshootingGpt/>
 <TroubleshootingFeedback
-log_path="C:\Users\ <你的用户名> \AppData\Roaming\ComfyUI\logs"
-config_path="C:\Users\ <你的用户名> \AppData\Roaming\ComfyUI"
+log_path="C:\\Users\\<你的用户名>\\AppData\\Roaming\\ComfyUI\\logs"
+config_path="C:\\Users\\<你的用户名>\\AppData\\Roaming\\ComfyUI"
 />
 


### PR DESCRIPTION
Backslashes are escape characters and must be escaped.