### PR TITLE
docs(cloud): document image upload size/dimension limits

### DIFF
--- a/openapi-cloud.yaml
+++ b/openapi-cloud.yaml
@@ -2063,7 +2063,15 @@ paths:
       tags:
         - file
       summary: Upload an image file
-      description: Upload an image file to cloud storage
+      description: |
+        Upload an image file to cloud storage.
+
+        Image limits:
+          - Maximum file size: 50 MB
+          - Maximum width/height per edge: 16384 px
+          - Maximum total pixel count: 64 megapixels (67108864 pixels)
+
+        Uploads that exceed any of these limits are rejected with HTTP 400.
       operationId: uploadImage
       requestBody:
         required: true
@@ -2139,7 +2147,16 @@ paths:
       tags:
         - file
       summary: Upload a mask image
-      description: Upload a mask image to be applied to an existing image
+      description: |
+        Upload a mask image to be applied to an existing image.
+
+        Image limits apply to both the uploaded mask and the referenced
+        original image:
+          - Maximum file size: 50 MB
+          - Maximum width/height per edge: 16384 px
+          - Maximum total pixel count: 64 megapixels (67108864 pixels)
+
+        Uploads that exceed any of these limits are rejected with HTTP 400.
       operationId: uploadMask
       requestBody:
         required: true


### PR DESCRIPTION
## Summary
Mirrors image upload limits into `openapi-cloud.yaml` for `/api/upload/image` and `/api/upload/mask`:

- Max file size: **50 MB**
- Max width/height per edge: **16384 px**
- Max total pixel count: **64 megapixels** (67108864 pixels)

Uploads exceeding any of these are rejected with HTTP 400.

Related: Comfy-Org/cloud#3099 — cloud-side OpenAPI spec update.

## Test plan
- [x] YAML edit only; no content/structure changes
- [ ] Verify Mintlify preview renders the new description block on both endpoints