### PR TITLE
Fix: Mintlify search corrupted by Chinese language files

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -758,7 +758,7 @@
         ]
       },
       {
-        "language": "cn",
+        "language": "zh",
         "tabs": [
           {
             "tab": "开始使用",

--- a/language-switcher-fix.js
+++ b/language-switcher-fix.js
@@ -7,7 +7,7 @@
  *
  * Language mapping:
  * - English (en): /path/to/page
- * - Chinese (cn): /zh-CN/path/to/page
+ * - Chinese (zh): /zh-CN/path/to/page
  */
 
 (function() {
@@ -20,8 +20,8 @@
       prefix: '',  // English pages have no prefix
       label: 'English'
     },
-    cn: {
-      code: 'cn',
+    zh: {
+      code: 'zh',
       prefix: '/zh-CN',  // Chinese pages are prefixed with /zh-CN
       label: '中文'
     }
@@ -33,7 +33,7 @@
   function getCurrentLanguage() {
     const path = window.location.pathname;
     if (path.startsWith('/zh-CN')) {
-      return 'cn';
+      return 'zh';
     }
     return 'en';
   }
@@ -184,6 +184,7 @@
                                  linkText.includes('chinese') ||
                                  linkText.includes('english') ||
                                  linkText === 'en' ||
+                                 linkText === 'zh' ||
                                  linkText === 'cn' ||
                                  href === '/' ||
                                  href === '/zh-CN/' ||
@@ -222,8 +223,8 @@
           // Determine which language this link is for
           let targetLang = null;
 
-          if (linkText.includes('中文') || linkText.includes('chinese') || linkText === 'cn') {
-            targetLang = 'cn';
+          if (linkText.includes('中文') || linkText.includes('chinese') || linkText === 'zh' || linkText === 'cn') {
+            targetLang = 'zh';
           } else if (linkText.includes('english') || linkText === 'en') {
             targetLang = 'en';
           } else if (url.pathname === '/' && !link.closest('[class*="footer"]')) {
@@ -233,7 +234,7 @@
               targetLang = 'en';
             }
           } else if (url.pathname.startsWith('/zh-CN')) {
-            targetLang = 'cn';
+            targetLang = 'zh';
           }
 
           if (targetLang) {
@@ -261,16 +262,16 @@
 
           if (itemId.endsWith('-en')) {
             targetLang = 'en';
-          } else if (itemId.endsWith('-cn')) {
-            targetLang = 'cn';
+          } else if (itemId.endsWith('-zh') || itemId.endsWith('-cn')) {
+            targetLang = 'zh';
           }
 
           if (!targetLang) {
             const text = item.textContent.trim().toLowerCase();
             if (text.includes('english') || text === 'en') {
               targetLang = 'en';
-            } else if (text.includes('中文') || text.includes('chinese') || text === 'cn') {
-              targetLang = 'cn';
+            } else if (text.includes('中文') || text.includes('chinese') || text === 'zh' || text === 'cn') {
+              targetLang = 'zh';
             }
           }
 


### PR DESCRIPTION
## Problem

Mintlify search on docs.comfy.org shows Chinese breadcrumbs and content in English search results. When users search for English terms, results include Chinese-language pages with Chinese breadcrumb trails.

## Root Cause

The `docs.json` uses `"language": "cn"` for the Chinese language partition. While `"cn"` is accepted by Mintlify's schema, the standard ISO 639-1 code for Chinese is `"zh"`. This mismatch may prevent Mintlify from properly isolating search scopes per language.

## Changes

- **`docs.json`**: Changed language code from `"cn"` to `"zh"`
- **`language-switcher-fix.js`**: Updated internal language code references to `"zh"`, keeping `"cn"` as a fallback in text matching for backward compatibility

## Testing

- [ ] Verify Mintlify preview deployment works correctly
- [ ] Test language switcher still navigates between EN/ZH pages
- [ ] Search for English terms — results should only show English pages
- [ ] Switch to Chinese and verify Chinese search works independently

## Related

Notion ticket: COM-16737