### PR TITLE
docs(cloud): mark /api/history_v2 as deprecated, prefer /api/jobs

### DIFF
--- a/openapi-cloud.yaml
+++ b/openapi-cloud.yaml
@@ -451,7 +451,10 @@ paths:
       tags:
         - job
       summary: Get execution history (v2)
+      deprecated: true
       description: |
+        **Deprecated.** Use [`/api/jobs`](#tag/job/GET/api/jobs) instead. This endpoint is maintained for ComfyUI compatibility but will be removed in a future release; no removal date set.
+
         Retrieve execution history for the authenticated user with pagination support.
         Returns a lightweight history format with filtered prompt data (workflow removed from extra_pnginfo).
       operationId: getHistory
@@ -494,7 +497,10 @@ paths:
       tags:
         - job
       summary: Get history for specific prompt
+      deprecated: true
       description: |
+        **Deprecated.** Use [`/api/jobs/{job_id}`](#tag/job/GET/api/jobs/{job_id}) instead — the `prompt_id` returned by `/api/prompt` is the same value as `job_id`. This endpoint is maintained for ComfyUI compatibility but will be removed in a future release; no removal date set.
+
         Retrieve detailed execution history for a specific prompt ID.
         Returns full history data including complete prompt information.
       operationId: getHistoryForPrompt

--- a/snippets/cloud/complete-example.mdx
+++ b/snippets/cloud/complete-example.mdx
@@ -34,12 +34,12 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
-  // 4. Get outputs via history endpoint
-  const historyRes = await fetch(`${BASE_URL}/api/history_v2/${prompt_id}`, {
+  // 4. Get outputs via job detail endpoint
+  const jobRes = await fetch(`${BASE_URL}/api/jobs/${prompt_id}`, {
     headers: { "X-API-Key": API_KEY },
   });
-  const history = await historyRes.json();
-  const outputs = history.outputs;
+  const job = await jobRes.json();
+  const outputs = job.outputs;
 
   // 5. Download output files
   for (const nodeOutputs of Object.values(outputs)) {
@@ -104,13 +104,13 @@ def main():
             raise RuntimeError(f"Job {status}")
         time.sleep(2)
 
-    # 4. Get outputs via history endpoint
-    history_res = requests.get(
-        f"{BASE_URL}/api/history_v2/{prompt_id}",
+    # 4. Get outputs via job detail endpoint
+    job_res = requests.get(
+        f"{BASE_URL}/api/jobs/{prompt_id}",
         headers={"X-API-Key": API_KEY}
     )
-    history = history_res.json()
-    outputs = history["outputs"]
+    job = job_res.json()
+    outputs = job["outputs"]
 
     # 5. Download output files
     for node_outputs in outputs.values():

--- a/snippets/zh/cloud/complete-example.mdx
+++ b/snippets/zh/cloud/complete-example.mdx
@@ -34,12 +34,12 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
-  // 4. 通过历史端点获取输出
-  const historyRes = await fetch(`${BASE_URL}/api/history_v2/${prompt_id}`, {
+  // 4. 通过任务详情端点获取输出
+  const jobRes = await fetch(`${BASE_URL}/api/jobs/${prompt_id}`, {
     headers: { "X-API-Key": API_KEY },
   });
-  const history = await historyRes.json();
-  const outputs = history.outputs;
+  const job = await jobRes.json();
+  const outputs = job.outputs;
 
   // 5. 下载输出文件
   for (const nodeOutputs of Object.values(outputs)) {
@@ -104,13 +104,13 @@ def main():
             raise RuntimeError(f"任务 {status}")
         time.sleep(2)
 
-    # 4. 通过历史端点获取输出
-    history_res = requests.get(
-        f"{BASE_URL}/api/history_v2/{prompt_id}",
+    # 4. 通过任务详情端点获取输出
+    job_res = requests.get(
+        f"{BASE_URL}/api/jobs/{prompt_id}",
         headers={"X-API-Key": API_KEY}
     )
-    history = history_res.json()
-    outputs = history["outputs"]
+    job = job_res.json()
+    outputs = job["outputs"]
 
     # 5. 下载输出文件
     for node_outputs in outputs.values():


### PR DESCRIPTION
## Summary
- Marks `/api/history_v2` and `/api/history_v2/{prompt_id}` as `deprecated: true` in `openapi-cloud.yaml` so Mintlify renders a deprecation banner, with descriptions pointing at `/api/jobs` and `/api/jobs/{job_id}` as replacements.
- Updates the complete-example snippets (EN + ZH) to fetch outputs via `/api/jobs/${prompt_id}` — the `prompt_id` returned by `/api/prompt` is literally the job UUID (`services/ingest/server/implementation/prompt.go:392`), and `JobDetailResponse.outputs` has the same shape the snippets were already reading.
- Docs-repo-only. No runtime spec changes in the cloud repo (`services/ingest/openapi.yaml` untouched) — full deprecation/removal is tracked for a future Linear ticket under Core ↔ Cloud Catchup, following the BE-120/121 pattern.

## Notes for review
- Wording intentionally leaves the removal date open (`"will be removed in a future release; no removal date set"`) since there's no timeline yet.
- Deprecation-link syntax uses the Mintlify OpenAPI anchor format (`[\`/api/jobs\`](#tag/job/GET/api/jobs)`); worth a quick Mintlify preview check to confirm it renders as a link.

## Test plan
- [ ] Mintlify preview renders a deprecation banner on `/api/history_v2` and `/api/history_v2/{prompt_id}`
- [ ] Anchor links in the deprecation notes resolve to the `/api/jobs` and `/api/jobs/{job_id}` operations
- [ ] Complete-example snippet still compiles/runs end-to-end against cloud (`prompt_id` → `/api/jobs/{prompt_id}` returns `outputs`)
- [ ] Chinese mirror (`snippets/zh/cloud/complete-example.mdx`) renders consistently with the English version

🤖 Generated with [Claude Code](https://claude.com/claude-code)