### PR TITLE
Document `comfy generate` for direct partner node calls

### DIFF
--- a/comfy-cli/getting-started.mdx
+++ b/comfy-cli/getting-started.mdx
@@ -12,7 +12,7 @@ import InstallCli from "/snippets/install-comfycli.mdx";
 It does two things:
 
 1. **Manage a local ComfyUI install** — install, launch, update, snapshot, and bisect ComfyUI and its custom nodes.
-2. **Call hosted partner nodes directly** — generate images and video from Flux, Ideogram, DALL·E, Recraft, Stability, Kling, Luma, Runway, Pika, Vidu, Hailuo, Moonvalley, and more, with a single command. No local ComfyUI or workflow JSON required.
+2. **Call hosted partner nodes directly** — generate images and video from Seedance, Nano Banana (Gemini), Grok, Flux, Ideogram, DALL·E, Recraft, Stability, Kling, Luma, Runway, Pika, Vidu, Hailuo, Moonvalley, and more, with a single command. No local ComfyUI or workflow JSON required.
 
 ### Install CLI
 
@@ -56,6 +56,37 @@ comfy generate flux-pro \
 ```
 
 That's it — the CLI uploads any local file inputs, submits the job, polls until it's ready, and saves the result to `cat.png`.
+
+### Popular models
+
+A few of the most-used partner models, callable with one line:
+
+```bash
+# Nano Banana (Google Gemini 2.5 Flash Image) — fast, prompt-driven image edits
+comfy generate nano-banana \
+    --prompt "make the sky look like a Van Gogh painting" \
+    --image ./photo.jpg \
+    --download edited.png
+
+# Seedance (ByteDance) — high-fidelity text-to-video
+comfy generate seedance \
+    --prompt "a hummingbird sipping from a neon orchid, macro shot" \
+    --duration 5 \
+    --download hummingbird.mp4
+
+# Seedance image-to-video — animate a still
+comfy generate seedance-i2v \
+    --prompt "the subject turns toward the camera and smiles" \
+    --image ./portrait.jpg \
+    --download animated.mp4
+
+# Grok (xAI) — image generation and editing
+comfy generate grok --prompt "a cyberpunk street market at night" --download street.png
+comfy generate grok-edit --prompt "swap the umbrella for a parasol" --image ./photo.jpg --download out.png
+
+# Grok video
+comfy generate grok-video --prompt "a paper plane gliding through a cathedral" --download flight.mp4
+```
 
 ### Discover models
 

--- a/comfy-cli/getting-started.mdx
+++ b/comfy-cli/getting-started.mdx
@@ -62,23 +62,35 @@ That's it — the CLI uploads any local file inputs, submits the job, polls unti
 A few of the most-used partner models, callable with one line:
 
 ```bash
-# Nano Banana (Google Gemini 2.5 Flash Image) — fast, prompt-driven image edits
+# Nano Banana (Google Gemini Flash Image) — text-to-image and prompt-driven edits
 comfy generate nano-banana \
-    --prompt "make the sky look like a Van Gogh painting" \
-    --image ./photo.jpg \
+    --prompt "a watercolor of a sleeping fox" \
+    --download fox.png
+
+# Same alias, now an image edit — pass a reference with --image (repeatable):
+comfy generate nano-banana \
+    --prompt "add a top hat" \
+    --image ./cat.png \
     --download edited.png
 
-# Seedance (ByteDance) — high-fidelity text-to-video
+# Pick a Gemini variant:
+comfy generate nano-banana \
+    --prompt "neon city skyline" \
+    --model gemini-3-pro-image-preview \
+    --download city.png
+
+# Seedance (ByteDance) — text-to-video, up to 1080p / 12s clips
 comfy generate seedance \
-    --prompt "a hummingbird sipping from a neon orchid, macro shot" \
-    --duration 5 \
+    --prompt "a hummingbird hovering over a flower" \
+    --resolution 1080p --duration 5 \
     --download hummingbird.mp4
 
-# Seedance image-to-video — animate a still
-comfy generate seedance-i2v \
-    --prompt "the subject turns toward the camera and smiles" \
-    --image ./portrait.jpg \
-    --download animated.mp4
+# Seedance image-to-video — pick a lite/i2v variant and pass a first frame
+comfy generate seedance \
+    --model seedance-1-0-lite-i2v-250428 \
+    --prompt "the wave crests and crashes" \
+    --image ./still.jpg \
+    --download wave.mp4
 
 # Grok (xAI) — image generation and editing
 comfy generate grok --prompt "a cyberpunk street market at night" --download street.png

--- a/comfy-cli/getting-started.mdx
+++ b/comfy-cli/getting-started.mdx
@@ -121,6 +121,10 @@ comfy generate upload ./photo.jpg
 # → prints a signed URL you can pass as --input_image
 ```
 
+<Note>
+Uploaded reference assets are auto-deleted after **24 hours**. They're stored in a Comfy-managed GCS bucket and served via signed URLs. For most workflows (upload → use → done) this is transparent; for long-running pipelines, plan to re-upload before each job. See the [reference](/comfy-cli/reference#upload) for details.
+</Note>
+
 ### Video generation (async jobs)
 
 Video jobs are async — the CLI blocks and polls until ready by default:

--- a/comfy-cli/getting-started.mdx
+++ b/comfy-cli/getting-started.mdx
@@ -9,6 +9,11 @@ import InstallCli from "/snippets/install-comfycli.mdx";
 
 `comfy-cli` is a [command line tool](https://github.com/Comfy-Org/comfy-cli) that makes it easier to install and manage Comfy.
 
+It does two things:
+
+1. **Manage a local ComfyUI install** — install, launch, update, snapshot, and bisect ComfyUI and its custom nodes.
+2. **Call hosted partner nodes directly** — generate images and video from Flux, Ideogram, DALL·E, Recraft, Stability, Kling, Luma, Runway, Pika, Vidu, Hailuo, Moonvalley, and more, with a single command. No local ComfyUI or workflow JSON required.
+
 ### Install CLI
 
 <InstallCli/>
@@ -23,7 +28,98 @@ import InstallCli from "/snippets/install-comfycli.mdx";
 comfy launch
 ```
 
-### Manage Custom Nodes
+## Call partner nodes directly with `comfy generate`
+
+<Tip>
+`comfy generate` is the fastest way to call Comfy's [partner nodes](/tutorials/partner-nodes/overview) from a terminal or a script. It hits the same hosted endpoints you'd otherwise wire into a ComfyUI workflow, but as one-shot CLI calls — perfect for batch jobs, quick experiments, and automation pipelines where standing up a full ComfyUI graph is overkill.
+</Tip>
+
+### Prerequisites
+
+* [Create a Comfy API key](/development/comfyui-server/api-key-integration)
+* [Add credits to your account](/interface/credits)
+* Optional: [Browse partner nodes and per-call pricing](/tutorials/partner-nodes/overview)
+
+Set the key once, then go:
+
+```bash
+export COMFY_API_KEY=comfyui-...   # or pass --api-key on each call
+```
+
+### Your first generation
+
+```bash
+comfy generate flux-pro \
+    --prompt "a cat on the moon, cinematic lighting" \
+    --width 1024 --height 1024 \
+    --download cat.png
+```
+
+That's it — the CLI uploads any local file inputs, submits the job, polls until it's ready, and saves the result to `cat.png`.
+
+### Discover models
+
+```bash
+comfy generate list                            # all available models
+comfy generate list --category text-to-video   # filter by category
+comfy generate list --partner kling            # filter by partner
+comfy generate schema flux-kontext             # see the params for one model
+```
+
+### Image editing with a reference image
+
+Pass local file paths directly — the CLI uploads them through Comfy's storage endpoint (or base64-encodes inline, depending on what each partner expects):
+
+```bash
+comfy generate flux-kontext \
+    --prompt "add a top hat and a monocle" \
+    --input_image ./photo.jpg \
+    --download out.png
+
+comfy generate ideogram-edit \
+    --image cat.png --mask mask.png \
+    --prompt "add sunglasses" \
+    --rendering_speed TURBO \
+    --download edited.png
+```
+
+If you'd rather upload once and reuse the signed URL across many calls:
+
+```bash
+comfy generate upload ./photo.jpg
+# → prints a signed URL you can pass as --input_image
+```
+
+### Video generation (async jobs)
+
+Video jobs are async — the CLI blocks and polls until ready by default:
+
+```bash
+comfy generate kling \
+    --prompt "a paper boat drifting on a river at dusk" \
+    --duration 5 \
+    --download boat.mp4
+```
+
+Pass `--async` to return immediately with a job id, then resume later:
+
+```bash
+comfy generate luma --prompt "neon koi swimming through clouds" --aspect_ratio 16:9 --async
+# → prints a job id; resume with:
+comfy generate resume luma <job_id> --download out.mp4
+```
+
+### Scripting with JSON output
+
+For pipelines, `--json` emits the raw API response:
+
+```bash
+comfy generate dalle --prompt "a watercolor whale" --json | jq '.data[0].url'
+```
+
+See the [reference](/comfy-cli/reference) for the full list of commands, flags, and model aliases.
+
+## Manage Custom Nodes
 
 ```bash
 comfy node install <NODE_NAME>
@@ -31,21 +127,21 @@ comfy node install <NODE_NAME>
 
 We use `cm-cli` for installing custom nodes. See the [docs](https://github.com/ltdrdata/ComfyUI-Manager/blob/main/docs/en/cm-cli.md) for more information.
 
-### Manage Models
+## Manage Models
 
 Downloading models with `comfy-cli` is easy. Just run:
 
 ```bash
-comfy model download <url> models/checkpoints
+comfy model download --url <url> --relative-path models/checkpoints
 ```
 
-### Contributing
+## Contributing
 
 We encourage contributions to comfy-cli! If you have suggestions, ideas, or bug reports, please open an issue on our [GitHub repository](https://github.com/Comfy-Org/comfy-cli/issues). If you want to contribute code, fork the repository and submit a pull request.
 
 Refer to the [Dev Guide](https://github.com/Comfy-Org/comfy-cli/blob/main/DEV_README.md) for further details.
 
-### Analytics
+## Analytics
 
 We track usage of the CLI to improve the user experience. You can disable this by running:
 

--- a/comfy-cli/reference.mdx
+++ b/comfy-cli/reference.mdx
@@ -1,10 +1,15 @@
 ---
 title: "Reference"
 ---
+import GenerateCliReference from '/snippets/cli-reference/generate.mdx'
 import NodesCliReference from '/snippets/cli-reference/nodes.mdx'
 import ModelsReference from '/snippets/cli-reference/models.mdx'
 
 # CLI
+
+## Generate (partner nodes)
+
+<GenerateCliReference/>
 
 ## Nodes
 

--- a/snippets/cli-reference/generate.mdx
+++ b/snippets/cli-reference/generate.mdx
@@ -91,6 +91,10 @@ comfy generate upload ./photo.jpg
 comfy generate upload ./photo.jpg --json
 ```
 
+<Note>
+**Reference assets are auto-deleted after 24 hours.** Uploaded files (whether via `comfy generate upload` or implicitly when you pass a local file path to a model) are stored in a Comfy-managed GCS bucket (`api-nodes-prod`) and reachable only via a signed URL. Objects are automatically deleted **1 day after upload** by a bucket lifecycle rule. If you need an asset to persist across long-running async jobs, re-upload it before each job, or host it yourself and pass the URL directly.
+</Note>
+
 ### `resume`
 
 Resume a previously submitted async job (typically a video job submitted with `--async`). Polls until the result is ready and optionally downloads it.

--- a/snippets/cli-reference/generate.mdx
+++ b/snippets/cli-reference/generate.mdx
@@ -111,6 +111,17 @@ comfy generate resume luma 7c3f9e2a --download out.mp4
 
 The following short aliases are accepted as `<MODEL>`. Run `comfy generate list` for the full, up-to-date catalog.
 
+**Popular**:
+
+| Alias | Partner | Category |
+| --- | --- | --- |
+| `nano-banana` | Google (Gemini 2.5 Flash Image) | image-edit / text-to-image |
+| `seedance`, `seedance-i2v` | ByteDance | text-to-video / image-to-video (async) |
+| `grok`, `grok-edit` | xAI | text-to-image / image-edit |
+| `grok-video` | xAI | text-to-video (async) |
+
+**Everything else**:
+
 | Alias | Partner | Category |
 | --- | --- | --- |
 | `flux-pro`, `flux-ultra`, `flux-2` | BFL | text-to-image (async) |
@@ -120,7 +131,6 @@ The following short aliases are accepted as `<MODEL>`. Run `comfy generate list`
 | `dalle`, `dalle-edit` | OpenAI | text-to-image / image-edit |
 | `stability-ultra`, `stability-sd3`, `stability-upscale`, `stability-upscale-creative`, `stability-upscale-fast` | Stability | text-to-image / upscale |
 | `recraft`, `recraft-vectorize`, `recraft-rmbg`, `recraft-replace-bg`, `recraft-i2i`, `recraft-inpaint`, `recraft-upscale`, `recraft-upscale-creative` | Recraft | text-to-image / image-edit |
-| `grok`, `grok-edit` | xAI | text-to-image / image-edit |
 | `reve`, `reve-edit` | Reve | text-to-image / image-edit |
 | `runway` | Runway | text-to-image |
 | `kling`, `kling-i2v`, `kling-extend`, `kling-lipsync` | Kling | text-to-video / image-to-video / video-extend / lipsync (async) |
@@ -130,4 +140,3 @@ The following short aliases are accepted as `<MODEL>`. Run `comfy generate list`
 | `moonvalley-t2v`, `moonvalley-i2v` | Moonvalley | text-to-video / image-to-video (async) |
 | `pika`, `pika-i2v` | Pika | text-to-video / image-to-video (async) |
 | `vidu`, `vidu-i2v`, `vidu-extend` | Vidu | text-to-video / image-to-video / video-extend (async) |
-| `grok-video` | xAI | text-to-video (async) |

--- a/snippets/cli-reference/generate.mdx
+++ b/snippets/cli-reference/generate.mdx
@@ -119,8 +119,8 @@ The following short aliases are accepted as `<MODEL>`. Run `comfy generate list`
 
 | Alias | Partner | Category |
 | --- | --- | --- |
-| `nano-banana` | Google (Gemini 2.5 Flash Image) | image-edit / text-to-image |
-| `seedance`, `seedance-i2v` | ByteDance | text-to-video / image-to-video (async) |
+| `nano-banana` | Google (Gemini Flash Image) | text-to-image / image-edit |
+| `seedance` | ByteDance | text-to-video / image-to-video (async) |
 | `grok`, `grok-edit` | xAI | text-to-image / image-edit |
 | `grok-video` | xAI | text-to-video (async) |
 

--- a/snippets/cli-reference/generate.mdx
+++ b/snippets/cli-reference/generate.mdx
@@ -1,0 +1,133 @@
+**Usage**:
+
+```console
+$ comfy generate [OPTIONS] <MODEL_OR_ACTION> [--<param> value]...
+```
+
+`<MODEL_OR_ACTION>` is either:
+
+* A **model alias** (e.g. `flux-pro`, `ideogram-edit`, `kling`, `dalle`) — calls that partner model directly.
+* A **reserved action**: `list`, `schema`, `refresh`, `upload`, `resume`.
+
+Anything not in the reserved set is treated as a model alias and the request is dispatched to that partner endpoint.
+
+**Auth**:
+
+Set the `COMFY_API_KEY` environment variable, or pass `--api-key <KEY>` on each call. Get a key at [platform.comfy.org](https://platform.comfy.org).
+
+**Run-level flags** (work with any model):
+
+* `--download PATH`: Save the result image/video to `PATH`.
+* `--async`: Submit and return a job id immediately instead of polling to completion. Resume later with `comfy generate resume <model> <job_id>`.
+* `--json`: Emit the raw API response as JSON (useful for scripting).
+* `--timeout SECONDS`: Override the default 300s polling timeout.
+* `--api-key KEY`: Inline API key (overrides `COMFY_API_KEY`).
+
+**Examples**:
+
+```bash
+comfy generate flux-pro --prompt "a cat on the moon" --width 1024 --height 1024 --download cat.png
+comfy generate ideogram-edit --image cat.png --mask m.png --prompt "add sunglasses" --rendering_speed TURBO
+comfy generate kling --prompt "a paper boat drifting at dusk" --duration 5 --download boat.mp4
+```
+
+### `list`
+
+List available partner models with their short aliases.
+
+**Usage**:
+
+```console
+$ comfy generate list [OPTIONS]
+```
+
+**Options**:
+
+* `--partner TEXT` / `-p TEXT`: Filter by partner (e.g. `bfl`, `kling`, `ideogram`, `openai`).
+* `--category TEXT` / `--style TEXT` / `-c TEXT`: Filter by category (e.g. `text-to-image`, `image-edit`, `inpaint`, `upscale`, `text-to-video`, `image-to-video`).
+* `--query TEXT` / `-q TEXT`: Substring match against model id/summary.
+
+### `schema`
+
+Show the parameters for a specific model, including required/optional flags, types, defaults, and an example invocation.
+
+**Usage**:
+
+```console
+$ comfy generate schema <MODEL>
+```
+
+**Example**:
+
+```bash
+comfy generate schema flux-pro
+comfy generate schema kling-i2v
+```
+
+### `refresh`
+
+Refresh the local cached model catalog from the cloud OpenAPI spec. Useful when new partner models are added.
+
+**Usage**:
+
+```console
+$ comfy generate refresh
+```
+
+### `upload`
+
+Upload a local file (or rehost a remote URL) to Comfy's storage and print the signed URL. Most models accept local file paths directly — this is for cases where you want the URL explicitly (e.g. to reuse the same asset across multiple calls).
+
+**Usage**:
+
+```console
+$ comfy generate upload <FILE_OR_URL> [--json]
+```
+
+**Example**:
+
+```bash
+comfy generate upload ./photo.jpg
+comfy generate upload ./photo.jpg --json
+```
+
+### `resume`
+
+Resume a previously submitted async job (typically a video job submitted with `--async`). Polls until the result is ready and optionally downloads it.
+
+**Usage**:
+
+```console
+$ comfy generate resume <MODEL> <JOB_ID> [--download PATH] [--json]
+```
+
+**Example**:
+
+```bash
+comfy generate resume luma 7c3f9e2a --download out.mp4
+```
+
+### Model aliases (selected)
+
+The following short aliases are accepted as `<MODEL>`. Run `comfy generate list` for the full, up-to-date catalog.
+
+| Alias | Partner | Category |
+| --- | --- | --- |
+| `flux-pro`, `flux-ultra`, `flux-2` | BFL | text-to-image (async) |
+| `flux-kontext`, `flux-kontext-max` | BFL | image-edit (async) |
+| `flux-fill`, `flux-expand`, `flux-canny`, `flux-depth` | BFL | inpaint / outpaint / controlnet |
+| `ideogram`, `ideogram-edit`, `ideogram-remix`, `ideogram-reframe`, `ideogram-bg` | Ideogram | text-to-image / image-edit |
+| `dalle`, `dalle-edit` | OpenAI | text-to-image / image-edit |
+| `stability-ultra`, `stability-sd3`, `stability-upscale`, `stability-upscale-creative`, `stability-upscale-fast` | Stability | text-to-image / upscale |
+| `recraft`, `recraft-vectorize`, `recraft-rmbg`, `recraft-replace-bg`, `recraft-i2i`, `recraft-inpaint`, `recraft-upscale`, `recraft-upscale-creative` | Recraft | text-to-image / image-edit |
+| `grok`, `grok-edit` | xAI | text-to-image / image-edit |
+| `reve`, `reve-edit` | Reve | text-to-image / image-edit |
+| `runway` | Runway | text-to-image |
+| `kling`, `kling-i2v`, `kling-extend`, `kling-lipsync` | Kling | text-to-video / image-to-video / video-extend / lipsync (async) |
+| `luma`, `luma-i2v` | Luma | text-to-video / image-to-video (async) |
+| `hailuo` | MiniMax | text-to-video (async) |
+| `runway-i2v` | Runway | image-to-video (async) |
+| `moonvalley-t2v`, `moonvalley-i2v` | Moonvalley | text-to-video / image-to-video (async) |
+| `pika`, `pika-i2v` | Pika | text-to-video / image-to-video (async) |
+| `vidu`, `vidu-i2v`, `vidu-extend` | Vidu | text-to-video / image-to-video / video-extend (async) |
+| `grok-video` | xAI | text-to-video (async) |


### PR DESCRIPTION
## Summary
- Add a prominent "Call partner nodes directly with `comfy generate`" section to the comfy-cli getting-started page, with examples for image generation, image editing with reference uploads, async video jobs, and JSON output.
- Add a new `snippets/cli-reference/generate.mdx` covering the top-level command, run-level flags (`--download`, `--async`, `--json`, `--timeout`, `--api-key`), all actions (`list`, `schema`, `refresh`, `upload`, `resume`), and a model alias table.
- Wire the new snippet into `comfy-cli/reference.mdx` as the first section.

## Test plan
- [ ] Preview the docs site and verify the new section renders correctly on the comfy-cli getting-started and reference pages
- [ ] Confirm internal links (`/tutorials/partner-nodes/overview`, `/development/comfyui-server/api-key-integration`, `/interface/credits`) resolve