### PR TITLE
fix: use timestamp in branch name to avoid push conflicts on re-run

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -95,7 +95,7 @@ jobs:
         id: create_branch
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
-          BRANCH="i18n/sync-${{ steps.commits.outputs.short_sha }}"
+          BRANCH="i18n/sync-${{ steps.commits.outputs.short_sha }}-$(date +%Y%m%d%H%M%S)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
Replace `i18n/sync-<sha>` with `i18n/sync-<sha>-<timestamp>` so each workflow run always creates a unique branch. No need to delete existing branches.