### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the **ComfyUI Official Documentation** site, built with [Mintlify](https://mintlify.com/). There is no backend, database, or build step — only a static docs preview server.
+
+### Running the dev server
+
+```
+npm run dev
+```
+
+This runs `npx mint dev` and starts the Mintlify local preview server on **port 3000**. The initial startup takes ~90 seconds due to ~3000 MDX files being processed. Hot-reload works for content edits.
+
+### Lint / CI checks available locally
+
+- **Broken links**: `npx mint broken-links` — checks for broken internal links across all pages.
+- **OpenAPI check**: `npx mint openapi-check https://api.comfy.org/openapi` — validates OpenAPI schema references.
+- There is no ESLint, TypeScript, or other code linting — this is a pure documentation repo.
+
+### Key files
+
+- `docs.json` — Main configuration for navigation, theming, redirects, and localization.
+- `package.json` — Only two runtime deps: `mint` and `sharp`.
+- `.github/workflows/` — CI checks for broken links, redirects, translation sync, and link validation.
+
+### Gotchas
+
+- The dev server may show navigation warnings about Japanese (`ja/`) translation pages that are referenced in `docs.json` but don't exist yet. These are non-blocking warnings.
+- When renaming or moving `.mdx` files, redirects must be added to `docs.json` — a CI check enforces this on PRs.
+- Chinese (`zh/`) translation files must be updated when modifying English `.mdx` files — enforced by CI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sno-japanese",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -295,6 +295,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6541,6 +6542,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6557,6 +6559,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6573,6 +6576,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6589,6 +6593,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6605,6 +6610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6621,6 +6627,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6637,6 +6644,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6653,6 +6661,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6669,6 +6678,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6685,6 +6695,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6701,6 +6712,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6717,6 +6729,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6733,6 +6746,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6749,6 +6763,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6765,6 +6780,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6781,6 +6797,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6797,6 +6814,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6813,6 +6831,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6829,6 +6848,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6845,6 +6865,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6861,6 +6882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6877,6 +6899,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6893,6 +6916,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6909,6 +6933,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, including:

- How to run the Mintlify dev server (`npm run dev` on port 3000)
- Available local lint/CI checks (`npx mint broken-links`, `npx mint openapi-check`)
- Key files reference (`docs.json`, `package.json`, workflows)
- Non-obvious gotchas (Japanese translation warnings, redirect requirements, Chinese translation sync enforcement)

## Walkthrough

[docs_dev_server_hot_reload_demo.mp4](https://cursor.com/agents/bc-22f381cd-db39-4ecf-88ed-c2b9f5223b01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_dev_server_hot_reload_demo.mp4)
Documentation site running locally with hot-reload; a test edit to `first_generation.mdx` is reflected in the browser.

[Documentation homepage at localhost:3000](https://cursor.com/agents/bc-22f381cd-db39-4ecf-88ed-c2b9f5223b01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_homepage.webp)
[Hot-reload test showing \[DEV ENVIRONMENT TEST\] marker](https://cursor.com/agents/bc-22f381cd-db39-4ecf-88ed-c2b9f5223b01/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_hot_reload_test.webp)

## Verification

- `npm install` — dependencies install cleanly
- `npm run dev` — Mintlify dev server starts on port 3000 (HTTP 200)
- `npx mint broken-links` — no broken links found
- Content edits are reflected via hot-reload


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22f381cd-db39-4ecf-88ed-c2b9f5223b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22f381cd-db39-4ecf-88ed-c2b9f5223b01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

