### PR TITLE
fix: handle workflow re-run when translation branch already exists

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -98,6 +98,8 @@ jobs:
           BRANCH="i18n/sync-${{ steps.commits.outputs.short_sha }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Delete remote branch if it already exists (re-run scenario)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git add "ja/" "zh/" "snippets/ja/" "snippets/zh/" 2>/dev/null || true
           git diff --cached --quiet || git commit -m "i18n: sync translations for ${{ steps.commits.outputs.short_sha }}"


### PR DESCRIPTION
When the translation sync workflow is re-run for the same SHA, the branch `i18n/sync-<sha>` already exists on remote, causing the push to fail.

Fix: delete the remote branch before creating it, so re-runs always succeed.