### PR TITLE
Update changelog with v0.3.64 and v0.3.65 (simplified)

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,38 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes"
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.3.65" description="October 14, 2025">
+
+**Node Schema Migration (V3)**
+- Migrated core node categories to V3 schema including model downscale, LoRA extraction, compositing, latent ops, SD3/SLG, Flux, upscale models, and HunyuanVideo nodes
+
+**Audio & Model Improvements**
+- Added MMaudio 16K VAE support for high-fidelity audio workflows
+- Fixed mono audio incorrectly saving as stereo
+- Refactored model sampling sigmas code and fixed FP8 scaled LoRA issues
+- Fixed loading of older Stable Diffusion checkpoints on newer NumPy versions
+
+**AMD GPU Optimizations**
+- Better memory estimation for SD/Flux VAE operations
+- Enabled RDNA4 PyTorch attention on ROCm 7.0+
+
+**API Node Updates**
+- Added price extractor and improvements to Kling/Pika API nodes
+- Enhanced Gemini Image API with aspect_ratio support
+
+**Updates**
+- Template v0.1.95, node docs v0.3.0
+- Fixed WAN2.2 cache VRAM leak
+
+</Update>
+
+<Update label="v0.3.64" description="October 8, 2025">
+
+**API Nodes**
+- Added Sora2 API node for OpenAI's video generation API
+
+</Update>
+
 <Update label="v0.3.63" description="October 6, 2025">
 
 **Model Compatibility Enhancements**

--- a/zh-CN/changelog/index.mdx
+++ b/zh-CN/changelog/index.mdx
@@ -4,6 +4,38 @@ description: "跟踪 ComfyUI 的最新功能、改进和错误修复"
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.3.65" description="2025年10月14日">
+
+**节点架构迁移 (V3)**
+- 将核心节点迁移到 V3 架构,包括模型缩放、LoRA 提取、合成、潜在操作、SD3/SLG、Flux、放大模型和 HunyuanVideo 节点
+
+**音频和模型改进**
+- 新增 MMaudio 16K VAE 支持高保真音频工作流
+- 修复单声道音频错误保存为立体声问题
+- 重构模型采样代码并修复 FP8 缩放 LoRA 问题
+- 修复旧版 Stable Diffusion 检查点在新版 NumPy 上的加载问题
+
+**AMD GPU 优化**
+- 改进 SD/Flux VAE 操作的内存估算
+- 在 ROCm 7.0+ 上启用 RDNA4 PyTorch 注意力
+
+**API 节点更新**
+- 新增价格提取器并改进 Kling/Pika API 节点
+- 增强 Gemini Image API 的 aspect_ratio 支持
+
+**其他更新**
+- 模板 v0.1.95,节点文档 v0.3.0
+- 修复 WAN2.2 缓存 VRAM 泄漏
+
+</Update>
+
+<Update label="v0.3.64" description="2025年10月8日">
+
+**API 节点**
+- 新增 Sora2 API 节点,支持 OpenAI 视频生成 API
+
+</Update>
+
 <Update label="v0.3.63" description="2025年10月6日">
 
 **模型兼容性增强**


### PR DESCRIPTION
- Combined updates from PR #487 (v0.3.64) and PR #491 (v0.3.65)
- Simplified changelog content to be more concise
- Removed unnecessary verbosity while keeping key information