### PR TITLE
Add intro YouTube video to APP mode docs (EN + ZH)

### DIFF
--- a/interface/app-mode.mdx
+++ b/interface/app-mode.mdx
@@ -7,6 +7,14 @@ icon: "mobile-screen-button"
 
 APP mode simplifies workflow interaction by allowing you to define custom input/output interfaces, making it easier to share and use workflows without editing nodes.
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/MR6CmStFoWA"
+  title="ComfyUI APP Mode Guide"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 <Note>
 APP mode is officially supported from ComfyUI front-end version 1.41.13. Earlier versions are in early test phase.
 </Note>

--- a/zh-CN/interface/app-mode.mdx
+++ b/zh-CN/interface/app-mode.mdx
@@ -7,6 +7,14 @@ icon: "mobile-screen-button"
 
 APP 模式通过允许您定义自定义输入/输出界面来简化工作流交互，使分享和使用工作流更加便捷，无需编辑节点。
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/MR6CmStFoWA"
+  title="ComfyUI APP Mode Guide"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 <Note>
 APP 模式从 ComfyUI 前端版本 1.41.13 开始正式支持，早期版本为测试阶段。
 </Note>


### PR DESCRIPTION
## Summary

- Embeds the ComfyUI APP mode tutorial video at the top of both English and Chinese `app-mode` pages
- Uses the same `<iframe>` pattern as other interface docs (e.g. `interface/features/subgraph.mdx`)
- Video: https://www.youtube.com/watch?v=MR6CmStFoWA

## Test plan

- [ ] Confirm the video renders correctly on both EN and ZH pages
- [ ] Confirm layout matches other pages that embed YouTube videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)