### PR TITLE
feat(homepage): add AI Agents & MCP section (EN/ZH/JA)

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -156,12 +156,33 @@ The most powerful open source node-based application for generative AI
     >
       Explore the ComfyUI Cloud API reference
     </Card>
+  </CardGroup>
+</div>
+
+{/* AI Agents & MCP Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">AI Agents & MCP</h2>
+  <CardGroup cols={3}>
+    <Card
+      title="Agent Tools Overview"
+      icon="robot"
+      href="/development/mcp/index"
+    >
+      Use AI agents to automate ComfyUI workflows
+    </Card>
     <Card
       title="Cloud MCP Server"
       icon="server"
       href="/development/cloud/mcp-server"
     >
       Connect AI agents to ComfyUI Cloud via MCP
+    </Card>
+    <Card
+      title="Partner MCP"
+      icon="plug"
+      href="/development/mcp/partner-mcp"
+    >
+      Run ComfyUI workflows from any MCP-compatible agent
     </Card>
   </CardGroup>
 </div>

--- a/index.mdx
+++ b/index.mdx
@@ -168,21 +168,21 @@ The most powerful open source node-based application for generative AI
       icon="robot"
       href="/development/mcp/index"
     >
-      Use AI agents to automate ComfyUI workflows
+      Connect AI agents via MCP for image, video, audio, and 3D generation
     </Card>
     <Card
       title="Cloud MCP Server"
       icon="server"
       href="/development/cloud/mcp-server"
     >
-      Connect AI agents to ComfyUI Cloud via MCP
+      Hosted MCP at cloud.comfy.org — run workflows on Cloud GPUs
     </Card>
     <Card
       title="Partner MCP"
       icon="plug"
       href="/development/mcp/partner-mcp"
     >
-      Run ComfyUI workflows from any MCP-compatible agent
+      Local MCP with unified generate tools across 30+ partner providers
     </Card>
   </CardGroup>
 </div>

--- a/ja/index.mdx
+++ b/ja/index.mdx
@@ -160,12 +160,33 @@ translationMismatches:
     >
       ComfyUI Cloud API リファレンスを確認
     </Card>
+  </CardGroup>
+</div>
+
+{/* AI Agents & MCP Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">AI エージェントと MCP</h2>
+  <CardGroup cols={3}>
+    <Card
+      title="エージェントツール概要"
+      icon="robot"
+      href="/ja/development/mcp/index"
+    >
+      AI エージェントで ComfyUI ワークフローを自動化
+    </Card>
     <Card
       title="Cloud MCP サーバー"
       icon="server"
       href="/ja/development/cloud/mcp-server"
     >
       MCP を介して AI エージェントを ComfyUI Cloud に接続
+    </Card>
+    <Card
+      title="Partner MCP"
+      icon="plug"
+      href="/ja/development/mcp/partner-mcp"
+    >
+      MCP 対応エージェントから ComfyUI ワークフローを実行
     </Card>
   </CardGroup>
 </div>

--- a/ja/index.mdx
+++ b/ja/index.mdx
@@ -172,21 +172,21 @@ translationMismatches:
       icon="robot"
       href="/ja/development/mcp/index"
     >
-      AI エージェントで ComfyUI ワークフローを自動化
+      MCP で AI エージェントを接続し、画像・動画・オーディオ・3D を生成
     </Card>
     <Card
       title="Cloud MCP サーバー"
       icon="server"
       href="/ja/development/cloud/mcp-server"
     >
-      MCP を介して AI エージェントを ComfyUI Cloud に接続
+      cloud.comfy.org のホスト型 MCP — Cloud GPU でワークフローを実行
     </Card>
     <Card
       title="Partner MCP"
       icon="plug"
       href="/ja/development/mcp/partner-mcp"
     >
-      MCP 対応エージェントから ComfyUI ワークフローを実行
+      ローカル MCP サーバー。30以上のパートナープロバイダー向け統一生成ツール
     </Card>
   </CardGroup>
 </div>

--- a/zh/index.mdx
+++ b/zh/index.mdx
@@ -171,21 +171,21 @@ sidebarTitle: "介绍"
       icon="robot"
       href="/zh/development/mcp/index"
     >
-      使用 AI 智能体自动化 ComfyUI 工作流
+      通过 MCP 连接 AI 智能体，生成图片、视频、音频和 3D 内容
     </Card>
     <Card
       title="Cloud MCP 服务器"
       icon="server"
       href="/zh/development/cloud/mcp-server"
     >
-      通过 MCP 将 AI 智能体连接到 ComfyUI Cloud
+      托管于 cloud.comfy.org 的 MCP — 在 Cloud GPU 上运行工作流
     </Card>
     <Card
       title="Partner MCP"
       icon="plug"
       href="/zh/development/mcp/partner-mcp"
     >
-      在任意支持 MCP 的智能体中运行 ComfyUI 工作流
+      本地 MCP 服务器，通过统一生成工具调用 30+ 合作提供商
     </Card>
   </CardGroup>
 </div>

--- a/zh/index.mdx
+++ b/zh/index.mdx
@@ -159,12 +159,33 @@ sidebarTitle: "介绍"
     >
       查看 ComfyUI Cloud API 参考文档
     </Card>
+  </CardGroup>
+</div>
+
+{/* AI Agents & MCP Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">AI 智能体与 MCP</h2>
+  <CardGroup cols={3}>
+    <Card
+      title="智能体工具概览"
+      icon="robot"
+      href="/zh/development/mcp/index"
+    >
+      使用 AI 智能体自动化 ComfyUI 工作流
+    </Card>
     <Card
       title="Cloud MCP 服务器"
       icon="server"
       href="/zh/development/cloud/mcp-server"
     >
       通过 MCP 将 AI 智能体连接到 ComfyUI Cloud
+    </Card>
+    <Card
+      title="Partner MCP"
+      icon="plug"
+      href="/zh/development/mcp/partner-mcp"
+    >
+      在任意支持 MCP 的智能体中运行 ComfyUI 工作流
     </Card>
   </CardGroup>
 </div>


### PR DESCRIPTION
## Summary

- **Problem**: The homepage "Development & Extension" section mixed general dev tools with Cloud API cards and a single MCP card, leaving two of the three "Agent Tools / MCP" sidebar pages (`development/mcp/index` and `development/mcp/partner-mcp`) completely absent from the homepage
- Splits the Development section: Cloud MCP Server card moves out, section now has 5 focused cards (Dev Guide, Custom Nodes, Local API, Cloud API, Cloud API Reference)
- Adds a new **"AI Agents & MCP"** section with all three nav-group pages represented:
  - Agent Tools Overview → `/development/mcp/index`
  - Cloud MCP Server → `/development/cloud/mcp-server`
  - Partner MCP → `/development/mcp/partner-mcp`
- All changes applied to **English, Chinese (zh), and Japanese (ja)** homepages

## Test plan

- [ ] Verify all 3 new MCP card links resolve correctly on the live preview
- [ ] Check that the "Development & Extension" section still renders correctly with 5 cards (3+2 layout)
- [ ] Check the new "AI Agents & MCP" section renders correctly with 3 cards on all three locale homepages