### PR TITLE
Add OpenRouter LLM partner node tutorial (en/zh/ja)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -372,6 +372,12 @@
                         ]
                       },
                       {
+                        "group": "OpenRouter",
+                        "pages": [
+                          "tutorials/partner-nodes/openrouter/llm"
+                        ]
+                      },
+                      {
                         "group": "Recraft",
                         "pages": [
                           "tutorials/partner-nodes/recraft/recraft-v4",
@@ -2491,6 +2497,12 @@
                           "zh/tutorials/partner-nodes/openai/dall-e-2",
                           "zh/tutorials/partner-nodes/openai/dall-e-3",
                           "zh/tutorials/partner-nodes/openai/chat"
+                        ]
+                      },
+                      {
+                        "group": "OpenRouter",
+                        "pages": [
+                          "zh/tutorials/partner-nodes/openrouter/llm"
                         ]
                       },
                       {
@@ -4618,6 +4630,12 @@
                           "ja/tutorials/partner-nodes/openai/dall-e-2",
                           "ja/tutorials/partner-nodes/openai/dall-e-3",
                           "ja/tutorials/partner-nodes/openai/chat"
+                        ]
+                      },
+                      {
+                        "group": "OpenRouter",
+                        "pages": [
+                          "ja/tutorials/partner-nodes/openrouter/llm"
                         ]
                       },
                       {

--- a/ja/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/ja/tutorials/partner-nodes/openrouter/llm.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "OpenRouter LLM"
 import ReqHint from "/snippets/ja/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
 
-**OpenRouter LLM** パートナーノードは OpenRouter 経由でチャットリクエストを送り、Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi、Perplexity Sonar など、厳選されたテキスト／マルチモーダルモデルを 1 つの ComfyUI ノードから選べます。
+[OpenRouter](https://openrouter.ai) は大規模言語モデル向けの統合ルーティングプラットフォームです。単一 API で複数プロバイダーにアクセスでき、連携方式を変えずにモデルを切り替えられます。ComfyUI では **OpenRouter LLM** パートナーノードから接続し、Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi、Perplexity Sonar など、厳選されたテキスト／マルチモーダルモデルを 1 つのノードで選べます。
 
 <ReqHint/>
 <UpdateReminder/>
@@ -59,7 +59,9 @@ import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
 
 テキスト専用モデルでは画像・動画入力は表示されません。
 
-## OpenRouter LLM ワークフロー
+## サンプルワークフロー（`api_openrouter_llm`）
+
+以下のテンプレートは **利用例のひとつ** であり、唯一の使い方ではありません。配線の参考としてダウンロードし、用途に合わせてグラフを変更してください（テキストのみの Q&A、キャプション、プロンプト整形、画像ノードへの文字列連携など）。
 
 <CardGroup cols={2}>
   {/* Comfy Cloud テンプレートは準備中
@@ -73,10 +75,10 @@ import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
 </CardGroup>
 
 <Note>
-`api_openrouter_llm` テンプレートは参照画像を解析し、下流の画像ノードに貼れる生成プロンプトを返します。
+このサンプルでは参照画像を解析し、下流の画像ノード用の生成プロンプトを返します。**Load Image** を外したり、プロンプトを変えたり、必要ならグラフを一から組み直して構いません。
 </Note>
 
-ワークフローの手順に沿って実行します：
+テンプレートを参考にする場合の典型的な流れは次のとおりです：
 
 1. **Load Image** で参照画像を読み込む（テキストのみの場合は省略可）
 2. **OpenRouter LLM** で画像を `image_1` に接続（多枚対応モデルではスロットが増える）

--- a/ja/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/ja/tutorials/partner-nodes/openrouter/llm.mdx
@@ -1,0 +1,82 @@
+---
+title: "OpenRouter LLM API ノード ComfyUI 公式サンプル"
+description: "ComfyUI の OpenRouter LLM パートナーノードで、複数の最先端モデルを 1 つのノードから選び、チャット・推論・ビジョン・ウェブ検索付き回答を利用できます。"
+sidebarTitle: "OpenRouter LLM"
+---
+
+import ReqHint from "/snippets/ja/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
+
+**OpenRouter LLM** パートナーノードは OpenRouter 経由でチャットリクエストを送り、Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi、Perplexity Sonar など、厳選されたテキスト／マルチモーダルモデルを 1 つの ComfyUI ノードから選べます。
+
+<ReqHint/>
+<UpdateReminder/>
+
+## できること
+
+- **テキストチャット** — `prompt` と任意の `system_prompt` で役割やタスクを指定
+- **ビジョン** — 対応モデルで参照画像を接続（スロット数はモデル依存）
+- **動画入力** — Gemini 3.5 Flash、Qwen 3.6 Plus/Flash で参照動画（任意）
+- **推論** — 推論／フロンティア推論モデルで `reasoning_effort`（`off`、`low`、`medium`、`high`）
+- **ウェブ検索** — Perplexity Sonar で `search_context_size` により根拠付き回答
+
+トークン料金は [パートナーノード料金](/ja/tutorials/partner-nodes/pricing#openrouter) を参照してください。
+
+## サポートモデル
+
+| モデル | ビジョン（最大画像数） | 動画 | 追加オプション |
+| :----- | :--------------------- | :--- | :------------- |
+| `anthropic/claude-opus-4.7` | 20 | — | 推論 effort |
+| `openai/gpt-5.5-pro` | 20 | — | 推論 effort |
+| `openai/gpt-5.5` | 20 | — | 推論 effort |
+| `google/gemini-3.5-flash` | 20 | 最大 4 | 推論 effort |
+| `x-ai/grok-4.20` | 20 | — | 推論 effort |
+| `x-ai/grok-4.3` | 20 | — | 推論 effort |
+| `deepseek/deepseek-v4-pro` | — | — | 推論 effort |
+| `deepseek/deepseek-v4-flash` | — | — | 推論 effort |
+| `deepseek/deepseek-v3.2` | — | — | 推論 effort |
+| `qwen/qwen3.6-max-preview` | — | — | 推論 effort |
+| `qwen/qwen3.6-plus` | 10 | 最大 4 | 推論 effort |
+| `qwen/qwen3.6-flash` | 10 | 最大 4 | 推論 effort |
+| `mistralai/mistral-large-2512` | 8 | — | — |
+| `mistralai/mistral-medium-3-5` | 8 | — | 推論 effort |
+| `z-ai/glm-4.6` | — | — | 推論 effort |
+| `z-ai/glm-5` | — | — | 推論 effort |
+| `moonshotai/kimi-k2.6` | 10 | — | 推論 effort |
+| `moonshotai/kimi-k2-thinking` | — | — | 推論 effort |
+| `perplexity/sonar-pro` | — | — | 検索コンテキストサイズ |
+| `perplexity/sonar-reasoning-pro` | — | — | 検索コンテキストサイズ、推論 effort |
+| `perplexity/sonar-deep-research` | — | — | 検索コンテキストサイズ、推論 effort |
+
+## モデルごとに変わる入力
+
+**model** は動的コンボです。モデルを変えると表示される入力が変わります。
+
+- **画像スロット** — ビジョン対応モデルのみ。上限までスロット表示
+- **動画スロット** — Gemini 3.5 Flash、Qwen 3.6 Plus/Flash のみ
+- **推論 effort** — 推論／フロンティア推論モデル
+- **検索コンテキストサイズ** — Perplexity Sonar 系
+
+テキスト専用モデルでは画像・動画入力は表示されません。
+
+## OpenRouter LLM ワークフロー
+
+最小構成：**Load Image**（任意）→ **OpenRouter LLM** → **Preview Any**。
+
+<Note>
+以下は画像から生成プロンプトを得る例です。参照画像を解析し、下流の画像ノードに貼れるプロンプト文字列を返します。
+</Note>
+
+1. **Load Image** を追加し参照画像を読み込む（テキストのみの場合は省略可）
+2. **OpenRouter LLM** を追加し、画像を `image_1` に接続（多枚対応モデルではスロットが増える）
+3. **prompt** を設定 — 例：画像を分析して生成プロンプトを出力させる
+4. （任意）詳細オプションの **system_prompt** で文体・形式・制約を指定
+5. **model** を選択。表示されていれば **reasoning_effort** や **search_context_size** を調整
+6. **Run** をクリック、または `Ctrl（Win）／Cmd（Mac） + Enter`
+7. **Preview Any** で応答テキストを確認
+
+### 補足
+
+- **seed** — `0` で未指定。多くのモデルではヒント程度で、結果は非決定的な場合があります
+- 参照画像・動画は実行時に自動アップロードされます。ComfyUI の画像／動画出力をノードに接続するだけで足ります
+- モデル別料金は [料金ページの OpenRouter](/ja/tutorials/partner-nodes/pricing#openrouter) を参照

--- a/ja/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/ja/tutorials/partner-nodes/openrouter/llm.mdx
@@ -61,14 +61,25 @@ import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
 
 ## OpenRouter LLM ワークフロー
 
-最小構成：**Load Image**（任意）→ **OpenRouter LLM** → **Preview Any**。
+<CardGroup cols={2}>
+  {/* Comfy Cloud テンプレートは準備中
+  <Card title="Comfy Cloud で実行" icon="cloud" href="https://cloud.comfy.org/?template=api_openrouter_llm&utm_source=docs&utm_medium=referral&utm_campaign=openrouter_llm">
+    Comfy Cloud を開く
+  </Card>
+  */}
+  <Card title="ワークフローをダウンロード" icon="download" href="https://github.com/Comfy-Org/workflow_templates/blob/main/templates/api_openrouter_llm.json">
+    JSON をダウンロードするか、テンプレートライブラリで "OpenRouter LLM" を検索
+  </Card>
+</CardGroup>
 
 <Note>
-以下は画像から生成プロンプトを得る例です。参照画像を解析し、下流の画像ノードに貼れるプロンプト文字列を返します。
+`api_openrouter_llm` テンプレートは参照画像を解析し、下流の画像ノードに貼れる生成プロンプトを返します。
 </Note>
 
-1. **Load Image** を追加し参照画像を読み込む（テキストのみの場合は省略可）
-2. **OpenRouter LLM** を追加し、画像を `image_1` に接続（多枚対応モデルではスロットが増える）
+ワークフローの手順に沿って実行します：
+
+1. **Load Image** で参照画像を読み込む（テキストのみの場合は省略可）
+2. **OpenRouter LLM** で画像を `image_1` に接続（多枚対応モデルではスロットが増える）
 3. **prompt** を設定 — 例：画像を分析して生成プロンプトを出力させる
 4. （任意）詳細オプションの **system_prompt** で文体・形式・制約を指定
 5. **model** を選択。表示されていれば **reasoning_effort** や **search_context_size** を調整

--- a/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/tutorials/partner-nodes/openrouter/llm.mdx
@@ -61,19 +61,30 @@ Text-only models hide image and video inputs.
 
 ## OpenRouter LLM workflow
 
-Build a minimal graph: **Load Image** (optional) → **OpenRouter LLM** → **Preview Any**.
+<CardGroup cols={2}>
+  {/* Comfy Cloud template coming soon
+  <Card title="Run in Comfy Cloud" icon="cloud" href="https://cloud.comfy.org/?template=api_openrouter_llm&utm_source=docs&utm_medium=referral&utm_campaign=openrouter_llm">
+    Open in Comfy Cloud
+  </Card>
+  */}
+  <Card title="Download Workflow" icon="download" href="https://github.com/Comfy-Org/workflow_templates/blob/main/templates/api_openrouter_llm.json">
+    Download JSON or search "OpenRouter LLM" in Template Library
+  </Card>
+</CardGroup>
 
 <Note>
-The example below uses an image-to-prompt workflow: analyze a reference image and return a text-to-image prompt you can paste into downstream image nodes.
+The `api_openrouter_llm` template analyzes a reference image and returns a text-to-image prompt you can paste into downstream image nodes.
 </Note>
 
-1. Add **Load Image** and load a reference image (skip for text-only chat)
-2. Add **OpenRouter LLM** and connect the image to the model’s `image_1` slot (additional slots appear when the model supports more images)
+Refer to the workflow to complete the basic run:
+
+1. In **Load Image**, load the reference image (skip for text-only chat)
+2. In **OpenRouter LLM**, connect the image to `image_1` (more slots appear when the model supports them)
 3. Set **prompt** — e.g. ask the model to analyze the image and output a generation prompt
 4. (Optional) Set **system_prompt** in advanced options for tone, format, or constraints
-5. Pick a **model** from the dropdown; adjust **reasoning_effort** or **search_context_size** if those inputs are visible
+5. Pick a **model**; adjust **reasoning_effort** or **search_context_size** when shown
 6. Click **Run** or press `Ctrl(cmd) + Enter`
-7. Read the model reply in **Preview Any**
+7. View the reply in **Preview Any**
 
 ### Additional notes
 

--- a/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/tutorials/partner-nodes/openrouter/llm.mdx
@@ -1,0 +1,82 @@
+---
+title: "OpenRouter LLM API Node ComfyUI Official Example"
+description: "Use the OpenRouter LLM partner node in ComfyUI for chat, reasoning, vision, and web-grounded answers across multiple frontier models."
+sidebarTitle: "OpenRouter LLM"
+---
+
+import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+
+The **OpenRouter LLM** partner node routes chat requests through OpenRouter so you can pick from a curated set of text and multimodal models—Claude, GPT, Gemini, Grok, DeepSeek, Qwen, Mistral, GLM, Kimi, and Perplexity Sonar—in one ComfyUI node.
+
+<ReqHint/>
+<UpdateReminder/>
+
+## What you can do
+
+- **Text chat** — prompts and optional `system_prompt` for role or task instructions
+- **Vision** — attach reference images on supported models (slot count depends on the model)
+- **Video input** — Gemini 3.5 Flash and Qwen 3.6 Plus/Flash support optional reference videos
+- **Reasoning** — `reasoning_effort` on reasoning / frontier-reasoning models (`off`, `low`, `medium`, `high`)
+- **Web search** — Perplexity Sonar models expose `search_context_size` for grounded answers
+
+Token pricing is listed under [Partner Node Pricing](/tutorials/partner-nodes/pricing#openrouter).
+
+## Supported models
+
+| Model | Vision (max images) | Video | Extra options |
+| :---- | :------------------ | :---- | :------------ |
+| `anthropic/claude-opus-4.7` | 20 | — | Reasoning effort |
+| `openai/gpt-5.5-pro` | 20 | — | Reasoning effort |
+| `openai/gpt-5.5` | 20 | — | Reasoning effort |
+| `google/gemini-3.5-flash` | 20 | Up to 4 | Reasoning effort |
+| `x-ai/grok-4.20` | 20 | — | Reasoning effort |
+| `x-ai/grok-4.3` | 20 | — | Reasoning effort |
+| `deepseek/deepseek-v4-pro` | — | — | Reasoning effort |
+| `deepseek/deepseek-v4-flash` | — | — | Reasoning effort |
+| `deepseek/deepseek-v3.2` | — | — | Reasoning effort |
+| `qwen/qwen3.6-max-preview` | — | — | Reasoning effort |
+| `qwen/qwen3.6-plus` | 10 | Up to 4 | Reasoning effort |
+| `qwen/qwen3.6-flash` | 10 | Up to 4 | Reasoning effort |
+| `mistralai/mistral-large-2512` | 8 | — | — |
+| `mistralai/mistral-medium-3-5` | 8 | — | Reasoning effort |
+| `z-ai/glm-4.6` | — | — | Reasoning effort |
+| `z-ai/glm-5` | — | — | Reasoning effort |
+| `moonshotai/kimi-k2.6` | 10 | — | Reasoning effort |
+| `moonshotai/kimi-k2-thinking` | — | — | Reasoning effort |
+| `perplexity/sonar-pro` | — | — | Search context size |
+| `perplexity/sonar-reasoning-pro` | — | — | Search context size, reasoning effort |
+| `perplexity/sonar-deep-research` | — | — | Search context size, reasoning effort |
+
+## Model-specific inputs
+
+The **model** dropdown is a dynamic combo. When you change the model, the node updates which inputs appear:
+
+- **Image slots** — shown only for vision-capable models; the number of slots matches the model limit
+- **Video slots** — shown only on Gemini 3.5 Flash and Qwen 3.6 Plus/Flash
+- **Reasoning effort** — shown on reasoning and frontier-reasoning models
+- **Search context size** — shown on Perplexity Sonar models
+
+Text-only models hide image and video inputs.
+
+## OpenRouter LLM workflow
+
+Build a minimal graph: **Load Image** (optional) → **OpenRouter LLM** → **Preview Any**.
+
+<Note>
+The example below uses an image-to-prompt workflow: analyze a reference image and return a text-to-image prompt you can paste into downstream image nodes.
+</Note>
+
+1. Add **Load Image** and load a reference image (skip for text-only chat)
+2. Add **OpenRouter LLM** and connect the image to the model’s `image_1` slot (additional slots appear when the model supports more images)
+3. Set **prompt** — e.g. ask the model to analyze the image and output a generation prompt
+4. (Optional) Set **system_prompt** in advanced options for tone, format, or constraints
+5. Pick a **model** from the dropdown; adjust **reasoning_effort** or **search_context_size** if those inputs are visible
+6. Click **Run** or press `Ctrl(cmd) + Enter`
+7. Read the model reply in **Preview Any**
+
+### Additional notes
+
+- **seed** — set to `0` to omit; most models treat it as a hint only
+- Reference images and videos are uploaded automatically when the workflow runs; you only wire ComfyUI image/video outputs into the node
+- For pricing per model, see [OpenRouter on the pricing page](/tutorials/partner-nodes/pricing#openrouter)

--- a/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/tutorials/partner-nodes/openrouter/llm.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "OpenRouter LLM"
 import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
 
-The **OpenRouter LLM** partner node routes chat requests through OpenRouter so you can pick from a curated set of text and multimodal models—Claude, GPT, Gemini, Grok, DeepSeek, Qwen, Mistral, GLM, Kimi, and Perplexity Sonar—in one ComfyUI node.
+[OpenRouter](https://openrouter.ai) is a unified routing platform for large language models. It exposes many providers through one API so you can switch models without changing your integration. ComfyUI connects through the **OpenRouter LLM** partner node, which offers a curated list of text and multimodal models—Claude, GPT, Gemini, Grok, DeepSeek, Qwen, Mistral, GLM, Kimi, and Perplexity Sonar—in a single node.
 
 <ReqHint/>
 <UpdateReminder/>
@@ -59,7 +59,9 @@ The **model** dropdown is a dynamic combo. When you change the model, the node u
 
 Text-only models hide image and video inputs.
 
-## OpenRouter LLM workflow
+## Example workflow (`api_openrouter_llm`)
+
+The template below is **one example**, not the only way to use the node. Download it to see how inputs connect, then adapt the graph for your task—pure text chat, captioning, prompt rewriting, feeding strings into image nodes, or anything else that fits your pipeline.
 
 <CardGroup cols={2}>
   {/* Comfy Cloud template coming soon
@@ -73,10 +75,10 @@ Text-only models hide image and video inputs.
 </CardGroup>
 
 <Note>
-The `api_openrouter_llm` template analyzes a reference image and returns a text-to-image prompt you can paste into downstream image nodes.
+In this sample, the workflow analyzes a reference image and returns a text-to-image prompt for downstream image nodes. You can omit **Load Image**, change the prompts, or rebuild the graph entirely for your own use case.
 </Note>
 
-Refer to the workflow to complete the basic run:
+If you use the template as a reference, a typical run looks like this:
 
 1. In **Load Image**, load the reference image (skip for text-only chat)
 2. In **OpenRouter LLM**, connect the image to `image_1` (more slots appear when the model supports them)

--- a/zh/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/zh/tutorials/partner-nodes/openrouter/llm.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "OpenRouter LLM"
 import ReqHint from "/snippets/zh/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
 
-**OpenRouter LLM** 合作伙伴节点通过 OpenRouter 转发聊天请求，让你在一个 ComfyUI 节点里选择多种文本与多模态模型——包括 Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi 以及 Perplexity Sonar。
+[OpenRouter](https://openrouter.ai) 是一个统一的大语言模型路由平台，通过单一 API 对接多家模型服务商，便于在不同模型之间切换而无需更换集成方式。ComfyUI 通过 **OpenRouter LLM** 合作伙伴节点接入，在一个节点内提供精选的文本与多模态模型——包括 Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi 以及 Perplexity Sonar。
 
 <ReqHint/>
 <UpdateReminder/>
@@ -59,7 +59,9 @@ import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
 
 纯文本模型不显示图片与视频输入。
 
-## OpenRouter LLM 工作流
+## 示例工作流（`api_openrouter_llm`）
+
+下方模板 **仅作示例**，并非唯一用法。你可以下载参考节点如何连接，再按自己的任务改图——纯文本问答、图像描述、提示词改写、把字符串接到图像节点等都可以。
 
 <CardGroup cols={2}>
   {/* Comfy Cloud 模板即将上线
@@ -73,10 +75,10 @@ import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
 </CardGroup>
 
 <Note>
-`api_openrouter_llm` 模板会分析参考图，并输出可粘贴到下游图像节点的文生图提示词。
+该示例会分析参考图并输出文生图提示词，供下游图像节点使用。你也可以去掉 **Load Image**、修改提示词，或完全按自己的需求重新搭建工作流。
 </Note>
 
-按工作流中的步骤完成基本运行：
+若以该模板为参考，一次典型运行大致如下：
 
 1. 在 **Load Image** 中加载参考图（纯文本对话可跳过）
 2. 在 **OpenRouter LLM** 中将图片连到 `image_1`（支持多图时会出现更多槽位）

--- a/zh/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/zh/tutorials/partner-nodes/openrouter/llm.mdx
@@ -61,17 +61,28 @@ import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
 
 ## OpenRouter LLM 工作流
 
-最小链路：**Load Image**（可选）→ **OpenRouter LLM** → **Preview Any**。
+<CardGroup cols={2}>
+  {/* Comfy Cloud 模板即将上线
+  <Card title="在 Comfy Cloud 运行" icon="cloud" href="https://cloud.comfy.org/?template=api_openrouter_llm&utm_source=docs&utm_medium=referral&utm_campaign=openrouter_llm">
+    打开 Comfy Cloud
+  </Card>
+  */}
+  <Card title="下载工作流" icon="download" href="https://github.com/Comfy-Org/workflow_templates/blob/main/templates/api_openrouter_llm.json">
+    下载 JSON 或在模板库中搜索 "OpenRouter LLM"
+  </Card>
+</CardGroup>
 
 <Note>
-下面以「图生提示词」为例：分析参考图，输出可粘贴到下游图像节点的文生图提示词。
+`api_openrouter_llm` 模板会分析参考图，并输出可粘贴到下游图像节点的文生图提示词。
 </Note>
 
-1. 添加 **Load Image** 并加载参考图（纯文本对话可跳过）
-2. 添加 **OpenRouter LLM**，将图片连到模型的 `image_1`（支持多图时会出现更多槽位）
+按工作流中的步骤完成基本运行：
+
+1. 在 **Load Image** 中加载参考图（纯文本对话可跳过）
+2. 在 **OpenRouter LLM** 中将图片连到 `image_1`（支持多图时会出现更多槽位）
 3. 填写 **prompt** — 例如让模型分析图片并输出生成提示词
 4. （可选）在高级选项中设置 **system_prompt**，约束语气、格式或任务
-5. 在 **model** 中选择模型；若有 **reasoning_effort** 或 **search_context_size** 可按需调整
+5. 选择 **model**；若有 **reasoning_effort** 或 **search_context_size** 可按需调整
 6. 点击 **Run** 或按 `Ctrl(cmd) + Enter` 执行
 7. 在 **Preview Any** 中查看返回文本
 

--- a/zh/tutorials/partner-nodes/openrouter/llm.mdx
+++ b/zh/tutorials/partner-nodes/openrouter/llm.mdx
@@ -1,0 +1,82 @@
+---
+title: "OpenRouter LLM 合作伙伴节点 ComfyUI 官方示例"
+description: "在 ComfyUI 中使用 OpenRouter LLM 合作伙伴节点，通过同一节点调用多种前沿大模型，完成对话、推理、视觉理解与联网搜索。"
+sidebarTitle: "OpenRouter LLM"
+---
+
+import ReqHint from "/snippets/zh/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
+
+**OpenRouter LLM** 合作伙伴节点通过 OpenRouter 转发聊天请求，让你在一个 ComfyUI 节点里选择多种文本与多模态模型——包括 Claude、GPT、Gemini、Grok、DeepSeek、Qwen、Mistral、GLM、Kimi 以及 Perplexity Sonar。
+
+<ReqHint/>
+<UpdateReminder/>
+
+## 能做什么
+
+- **文本对话** — 使用 `prompt`，可选 `system_prompt` 设定角色或任务
+- **视觉理解** — 在支持的模型上连接参考图（可连接数量因模型而异）
+- **视频输入** — Gemini 3.5 Flash、Qwen 3.6 Plus/Flash 支持可选参考视频
+- **推理模式** — 推理类 / 前沿推理类模型可设置 `reasoning_effort`（`off`、`low`、`medium`、`high`）
+- **联网搜索** — Perplexity Sonar 系列可设置 `search_context_size` 获取带检索上下文的回答
+
+各模型 token 价格见 [合作伙伴节点定价](/zh/tutorials/partner-nodes/pricing#openrouter)。
+
+## 支持的模型
+
+| 模型 | 视觉（最多图片数） | 视频 | 额外选项 |
+| :--- | :----------------- | :--- | :------- |
+| `anthropic/claude-opus-4.7` | 20 | — | 推理强度 |
+| `openai/gpt-5.5-pro` | 20 | — | 推理强度 |
+| `openai/gpt-5.5` | 20 | — | 推理强度 |
+| `google/gemini-3.5-flash` | 20 | 最多 4 个 | 推理强度 |
+| `x-ai/grok-4.20` | 20 | — | 推理强度 |
+| `x-ai/grok-4.3` | 20 | — | 推理强度 |
+| `deepseek/deepseek-v4-pro` | — | — | 推理强度 |
+| `deepseek/deepseek-v4-flash` | — | — | 推理强度 |
+| `deepseek/deepseek-v3.2` | — | — | 推理强度 |
+| `qwen/qwen3.6-max-preview` | — | — | 推理强度 |
+| `qwen/qwen3.6-plus` | 10 | 最多 4 个 | 推理强度 |
+| `qwen/qwen3.6-flash` | 10 | 最多 4 个 | 推理强度 |
+| `mistralai/mistral-large-2512` | 8 | — | — |
+| `mistralai/mistral-medium-3-5` | 8 | — | 推理强度 |
+| `z-ai/glm-4.6` | — | — | 推理强度 |
+| `z-ai/glm-5` | — | — | 推理强度 |
+| `moonshotai/kimi-k2.6` | 10 | — | 推理强度 |
+| `moonshotai/kimi-k2-thinking` | — | — | 推理强度 |
+| `perplexity/sonar-pro` | — | — | 搜索上下文大小 |
+| `perplexity/sonar-reasoning-pro` | — | — | 搜索上下文大小、推理强度 |
+| `perplexity/sonar-deep-research` | — | — | 搜索上下文大小、推理强度 |
+
+## 随模型变化的输入项
+
+**model** 为动态下拉：切换模型后，节点会更新显示的输入项：
+
+- **图片槽位** — 仅视觉模型显示，数量与模型上限一致
+- **视频槽位** — 仅 Gemini 3.5 Flash、Qwen 3.6 Plus/Flash 显示
+- **推理强度** — 推理类 / 前沿推理类模型显示
+- **搜索上下文大小** — Perplexity Sonar 系列显示
+
+纯文本模型不显示图片与视频输入。
+
+## OpenRouter LLM 工作流
+
+最小链路：**Load Image**（可选）→ **OpenRouter LLM** → **Preview Any**。
+
+<Note>
+下面以「图生提示词」为例：分析参考图，输出可粘贴到下游图像节点的文生图提示词。
+</Note>
+
+1. 添加 **Load Image** 并加载参考图（纯文本对话可跳过）
+2. 添加 **OpenRouter LLM**，将图片连到模型的 `image_1`（支持多图时会出现更多槽位）
+3. 填写 **prompt** — 例如让模型分析图片并输出生成提示词
+4. （可选）在高级选项中设置 **system_prompt**，约束语气、格式或任务
+5. 在 **model** 中选择模型；若有 **reasoning_effort** 或 **search_context_size** 可按需调整
+6. 点击 **Run** 或按 `Ctrl(cmd) + Enter` 执行
+7. 在 **Preview Any** 中查看返回文本
+
+### 补充说明
+
+- **seed** — 设为 `0` 表示不传；多数模型仅将其视为提示，结果仍可能不同
+- 参考图、参考视频在运行工作流时自动上传，你只需在图中连接 ComfyUI 的图像/视频输出
+- 各模型价格见 [定价页 OpenRouter 章节](/zh/tutorials/partner-nodes/pricing#openrouter)


### PR DESCRIPTION
## Summary

- Add partner node guide for **OpenRouter LLM** (`OpenRouterLLMNode`) in en / zh / ja
- Cover capabilities (chat, vision, video, reasoning, Perplexity web search), supported models table, and dynamic inputs by model
- Walk through a minimal **Load Image → OpenRouter LLM → Preview Any** workflow (image-to-prompt example)
- Register navigation under a new **OpenRouter** group in `docs.json`

## Related

- Pricing table: #1005 (`pricing-update` branch) — tutorial links to `#openrouter` on the pricing page

## Test plan

- [ ] Preview docs site for en / zh / ja routes
- [ ] Confirm sidebar shows **OpenRouter → OpenRouter LLM**
- [ ] Verify pricing anchor link after pricing PR merges