### PR TITLE
feat: add unauthenticated user handling for Giscus comments

### DIFF
--- a/giscus-comments.js
+++ b/giscus-comments.js
@@ -458,82 +458,35 @@
   }
 
   // Show friendly discussion notice
-  function showGiscusNotice(container, noticeType = 'rate_limit') {
+  function showGiscusNotice(container) {
     const discussionUrl = generateDiscussionUrl();
     const newDiscussionUrl = generateNewDiscussionUrl();
     
-    const noticeMessages = {
-      rate_limit: {
-        en: {
-          title: '💬 Join the Discussion',
-          message: 'Comments are temporarily unavailable due to high traffic.',
-          suggestion: 'Please first check if there are existing discussions about this page. If you can\'t find any relevant discussions, then start a new one to connect your comments with this page.',
-          discussionLink: 'Find Related Discussions',
-          newDiscussionLink: 'Start New Discussion'
-        },
-        zh: {
-          title: '💬 参与讨论', 
-          message: '由于访问量较高，评论功能暂时不可用。',
-          suggestion: '请先查找是否有关于此页面的相关讨论。如果找不到相关讨论，再发起新的讨论以便将评论与此页面关联。',
-          discussionLink: '查找相关讨论',
-          newDiscussionLink: '发起新讨论'
-        }
-      },
-      unauthenticated: {
-        en: {
-          title: '🔐 Sign in to GitHub',
-          message: 'You are viewing comments as a guest. Sign in to GitHub to post comments and enjoy higher rate limits (5000 requests/hour vs 60 for guests).',
-          suggestion: 'After signing in, you can post comments directly here. You can also check existing discussions or start a new one.',
-          discussionLink: 'Find Related Discussions',
-          newDiscussionLink: 'Start New Discussion',
-          signInLink: 'Sign in to GitHub'
-        },
-        zh: {
-          title: '🔐 登录 GitHub',
-          message: '您当前以访客身份查看评论。登录 GitHub 后可以发表评论，并享受更高的 API 限额（每小时 5000 次请求，访客为 60 次）。',
-          suggestion: '登录后，您可以直接在此发表评论。您也可以查看现有讨论或发起新讨论。',
-          discussionLink: '查找相关讨论',
-          newDiscussionLink: '发起新讨论',
-          signInLink: '登录 GitHub'
-        }
-      },
-      network: {
-        en: {
-          title: '💬 Join the Discussion',
-          message: 'Comments could not be loaded at this time.',
-          suggestion: 'Please first check if there are existing discussions about this page. If you can\'t find any relevant discussions, then start a new one to connect your comments with this page.',
-          discussionLink: 'Find Related Discussions',
-          newDiscussionLink: 'Start New Discussion'
-        },
-        zh: {
-          title: '💬 参与讨论',
-          message: '评论暂时无法加载。',
-          suggestion: '请先查找是否有关于此页面的相关讨论。如果找不到相关讨论，再发起新的讨论以便将评论与此页面关联。',
-          discussionLink: '查找相关讨论',
-          newDiscussionLink: '发起新讨论'
-        }
-      }
+    const isChinesePage = window.location.pathname.includes('/zh-CN/') || window.location.pathname.includes('/cn/');
+    const notice = isChinesePage ? {
+      title: '💬 参与讨论',
+      message: '由于访问量较高，评论功能暂时不可用。',
+      suggestion: '登录 GitHub 可享受更高的 API 限额（每小时 5000 次请求，访客为 60 次）。您也可以查看现有讨论或发起新讨论。',
+      signInLink: '登录 GitHub',
+      discussionLink: '查找相关讨论',
+      newDiscussionLink: '发起新讨论'
+    } : {
+      title: '💬 Join the Discussion',
+      message: 'Comments are temporarily unavailable due to high traffic.',
+      suggestion: 'Sign in to GitHub to enjoy higher rate limits (5000 requests/hour vs 60 for guests). You can also check existing discussions or start a new one.',
+      signInLink: 'Sign in to GitHub',
+      discussionLink: 'Find Related Discussions',
+      newDiscussionLink: 'Start New Discussion'
     };
     
-    const isChinesePage = window.location.pathname.includes('/zh-CN/') || window.location.pathname.includes('/cn/');
-    const lang = isChinesePage ? 'zh' : 'en';
-    const notice = noticeMessages[noticeType][lang];
-    
-    // For unauthenticated users, add sign-in button
-    const buttonsHtml = noticeType === 'unauthenticated' 
-      ? `
-        <div style="margin-top: 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
-          <a href="https://github.com/login" target="_blank" class="giscus-notice-button">${notice.signInLink}</a>
-          <a href="${discussionUrl}" target="_blank" class="giscus-notice-button secondary">${notice.discussionLink}</a>
-          <a href="${newDiscussionUrl}" target="_blank" class="giscus-notice-button secondary">${notice.newDiscussionLink}</a>
-        </div>
-      `
-      : `
-        <div style="margin-top: 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
-          <a href="${discussionUrl}" target="_blank" class="giscus-notice-button">${notice.discussionLink}</a>
-          <a href="${newDiscussionUrl}" target="_blank" class="giscus-notice-button secondary">${notice.newDiscussionLink}</a>
-        </div>
-      `;
+    // Always show sign-in button along with discussion links
+    const buttonsHtml = `
+      <div style="margin-top: 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+        <a href="https://github.com/login" target="_blank" class="giscus-notice-button">${notice.signInLink}</a>
+        <a href="${discussionUrl}" target="_blank" class="giscus-notice-button secondary">${notice.discussionLink}</a>
+        <a href="${newDiscussionUrl}" target="_blank" class="giscus-notice-button secondary">${notice.newDiscussionLink}</a>
+      </div>
+    `;
     
     const noticeDiv = document.createElement('div');
     noticeDiv.className = 'giscus-notice';
@@ -573,36 +526,11 @@
       
       // Check for various error patterns
       if (message && message.giscus) {
-        // Detect unauthenticated state
-        // viewer === null but discussion !== null means user is not logged in but can view comments
-        // We only show notice if there's an error, not for normal viewing
-        if (message.giscus.viewer === null && message.giscus.discussion !== null) {
-          console.log('Giscus: User is not authenticated (viewer is null)');
-          // Don't show error for unauthenticated users who can view comments normally
-          // Only show notice if there's an actual error
-          return;
-        }
-        
         // Standard giscus error format
         if (message.giscus.error) {
           const errorType = message.giscus.error.type;
           console.warn('Giscus error detected:', errorType, message.giscus.error);
-          
-          if (errorType === 'rate_limit' || errorType === 'rate-limit' || errorType === 'RATE_LIMITED') {
-            // Check if rate limit is due to unauthenticated user
-            if (message.giscus.viewer === null) {
-              // Unauthenticated user hit rate limit, suggest login
-              showGiscusNotice(container, 'unauthenticated');
-            } else {
-              // Authenticated user hit rate limit
-              showGiscusNotice(container, 'rate_limit');
-            }
-          } else if (errorType === 'unauthorized' || errorType === 'UNAUTHORIZED') {
-            // Explicit authentication error
-            showGiscusNotice(container, 'unauthenticated');
-          } else {
-            showGiscusNotice(container, 'network');
-          }
+          showGiscusNotice(container);
         }
         
         // Check for discussion data with error indicators
@@ -616,13 +544,7 @@
                 const errorElements = iframe.contentDocument.querySelectorAll('[class*="error"], [class*="Error"]');
                 if (errorElements.length > 0) {
                   console.warn('Giscus: Error elements found in iframe');
-                  // Check error content to determine if it's authentication-related
-                  const errorText = iframe.contentDocument.body?.textContent || '';
-                  if (errorText.includes('sign in') || errorText.includes('login') || errorText.includes('authenticate')) {
-                    showGiscusNotice(container, 'unauthenticated');
-                  } else {
-                    showGiscusNotice(container, 'rate_limit');
-                  }
+                  showGiscusNotice(container);
                 }
               }
             }
@@ -631,14 +553,9 @@
       }
       
       // Also check for direct error messages in the content
-      if (typeof message === 'string') {
-        if (message.includes('rate limit')) {
-          console.warn('Giscus: Rate limit detected in string message');
-          showGiscusNotice(container, 'rate_limit');
-        } else if (message.includes('sign in') || message.includes('login') || message.includes('authenticate')) {
-          console.warn('Giscus: Authentication required detected in string message');
-          showGiscusNotice(container, 'unauthenticated');
-        }
+      if (typeof message === 'string' && message.includes('rate limit')) {
+        console.warn('Giscus: Rate limit detected in string message');
+        showGiscusNotice(container);
       }
     });
     
@@ -654,15 +571,9 @@
             const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
             if (iframeDoc) {
               const bodyText = iframeDoc.body ? iframeDoc.body.textContent || '' : '';
-              if (bodyText.includes('rate limit') || bodyText.includes('API rate limit') || bodyText.includes('exceeded')) {
-                console.warn('Giscus: Rate limit detected in iframe content');
-                showGiscusNotice(container, 'rate_limit');
-              } else if (bodyText.includes('sign in') || bodyText.includes('login') || bodyText.includes('authenticate')) {
-                console.warn('Giscus: Authentication required detected in iframe content');
-                showGiscusNotice(container, 'unauthenticated');
-              } else if (bodyText.includes('error occurred')) {
-                console.warn('Giscus: Generic error detected in iframe content');
-                showGiscusNotice(container, 'rate_limit'); // Assume it's rate limit for now
+              if (bodyText.includes('rate limit') || bodyText.includes('API rate limit') || bodyText.includes('exceeded') || bodyText.includes('error occurred')) {
+                console.warn('Giscus: Error detected in iframe content');
+                showGiscusNotice(container);
               }
             }
           }, 5000); // Check after 5 seconds
@@ -741,7 +652,7 @@
       }
       
       console.error('Giscus: Failed to load giscus script');
-      showGiscusNotice(container, 'network');
+      showGiscusNotice(container);
     };
     
     // Set up a timeout to detect if giscus fails to load
@@ -757,12 +668,9 @@
             const iframeDoc = iframe.contentDocument;
             const bodyText = iframeDoc.body ? iframeDoc.body.textContent || '' : '';
             
-            if (bodyText.includes('sign in') || bodyText.includes('login') || bodyText.includes('authenticate')) {
-              console.warn('Giscus: Authentication required detected in iframe after timeout');
-              showGiscusNotice(container, 'unauthenticated');
-            } else if (bodyText.includes('error occurred') || bodyText.includes('rate limit') || bodyText.includes('exceeded')) {
+            if (bodyText.includes('error occurred') || bodyText.includes('rate limit') || bodyText.includes('exceeded')) {
               console.warn('Giscus: Error detected in iframe after timeout');
-              showGiscusNotice(container, 'rate_limit');
+              showGiscusNotice(container);
             }
           } else {
             console.warn('Giscus: Loading timeout, possibly rate limited');
@@ -857,31 +765,11 @@
   
   // Debug functions for testing notice messages
   window.giscusDebug = {
-    // Force show rate limit notice
-    showRateLimitNotice: () => {
+    // Force show notice
+    showNotice: () => {
       const container = document.querySelector('.giscus-container');
       if (container) {
-        showGiscusNotice(container, 'rate_limit');
-      } else {
-        console.warn('No giscus container found. Wait for page to load giscus placeholder first.');
-      }
-    },
-    
-    // Force show unauthenticated notice
-    showUnauthenticatedNotice: () => {
-      const container = document.querySelector('.giscus-container');
-      if (container) {
-        showGiscusNotice(container, 'unauthenticated');
-      } else {
-        console.warn('No giscus container found. Wait for page to load giscus placeholder first.');
-      }
-    },
-    
-    // Force show network notice
-    showNetworkNotice: () => {
-      const container = document.querySelector('.giscus-container');
-      if (container) {
-        showGiscusNotice(container, 'network');
+        showGiscusNotice(container);
       } else {
         console.warn('No giscus container found. Wait for page to load giscus placeholder first.');
       }
@@ -918,9 +806,7 @@
     
     // Add debug info
     console.log('Giscus Debug Commands Available:');
-    console.log('- giscusDebug.showRateLimitNotice() - Show rate limit notice');
-    console.log('- giscusDebug.showUnauthenticatedNotice() - Show unauthenticated notice');
-    console.log('- giscusDebug.showNetworkNotice() - Show network notice'); 
+    console.log('- giscusDebug.showNotice() - Show error notice');
     console.log('- giscusDebug.resetToPlaceholder() - Reset to placeholder');
     console.log('- giscusDebug.testUrls() - Test URL generation for current page');
     


### PR DESCRIPTION
- Add unauthenticated notice type with login prompt
- Distinguish between unauthenticated rate limits and authenticated rate limits
- Show login suggestion when unauthenticated users hit rate limits
- Detect authentication errors and show appropriate notices
- Add debug function to test unauthenticated notice
- Improve error detection to check for auth-related messages in iframe content