### PR TITLE
disable telemetry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1295,11 +1295,7 @@
       "claude"
     ]
   },
-  "integrations": {
-    "mixpanel": {
-      "projectToken": "3f02b60047411909a040d32a7bf2abe7"
-    }
-  },
+  "integrations": {},
   "redirects": [
     {
       "source": "/get_started/manual_install",


### PR DESCRIPTION
temporarily disables Mixpanel telemetry. This project is taking too much of the event quota. In a followup PR, we can change to Clickhouse, since we are just doing a SUM of events and not doing any complex analysis/funnels/flows/etc.