### PR TITLE
fix(docs): correct typos in comments and strings found during code review

### DIFF
--- a/custom-nodes/v3_migration.mdx
+++ b/custom-nodes/v3_migration.mdx
@@ -96,11 +96,11 @@ class Example(io.ComfyNode):
 
 ### Step 2: Convert INPUT_TYPES to define_schema
 
-Node properites like node id, display name, category, etc. that were assigned in different places in code such as dictionaries and class properties are now kept together via the ```Schema``` class.
+Node properties like node id, display name, category, etc. that were assigned in different places in code such as dictionaries and class properties are now kept together via the ```Schema``` class.
 
 The ```define_schema(cls)``` function is expected to return a ```Schema``` object in much the same way INPUT_TYPES(s) worked in V1.
 
-Supported core Input/Output types are stored and documented in ```comfy_api/{version}``` in ```_io.py```, which is namespaced as ```io``` by default. Since Inputs/Outputs are defined by classes now instead of dictionaries or strings, custom types are supported by either definining your own class or using the helper function ```Custom``` in ```io```.
+Supported core Input/Output types are stored and documented in ```comfy_api/{version}``` in ```_io.py```, which is namespaced as ```io``` by default. Since Inputs/Outputs are defined by classes now instead of dictionaries or strings, custom types are supported by either defining your own class or using the helper function ```Custom``` in ```io```.
 
 Custom types are elaborated on in a section further below.
 

--- a/interface/settings/3d.mdx
+++ b/interface/settings/3d.mdx
@@ -64,4 +64,4 @@ Change the background color, which can also be adjusted in the canvas.
 
 Hide or show the grid on initialization
 
-![Show gird vs hide gird](/images/interface/setting/3d/hide_grid.jpg)
+![Show grid vs hide grid](/images/interface/setting/3d/hide_grid.jpg)

--- a/tutorials/image/cosmos/cosmos-predict2-t2i.mdx
+++ b/tutorials/image/cosmos/cosmos-predict2-t2i.mdx
@@ -78,5 +78,5 @@ Please follow the steps in the image to run the workflow:
 3. Ensure the `Load VAE` node has loaded `wan_2.1_vae.safetensors`
 4. Set the image size in `EmptySD3LatentImage`
 5. Modify the prompts in the `ClipTextEncode` node
-6. Click the `Run` button or use the shortcut `Ctrl(cmd) + Enter` to run the worklfow
+6. Click the `Run` button or use the shortcut `Ctrl(cmd) + Enter` to run the workflow
 7. Once generation is complete, the image will automatically save to the `ComfyUI/output/` directory. You can also preview it in the `save image` node. */}

--- a/tutorials/video/wan/wan2-2-animate.mdx
+++ b/tutorials/video/wan/wan2-2-animate.mdx
@@ -38,7 +38,7 @@ It can also replace characters in a video with animated characters, preserving t
 In this docs, we will provide two workflow:
 
 1. Workflow that only uses core nodes (It is incomplete; you need to preprocess the image by yourself first)
-2. Workflow that inculdes some custom nodes (It is complete; you can use it directly, but some new user might not know how to install the custom nodes)
+2. Workflow that includes some custom nodes (It is complete; you can use it directly, but some new user might not know how to install the custom nodes)
 
 ## Wan2.2 Anmate ComfyUI native workflow(without custom nodes)
 


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>