### PR TITLE
Remove download links for cu128 portable and add python and cuda version info

### DIFF
--- a/installation/comfyui_portable_windows.mdx
+++ b/installation/comfyui_portable_windows.mdx
@@ -18,6 +18,7 @@ You can get the latest ComfyUI Portable download link by clicking the link below
 
 <CardGroup cols={2}>
   <Card title="Standard portable for Nvidia GPUs" icon="download" href="https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia.7z">
+   Current environment: Python 3.13 + CUDA 13.0
   </Card>
   <Card title="Experimental portable for AMD GPUs" icon="microchip" href="https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_amd.7z">
   </Card>
@@ -26,7 +27,8 @@ You can get the latest ComfyUI Portable download link by clicking the link below
 ### Alternative downloads for Nvidia GPUs
 
 <CardGroup cols={2}>
-  <Card title="Portable with pytorch cuda 12.8 and python 3.12" icon="download" href="https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu128.7z">
+  <Card title="Portable with pytorch cuda 12.8 and python 3.12" icon="download" href="#">
+    CUDA 12.8 builds were dropped with ComfyUI 0.16.0 as there is no benefit over standard builds with CUDA 13.0
   </Card>
   <Card title="Portable with pytorch cuda 12.6 and python 3.12" icon="download" href="https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu126.7z">
     Supports Nvidia 10 series and older GPUs
@@ -36,7 +38,6 @@ You can get the latest ComfyUI Portable download link by clicking the link below
 ### Alternative downloads
 
 - [Experimental portable for AMD GPUs](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_amd.7z)
-- [Portable with PyTorch CUDA 12.8 and Python 3.12](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu128.7z)
 - [Portable with PyTorch CUDA 12.6 and Python 3.12](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu126.7z) (Supports Nvidia 10 series and older GPUs)
 
 After downloading, you can use decompression software like [7-ZIP](https://7-zip.org/) to extract the compressed package


### PR DESCRIPTION
Remove download links for cuda 12.8 portable version which is no longer built and gives a 404. Add python and cuda version info in download card for nvidia portable standard download. (zh_CN has to be adapted by someone else)