### PR TITLE
[codex] Fix outpaint checkpoint link

### DIFF
--- a/ja/tutorials/basic/outpaint.mdx
+++ b/ja/tutorials/basic/outpaint.mdx
@@ -31,7 +31,7 @@ AI画像生成においては、既存の画像の構図が優れているもの
 #### 1. モデルのインストール
 
 以下のモデルファイルをダウンロードし、`ComfyUI/models/checkpoints` ディレクトリに保存してください：
-- [512-inpainting-ema.safetensors](https://huggingface.co/stabilityai/stable-diffusion-2-inpainting/blob/main/512-inpainting-ema.safetensors)
+- [512-inpainting-ema.safetensors](https://huggingface.co/Comfy-Org/stable_diffusion_2.1_repackaged/resolve/main/512-inpainting-ema.safetensors)
 
 #### 2. 入力画像
 

--- a/tutorials/basic/outpaint.mdx
+++ b/tutorials/basic/outpaint.mdx
@@ -27,7 +27,7 @@ Outpainting applications include:
 #### 1. Model Installation
 
 Download the following model file and save it to `ComfyUI/models/checkpoints` directory:
-- [512-inpainting-ema.safetensors](https://huggingface.co/stabilityai/stable-diffusion-2-inpainting/blob/main/512-inpainting-ema.safetensors)
+- [512-inpainting-ema.safetensors](https://huggingface.co/Comfy-Org/stable_diffusion_2.1_repackaged/resolve/main/512-inpainting-ema.safetensors)
 
 #### 2. Input Image
 

--- a/zh/tutorials/basic/outpaint.mdx
+++ b/zh/tutorials/basic/outpaint.mdx
@@ -31,7 +31,7 @@ import InstallationModels from '/snippets/zh/tutorials/basic/installation-models
 #### 1. 模型安装
 
 <InstallationModels />
-- [512-inpainting-ema.safetensors](https://huggingface.co/stabilityai/stable-diffusion-2-inpainting/blob/main/512-inpainting-ema.safetensors)
+- [512-inpainting-ema.safetensors](https://huggingface.co/Comfy-Org/stable_diffusion_2.1_repackaged/resolve/main/512-inpainting-ema.safetensors)
 
 #### 2. 输入图片
 


### PR DESCRIPTION
## Summary

Fixes the broken Stable Diffusion 2 inpainting checkpoint link on the basic outpainting tutorial.

## Changes

- Replaces the old `stabilityai/stable-diffusion-2-inpainting/blob/main` URL with the working Comfy-Org repackaged `resolve/main` checkpoint URL.
- Applies the same fix to the English, Chinese, and Japanese outpainting tutorial pages to keep translations consistent.

## Validation

- `git diff --check`
- Confirmed the old `stabilityai/.../blob/main/512-inpainting-ema.safetensors` URL returns `401 Unauthorized`.
- Confirmed the replacement `Comfy-Org/stable_diffusion_2.1_repackaged/resolve/main/512-inpainting-ema.safetensors` URL resolves to `200 OK` after redirect.

Fixes #973.