### PR TITLE
Mark `comfy generate` as beta

### DIFF
--- a/comfy-cli/getting-started.mdx
+++ b/comfy-cli/getting-started.mdx
@@ -28,7 +28,11 @@ It does two things:
 comfy launch
 ```
 
-## Call partner nodes directly with `comfy generate`
+## Call partner nodes directly with `comfy generate` (Beta)
+
+<Info>
+**`comfy generate` is in beta.** Flag names, model aliases, and output formats may change while we iron things out based on feedback. The underlying partner endpoints are stable — the CLI ergonomics on top of them are what's still evolving. File feedback or issues on the [comfy-cli GitHub repo](https://github.com/Comfy-Org/comfy-cli/issues).
+</Info>
 
 <Tip>
 `comfy generate` is the fastest way to call Comfy's [partner nodes](/tutorials/partner-nodes/overview) from a terminal or a script. It hits the same hosted endpoints you'd otherwise wire into a ComfyUI workflow, but as one-shot CLI calls — perfect for batch jobs, quick experiments, and automation pipelines where standing up a full ComfyUI graph is overkill.

--- a/comfy-cli/reference.mdx
+++ b/comfy-cli/reference.mdx
@@ -7,7 +7,11 @@ import ModelsReference from '/snippets/cli-reference/models.mdx'
 
 # CLI
 
-## Generate (partner nodes)
+## Generate (partner nodes) — Beta
+
+<Info>
+**`comfy generate` is in beta.** Flag names, model aliases, and output formats may change. The underlying partner endpoints are stable; the CLI surface is still evolving. File feedback on the [comfy-cli GitHub repo](https://github.com/Comfy-Org/comfy-cli/issues).
+</Info>
 
 <GenerateCliReference/>
 


### PR DESCRIPTION
## Summary
- Add "(Beta)" tags to the `comfy generate` section headings in `comfy-cli/getting-started.mdx` and `comfy-cli/reference.mdx`.
- Add `<Info>` callouts at the top of each section clarifying that flag names, model aliases, and output formats may change while underlying partner endpoints stay stable. Points readers at the comfy-cli issue tracker for feedback.

## Test plan
- [ ] Preview both pages and verify the Beta tag + Info callout render correctly