### PR TITLE
Warn on missing zh-CN translations instead of failing

### DIFF
--- a/.github/workflows/zh-cn-sync-check.yml
+++ b/.github/workflows/zh-cn-sync-check.yml
@@ -180,14 +180,14 @@ jobs:
           # Determine if we need to fail the check
           SHOULD_FAIL="false"
           
-          # Check for missing translations
+          # Check for missing translations (warning only, does not fail the build)
           if [ "$MISSING_TRANSLATIONS" != "" ]; then
-            SHOULD_FAIL="true"
             echo "------------------------"
-            echo "❌ The following translations need to be updated:"
+            echo "⚠️ The following translations need to be updated:"
             for missing in $MISSING_TRANSLATIONS; do
               echo "- $missing"
             done
+            echo "::warning::The following zh-CN translation files need to be updated to stay in sync with the English version:$MISSING_TRANSLATIONS"
           fi
           
           # Check for moved files without redirects


### PR DESCRIPTION
Update zh-cn-sync-check workflow to emit warnings rather than failing the job when translations are missing. Removes setting SHOULD_FAIL to true, changes the log message/emoji to a warning, and adds a GitHub Actions ::warning:: annotation with the list of missing files so issues surface in the Actions UI without breaking the build.