### PR TITLE
Fix giscus language mapping issue by enforcing strict pathname matching

### DIFF
--- a/giscus-comments.js
+++ b/giscus-comments.js
@@ -257,7 +257,7 @@
     script.setAttribute('data-category', 'Announcements');
     script.setAttribute('data-category-id', 'DIC_kwDOLlassc4CtQoz'); // Replace with real ID
     script.setAttribute('data-mapping', 'pathname');
-    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-strict', '1');
     script.setAttribute('data-reactions-enabled', '1');
     script.setAttribute('data-emit-metadata', '0');
     script.setAttribute('data-input-position', 'bottom');


### PR DESCRIPTION
Changed data-strict from '0' to '1' to prevent English pages from matching Chinese discussion threads. This ensures that:
- English pages (/tutorials/video/wan/wan2_2) will have their own separate discussions
- Chinese pages (/zh-CN/tutorials/video/wan/wan2_2) will maintain their separate discussions
- No cross-language comment mixing will occur

Fixes the issue where English tutorial pages were displaying Chinese comments due to fuzzy pathname matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)