### PR TITLE
docs: add Startup Flags reference and update related documentation

### DIFF
--- a/development/comfyui-server/comms_overview.mdx
+++ b/development/comfyui-server/comms_overview.mdx
@@ -14,7 +14,7 @@ To run ComfyUI as a headless server (no browser):
 <CodeGroup>
 ```bash
 # Run without opening the browser
-python main.py --headless
+python main.py --disable-auto-launch
 ```
 
 ```bash
@@ -29,12 +29,15 @@ python main.py --listen 0.0.0.0
 </CodeGroup>
 
 <Tip>
-  For a full list of startup flags, run `python main.py --help` or see the [install guide](/installation/manual_install#basic-usage).
+  For a full list of startup flags, run `python main.py --help` or see the [Startup Flags reference](/development/comfyui-server/startup-flags).
 </Tip>
 
 ## Key Pages in This Section
 
 <CardGroup cols={2}>
+  <Card title="Startup Flags" icon="terminal" href="/development/comfyui-server/startup-flags">
+    Complete reference for all main.py command-line arguments.
+  </Card>
   <Card title="API Routes" icon="route" href="/development/comfyui-server/comms_routes">
     Available HTTP endpoints for submitting workflows, uploading files, and querying status.
   </Card>

--- a/development/comfyui-server/startup-flags.mdx
+++ b/development/comfyui-server/startup-flags.mdx
@@ -1,0 +1,276 @@
+---
+title: "Startup Flags"
+sidebarTitle: "Startup Flags"
+description: "Complete reference for ComfyUI main.py command-line arguments"
+icon: "terminal"
+---
+
+ComfyUI accepts command-line arguments when started with `python main.py`. This page documents every flag defined in [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py).
+
+<Note>
+  **Windows Portable** users can add flags to the `.bat` launch files (for example, `run_nvidia_gpu.bat`). See the [Windows Portable guide](/installation/comfyui_portable_windows) for details.
+</Note>
+
+Run `python main.py --help` in your ComfyUI directory for the built-in help text. Combine multiple flags as needed:
+
+```bash
+python main.py --listen 0.0.0.0 --port 8288 --disable-auto-launch --lowvram
+```
+
+## Network & Server
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--listen` `[IP]` | `127.0.0.1` | IP address to listen on. Comma-separated list supported (e.g. `127.2.2.2,127.3.3.3`). If provided without a value, defaults to `0.0.0.0,::` (all IPv4 and IPv6 interfaces). |
+| `--port` | `8188` | Port to listen on. |
+| `--tls-keyfile` `PATH` | — | Path to TLS (SSL) key file. Enables HTTPS. Requires `--tls-certfile`. |
+| `--tls-certfile` `PATH` | — | Path to TLS (SSL) certificate file. Enables HTTPS. Requires `--tls-keyfile`. |
+| `--enable-cors-header` `[ORIGIN]` | disabled | Enable CORS. Optional origin, or `*` for all origins when no value is given. |
+| `--max-upload-size` | `100` | Maximum upload size in MB. |
+| `--enable-compress-response-body` | disabled | Enable compressing the HTTP response body. |
+
+<CodeGroup>
+```bash
+# Listen on all interfaces (LAN access)
+python main.py --listen
+
+# Listen on a specific IP
+python main.py --listen 0.0.0.0
+
+# Custom port with HTTPS
+python main.py --port 8443 --tls-keyfile key.pem --tls-certfile cert.pem
+```
+</CodeGroup>
+
+## Directories
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--base-directory` `PATH` | ComfyUI root | Base directory for models, custom_nodes, input, output, temp, and user directories. |
+| `--extra-model-paths-config` `PATH` | — | Load one or more `extra_model_paths.yaml` files. Can be specified multiple times. |
+| `--output-directory` `PATH` | — | Output directory. Overrides `--base-directory`. |
+| `--temp-directory` `PATH` | — | Temp directory. Overrides `--base-directory`. |
+| `--input-directory` `PATH` | — | Input directory. Overrides `--base-directory`. |
+| `--user-directory` `PATH` | — | User directory (absolute path). Overrides `--base-directory`. Path must exist and be readable. |
+
+## Launch & Browser
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--auto-launch` | disabled | Automatically open ComfyUI in the default browser on startup. |
+| `--disable-auto-launch` | disabled | Disable auto-launching the browser. |
+| `--windows-standalone-build` | disabled | Windows portable build convenience mode. Enables auto-launch on startup (equivalent to `--auto-launch`). |
+
+<Note>
+  `--windows-standalone-build` sets `auto_launch` to `true`. `--disable-auto-launch` overrides it. To run as a server without opening a browser, use `--disable-auto-launch`.
+</Note>
+
+```bash
+# Run server without opening browser
+python main.py --disable-auto-launch
+```
+
+## Devices & CUDA
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cuda-device` `DEVICE_ID` | — | CUDA device IDs to use, comma-separated (e.g. `0` or `0,1`). Other devices are hidden. |
+| `--default-device` `ID` | — | Default device ID. All other devices remain visible. |
+| `--cuda-malloc` | auto (torch 2.0+) | Enable cudaMallocAsync. Mutually exclusive with `--disable-cuda-malloc`. |
+| `--disable-cuda-malloc` | — | Disable cudaMallocAsync. Mutually exclusive with `--cuda-malloc`. |
+| `--directml` `[DEVICE]` | — | Use torch-directml. Optional device index; defaults to `-1` when no value is given. |
+| `--oneapi-device-selector` `STRING` | — | oneAPI device selector string for Intel devices. |
+
+## Precision & Inference
+
+<Note>
+  Flags in the **Global**, **UNET**, **VAE**, and **Text Encoder** groups below are mutually exclusive within each group. Only one flag per group can be used at a time.
+</Note>
+
+### Global floating point
+
+| Flag | Description |
+|------|-------------|
+| `--force-fp32` | Force fp32 globally. Report if this improves GPU performance. |
+| `--force-fp16` | Force fp16 globally. Also sets `--fp16-unet`. |
+
+### UNET precision
+
+| Flag | Description |
+|------|-------------|
+| `--fp32-unet` | Run the diffusion model in fp32. |
+| `--fp64-unet` | Run the diffusion model in fp64. |
+| `--bf16-unet` | Run the diffusion model in bf16. |
+| `--fp16-unet` | Run the diffusion model in fp16. |
+| `--fp8_e4m3fn-unet` | Store UNet weights in fp8 (e4m3fn). |
+| `--fp8_e5m2-unet` | Store UNet weights in fp8 (e5m2). |
+| `--fp8_e8m0fnu-unet` | Store UNet weights in fp8 (e8m0fnu). |
+
+### VAE precision
+
+| Flag | Description |
+|------|-------------|
+| `--fp16-vae` | Run the VAE in fp16. May cause black images. |
+| `--fp32-vae` | Run the VAE in full precision fp32. |
+| `--bf16-vae` | Run the VAE in bf16. |
+| `--cpu-vae` | Run the VAE on the CPU (not mutually exclusive with VAE precision flags). |
+
+### Text encoder precision
+
+| Flag | Description |
+|------|-------------|
+| `--fp8_e4m3fn-text-enc` | Store text encoder weights in fp8 (e4m3fn). |
+| `--fp8_e5m2-text-enc` | Store text encoder weights in fp8 (e5m2). |
+| `--fp16-text-enc` | Store text encoder weights in fp16. |
+| `--fp32-text-enc` | Store text encoder weights in fp32. |
+| `--bf16-text-enc` | Store text encoder weights in bf16. |
+
+### Other inference options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--fp16-intermediates` | disabled | Experimental: use fp16 for intermediate tensors between nodes instead of fp32. |
+| `--force-channels-last` | disabled | Force channels-last memory format during inference. |
+| `--supports-fp8-compute` | disabled | Act as if the device supports fp8 compute. |
+| `--enable-triton-backend` | disabled | Enable Triton backend in comfy-kitchen. Disabled by default at launch. |
+
+## Preview
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--preview-method` | `none` | Preview method for sampler nodes. Choices: `none`, `auto`, `latent2rgb`, `taesd`. |
+| `--preview-size` | `512` | Maximum preview image size in pixels. |
+
+## Cache
+
+<Note>
+  Cache mode flags are mutually exclusive. Only one of `--cache-ram`, `--cache-classic`, `--cache-lru`, or `--cache-none` should be used.
+</Note>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cache-ram` `[GB] [GB]` | enabled (default mode) | RAM pressure caching. First value: active-cache threshold in GB. Optional second value: inactive-cache/pin threshold in GB. When no values given: active = 10% of system RAM (min 2 GB, max 10 GB); inactive = 100% of system RAM (max 96 GB). Accepts at most two values. |
+| `--cache-classic` | — | Use the old aggressive caching style. |
+| `--cache-lru` `N` | `0` (disabled) | LRU caching with a maximum of N node results cached. May use more RAM/VRAM. |
+| `--cache-none` | — | Reduced RAM/VRAM usage; re-executes every node on each run. |
+
+## Attention
+
+<Note>
+  Cross-attention method flags are mutually exclusive. Split and quad attention are ignored when xformers is used.
+</Note>
+
+| Flag | Description |
+|------|-------------|
+| `--use-split-cross-attention` | Use split cross attention optimization. |
+| `--use-quad-cross-attention` | Use sub-quadratic cross attention optimization. |
+| `--use-pytorch-cross-attention` | Use PyTorch 2.0 cross attention. |
+| `--use-sage-attention` | Use Sage attention. |
+| `--use-flash-attention` | Use FlashAttention. |
+| `--disable-xformers` | Disable xformers. |
+| `--force-upcast-attention` | Force attention upcasting. Report if this fixes black images. Mutually exclusive with `--dont-upcast-attention`. |
+| `--dont-upcast-attention` | Disable all attention upcasting. For debugging only. |
+
+## VRAM & Memory
+
+<Note>
+  VRAM mode flags (`--gpu-only`, `--highvram`, `--lowvram`, `--novram`, `--cpu`) are mutually exclusive.
+</Note>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--gpu-only` | — | Store and run everything on the GPU (text encoders, CLIP, etc.). |
+| `--highvram` | — | Keep models in GPU memory instead of unloading to CPU after use. |
+| `--lowvram` | — | No effect when dynamic VRAM is enabled. Otherwise, runs text encoders on CPU. |
+| `--novram` | — | Minimal VRAM usage when `--lowvram` is not enough. |
+| `--cpu` | — | Use CPU for everything (slow). |
+| `--reserve-vram` `GB` | OS-dependent | VRAM in GB to reserve for the OS and other software. |
+| `--async-offload` `[NUM_STREAMS]` | enabled on Nvidia | Async weight offloading. Optional stream count (default: 2). |
+| `--disable-async-offload` | — | Disable async weight offloading. |
+| `--disable-dynamic-vram` | — | Disable dynamic VRAM; use estimate-based model loading. |
+| `--enable-dynamic-vram` | auto on Nvidia | Enable dynamic VRAM on systems where it is not enabled by default. |
+| `--fast-disk` | disabled | Prefer disk-backed dynamic loading over unpinned RAM. Useful with fast NVMe. |
+| `--force-non-blocking` | disabled | Force non-blocking tensor operations. May help on non-Nvidia systems; can break some workflows. |
+| `--disable-smart-memory` | disabled | Aggressively offload to RAM instead of keeping models in VRAM. |
+| `--disable-pinned-memory` | disabled | Disable pinned memory use. |
+| `--mmap-torch-files` | disabled | Use mmap when loading ckpt/pt files. |
+| `--disable-mmap` | disabled | Do not use mmap when loading safetensors. |
+
+## Performance & Debugging
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--fast` `[OPT...]` | disabled | Enable experimental optimizations that may affect quality or stability. `--fast` alone enables all. Specific options: `fp16_accumulation`, `fp8_matrix_mult`, `cublas_ops`, `autotune`. |
+| `--deterministic` | disabled | Use slower deterministic PyTorch algorithms where possible. Does not guarantee identical images in all cases. |
+| `--default-hashing-function` | `sha256` | Hash function for duplicate filename/content comparison. Choices: `md5`, `sha1`, `sha256`, `sha512`. |
+
+```bash
+# Enable all fast optimizations (experimental)
+python main.py --fast
+
+# Enable specific optimizations only
+python main.py --fast fp16_accumulation cublas_ops
+```
+
+## ComfyUI Manager
+
+See [ComfyUI-Manager Installation](/manager/install) for setup instructions.
+
+| Flag | Description |
+|------|-------------|
+| `--enable-manager` | Enable ComfyUI-Manager. |
+| `--disable-manager-ui` | Disable Manager UI and endpoints only. Background tasks (scheduled installs, etc.) continue. Requires `--enable-manager`. |
+| `--enable-manager-legacy-ui` | Use the legacy Manager UI. Requires `--enable-manager`. |
+
+## Custom Nodes & API Nodes
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--disable-all-custom-nodes` | disabled | Disable loading all custom nodes. |
+| `--whitelist-custom-nodes` `FOLDER...` | — | Custom node folders to load even when `--disable-all-custom-nodes` is set. |
+| `--disable-api-nodes` | disabled | Disable API nodes and prevent the frontend from communicating with the internet. |
+| `--disable-metadata` | disabled | Disable saving prompt metadata in output files. |
+
+```bash
+# Troubleshoot custom node issues
+python main.py --disable-all-custom-nodes
+
+# Allow only specific custom nodes
+python main.py --disable-all-custom-nodes --whitelist-custom-nodes ComfyUI-Manager
+```
+
+## Frontend & API
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--front-end-version` | `comfyanonymous/ComfyUI@latest` | Frontend version in `[owner]/[repo]@[version]` format. Requires internet to download from GitHub releases. Version can be `latest` or a semver (e.g. `1.0.0`). |
+| `--front-end-root` `PATH` | — | Local filesystem path to the frontend directory. Overrides `--front-end-version`. |
+| `--comfy-api-base` | `https://api.comfy.org` | Base URL for the ComfyUI API. |
+| `--database-url` | `sqlite:///<ComfyUI>/user/comfyui.db` | Database URL. Use `sqlite:///:memory:` for in-memory. |
+| `--enable-assets` | disabled | Enable the assets system (API routes, database sync, background scanning). |
+| `--feature-flag` `KEY[=VALUE]` | — | Set a server feature flag. Bare `KEY` sets true. Can be repeated. Booleans and numbers are auto-converted. |
+| `--list-feature-flags` | — | Print known CLI-settable feature flags as JSON and exit. |
+
+```bash
+# List available feature flags
+python main.py --list-feature-flags
+
+# Set feature flags
+python main.py --feature-flag show_signin_button=true
+```
+
+## Logging & Misc
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--verbose` `[LEVEL]` | `INFO` | Logging level. Choices: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. `--verbose` alone sets `DEBUG`. |
+| `--log-stdout` | disabled | Send normal process output to stdout instead of stderr. |
+| `--dont-print-server` | disabled | Do not print server output to the console. |
+| `--multi-user` | disabled | Enable per-user storage. |
+| `--quick-test-for-ci` | disabled | Quick startup test for CI. Exits immediately after initialization. |
+
+---
+
+<Note>
+  This reference is based on ComfyUI [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py). When upgrading ComfyUI, run `python main.py --help` or compare your local [`cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) against this page to check for new or changed flags.
+</Note>

--- a/docs.json
+++ b/docs.json
@@ -2293,6 +2293,7 @@
                     "icon": "server",
                     "pages": [
                       "development/comfyui-server/comms_overview",
+                      "development/comfyui-server/startup-flags",
                       "development/comfyui-server/comms_routes",
                       "development/comfyui-server/api-examples",
                       "development/comfyui-server/comms_messages",
@@ -4744,6 +4745,7 @@
                     "icon": "server",
                     "pages": [
                       "zh/development/comfyui-server/comms_overview",
+                      "zh/development/comfyui-server/startup-flags",
                       "zh/development/comfyui-server/comms_routes",
                       "zh/development/comfyui-server/api-examples",
                       "zh/development/comfyui-server/comms_messages",
@@ -7195,6 +7197,7 @@
                     "icon": "server",
                     "pages": [
                       "ja/development/comfyui-server/comms_overview",
+                      "ja/development/comfyui-server/startup-flags",
                       "ja/development/comfyui-server/comms_routes",
                       "ja/development/comfyui-server/api-examples",
                       "ja/development/comfyui-server/comms_messages",

--- a/installation/manual_install.mdx
+++ b/installation/manual_install.mdx
@@ -60,6 +60,8 @@ git clone https://github.com/Comfy-Org/ComfyUI.git
     </Step>
 </Steps>
 
+For advanced server configuration (custom port, LAN access, VRAM modes, and more), see the [Startup Flags reference](/development/comfyui-server/startup-flags).
+
 ## How to update ComfyUI
 
 <Steps>

--- a/ja/development/comfyui-server/comms_overview.mdx
+++ b/ja/development/comfyui-server/comms_overview.mdx
@@ -14,7 +14,7 @@ ComfyUI を起動すると、自動的に HTTP サーバーが `http://127.0.0.1
 <CodeGroup>
 ```bash
 # ブラウザを開かずに実行
-python main.py --headless
+python main.py --disable-auto-launch
 ```
 
 ```bash
@@ -29,12 +29,15 @@ python main.py --listen 0.0.0.0
 </CodeGroup>
 
 <Tip>
-  全起動オプションの一覧は `python main.py --help` を実行してください。[インストールガイド](/ja/installation/manual_install#basic-usage)も参照。
+  全起動オプションの一覧は `python main.py --help` を実行するか、[起動オプションリファレンス](/ja/development/comfyui-server/startup-flags)を参照してください。
 </Tip>
 
 ## このセクションの主要ページ
 
 <CardGroup cols={2}>
+  <Card title="起動オプション" icon="terminal" href="/ja/development/comfyui-server/startup-flags">
+    main.py のすべてのコマンドライン起動オプションの完全リファレンス。
+  </Card>
   <Card title="API ルート" icon="route" href="/ja/development/comfyui-server/comms_routes">
     ワークフロー送信、ファイルアップロード、ステータス確認用の HTTP エンドポイント。
   </Card>

--- a/ja/development/comfyui-server/startup-flags.mdx
+++ b/ja/development/comfyui-server/startup-flags.mdx
@@ -1,0 +1,276 @@
+---
+title: "起動オプション"
+sidebarTitle: "起動オプション"
+description: "ComfyUI main.py コマンドライン引数の完全リファレンス"
+icon: "terminal"
+---
+
+`python main.py` で ComfyUI を起動する際、コマンドライン引数を指定できます。このページでは [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) で定義されているすべてのフラグを説明します。
+
+<Note>
+  **Windows ポータブル版** ユーザーは `.bat` 起動ファイル（例：`run_nvidia_gpu.bat`）にフラグを追加できます。詳細は [Windows ポータブル版インストールガイド](/ja/installation/comfyui_portable_windows) を参照してください。
+</Note>
+
+ComfyUI ディレクトリで `python main.py --help` を実行すると、組み込みヘルプを確認できます。必要に応じて複数のフラグを組み合わせてください：
+
+```bash
+python main.py --listen 0.0.0.0 --port 8288 --disable-auto-launch --lowvram
+```
+
+## ネットワークとサーバー
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--listen` `[IP]` | `127.0.0.1` | 待ち受ける IP アドレス。カンマ区切りで複数指定可能（例：`127.2.2.2,127.3.3.3`）。値なしの場合は `0.0.0.0,::`（すべての IPv4/IPv6 インターフェース）。 |
+| `--port` | `8188` | 待ち受けポート。 |
+| `--tls-keyfile` `PATH` | — | TLS（SSL）キーファイルのパス。HTTPS を有効化。`--tls-certfile` が必要。 |
+| `--tls-certfile` `PATH` | — | TLS（SSL）証明書ファイルのパス。HTTPS を有効化。`--tls-keyfile` が必要。 |
+| `--enable-cors-header` `[ORIGIN]` | 無効 | CORS を有効化。オプションでオリジン指定。値なしの場合は `*`（すべてのオリジン）。 |
+| `--max-upload-size` | `100` | 最大アップロードサイズ（MB）。 |
+| `--enable-compress-response-body` | 無効 | HTTP レスポンスボディの圧縮を有効化。 |
+
+<CodeGroup>
+```bash
+# すべてのインターフェースで待受（LAN アクセス）
+python main.py --listen
+
+# 特定の IP で待受
+python main.py --listen 0.0.0.0
+
+# カスタムポートと HTTPS
+python main.py --port 8443 --tls-keyfile key.pem --tls-certfile cert.pem
+```
+</CodeGroup>
+
+## ディレクトリ
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--base-directory` `PATH` | ComfyUI ルート | models、custom_nodes、input、output、temp、user などのベースディレクトリ。 |
+| `--extra-model-paths-config` `PATH` | — | 1 つ以上の `extra_model_paths.yaml` を読み込み。複数回指定可能。 |
+| `--output-directory` `PATH` | — | 出力ディレクトリ。`--base-directory` を上書き。 |
+| `--temp-directory` `PATH` | — | 一時ディレクトリ。`--base-directory` を上書き。 |
+| `--input-directory` `PATH` | — | 入力ディレクトリ。`--base-directory` を上書き。 |
+| `--user-directory` `PATH` | — | ユーザーディレクトリ（絶対パス）。`--base-directory` を上書き。パスは存在し読み取り可能である必要あり。 |
+
+## 起動とブラウザ
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--auto-launch` | 無効 | 起動時にデフォルトブラウザで ComfyUI を自動的に開く。 |
+| `--disable-auto-launch` | 無効 | ブラウザの自動起動を無効化。 |
+| `--windows-standalone-build` | 無効 | Windows ポータブル版の便利モード。起動時にブラウザを自動で開く（`--auto-launch` と同等）。 |
+
+<Note>
+  `--windows-standalone-build` は `auto_launch` を `true` に設定します。`--disable-auto-launch` で上書きできます。ブラウザを開かずにサーバーとして実行するには `--disable-auto-launch` を使用してください。
+</Note>
+
+```bash
+# ブラウザを開かずにサーバーを実行
+python main.py --disable-auto-launch
+```
+
+## デバイスと CUDA
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--cuda-device` `DEVICE_ID` | — | 使用する CUDA デバイス ID（カンマ区切り、例：`0` または `0,1`）。他のデバイスは非表示。 |
+| `--default-device` `ID` | — | デフォルトデバイス ID。他のデバイスは表示されたまま。 |
+| `--cuda-malloc` | 自動（torch 2.0+） | cudaMallocAsync を有効化。`--disable-cuda-malloc` と排他。 |
+| `--disable-cuda-malloc` | — | cudaMallocAsync を無効化。`--cuda-malloc` と排他。 |
+| `--directml` `[DEVICE]` | — | torch-directml を使用。オプションのデバイスインデックス。値なしの場合は `-1`。 |
+| `--oneapi-device-selector` `STRING` | — | Intel デバイス用 oneAPI デバイスセレクター文字列。 |
+
+## 精度と推論
+
+<Note>
+  以下の **グローバル**、**UNET**、**VAE**、**テキストエンコーダー** 各グループ内のフラグは排他的です。各グループで同時に 1 つだけ使用できます。
+</Note>
+
+### グローバル浮動小数点
+
+| フラグ | 説明 |
+|--------|------|
+| `--force-fp32` | グローバルに fp32 を強制。GPU 性能が向上する場合は報告してください。 |
+| `--force-fp16` | グローバルに fp16 を強制。`--fp16-unet` も設定。 |
+
+### UNET 精度
+
+| フラグ | 説明 |
+|--------|------|
+| `--fp32-unet` | 拡散モデルを fp32 で実行。 |
+| `--fp64-unet` | 拡散モデルを fp64 で実行。 |
+| `--bf16-unet` | 拡散モデルを bf16 で実行。 |
+| `--fp16-unet` | 拡散モデルを fp16 で実行。 |
+| `--fp8_e4m3fn-unet` | UNet 重みを fp8（e4m3fn）で保存。 |
+| `--fp8_e5m2-unet` | UNet 重みを fp8（e5m2）で保存。 |
+| `--fp8_e8m0fnu-unet` | UNet 重みを fp8（e8m0fnu）で保存。 |
+
+### VAE 精度
+
+| フラグ | 説明 |
+|--------|------|
+| `--fp16-vae` | VAE を fp16 で実行。黒い画像になる可能性あり。 |
+| `--fp32-vae` | VAE を fp32 全精度で実行。 |
+| `--bf16-vae` | VAE を bf16 で実行。 |
+| `--cpu-vae` | VAE を CPU で実行（VAE 精度フラグとは排他ではない）。 |
+
+### テキストエンコーダー精度
+
+| フラグ | 説明 |
+|--------|------|
+| `--fp8_e4m3fn-text-enc` | テキストエンコーダー重みを fp8（e4m3fn）で保存。 |
+| `--fp8_e5m2-text-enc` | テキストエンコーダー重みを fp8（e5m2）で保存。 |
+| `--fp16-text-enc` | テキストエンコーダー重みを fp16 で保存。 |
+| `--fp32-text-enc` | テキストエンコーダー重みを fp32 で保存。 |
+| `--bf16-text-enc` | テキストエンコーダー重みを bf16 で保存。 |
+
+### その他の推論オプション
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--fp16-intermediates` | 無効 | 実験的：ノード間の中間テンソルに fp32 の代わりに fp16 を使用。 |
+| `--force-channels-last` | 無効 | 推論時に channels-last メモリ形式を強制。 |
+| `--supports-fp8-compute` | 無効 | デバイスが fp8 計算をサポートしているかのように動作。 |
+| `--enable-triton-backend` | 無効 | comfy-kitchen で Triton バックエンドを有効化。起動時はデフォルトで無効。 |
+
+## プレビュー
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--preview-method` | `none` | サンプラーノードのプレビュー方式。選択肢：`none`、`auto`、`latent2rgb`、`taesd`。 |
+| `--preview-size` | `512` | プレビュー画像の最大サイズ（ピクセル）。 |
+
+## キャッシュ
+
+<Note>
+  キャッシュモードのフラグは排他的です。`--cache-ram`、`--cache-classic`、`--cache-lru`、`--cache-none` のいずれか 1 つのみ使用してください。
+</Note>
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--cache-ram` `[GB] [GB]` | 有効（デフォルト） | RAM 圧力キャッシュ。第 1 値：アクティブキャッシュ閾値（GB）。第 2 値（任意）：非アクティブ/ピン閾値（GB）。値なしの場合：アクティブ = システム RAM の 10%（最小 2 GB、最大 10 GB）；非アクティブ = システム RAM の 100%（最大 96 GB）。最大 2 値。 |
+| `--cache-classic` | — | 旧式の積極的キャッシュを使用。 |
+| `--cache-lru` `N` | `0`（無効） | LRU キャッシュ。最大 N 個のノード結果をキャッシュ。RAM/VRAM を多く使用する可能性あり。 |
+| `--cache-none` | — | RAM/VRAM 使用量を削減。実行のたびにすべてのノードを再実行。 |
+
+## アテンション
+
+<Note>
+  クロスアテンション方式のフラグは排他的です。xformers 使用時、split と quad アテンションは無視されます。
+</Note>
+
+| フラグ | 説明 |
+|--------|------|
+| `--use-split-cross-attention` | split クロスアテンション最適化を使用。 |
+| `--use-quad-cross-attention` | sub-quadratic クロスアテンション最適化を使用。 |
+| `--use-pytorch-cross-attention` | PyTorch 2.0 クロスアテンションを使用。 |
+| `--use-sage-attention` | Sage アテンションを使用。 |
+| `--use-flash-attention` | FlashAttention を使用。 |
+| `--disable-xformers` | xformers を無効化。 |
+| `--force-upcast-attention` | アテンションのアップキャストを強制。黒い画像が修正される場合は報告してください。`--dont-upcast-attention` と排他。 |
+| `--dont-upcast-attention` | すべてのアテンションアップキャストを無効化。デバッグ用。 |
+
+## VRAM とメモリ
+
+<Note>
+  VRAM モードのフラグ（`--gpu-only`、`--highvram`、`--lowvram`、`--novram`、`--cpu`）は排他的です。
+</Note>
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--gpu-only` | — | すべて（テキストエンコーダー、CLIP など）を GPU に保存して実行。 |
+| `--highvram` | — | 使用後もモデルを CPU にアンロードせず GPU メモリに保持。 |
+| `--lowvram` | — | 動的 VRAM 有効時は効果なし。それ以外ではテキストエンコーダーを CPU で実行。 |
+| `--novram` | — | `--lowvram` でも不足する場合の最小 VRAM 使用。 |
+| `--cpu` | — | すべて CPU で実行（遅い）。 |
+| `--reserve-vram` `GB` | OS 依存 | OS と他ソフトウェア用に予約する VRAM（GB）。 |
+| `--async-offload` `[NUM_STREAMS]` | Nvidia でデフォルト有効 | 非同期ウェイトオフロード。オプションのストリーム数（デフォルト：2）。 |
+| `--disable-async-offload` | — | 非同期ウェイトオフロードを無効化。 |
+| `--disable-dynamic-vram` | — | 動的 VRAM を無効化。推定ベースのモデル読み込みを使用。 |
+| `--enable-dynamic-vram` | Nvidia で自動 | デフォルトで無効なシステムで動的 VRAM を有効化。 |
+| `--fast-disk` | 無効 | 非ピン RAM よりディスクベースの動的読み込みを優先。高速 NVMe に有用。 |
+| `--force-non-blocking` | 無効 | 非ブロッキングテンソル操作を強制。非 Nvidia システムで改善する可能性。一部ワークフローで問題の可能性。 |
+| `--disable-smart-memory` | 無効 | VRAM に保持せず RAM へ積極的にオフロード。 |
+| `--disable-pinned-memory` | 無効 | ピン留めメモリの使用を無効化。 |
+| `--mmap-torch-files` | 無効 | ckpt/pt ファイル読み込み時に mmap を使用。 |
+| `--disable-mmap` | 無効 | safetensors 読み込み時に mmap を使用しない。 |
+
+## パフォーマンスとデバッグ
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--fast` `[OPT...]` | 無効 | 品質や安定性に影響する可能性のある実験的最適化を有効化。`--fast` のみですべて有効。オプション：`fp16_accumulation`、`fp8_matrix_mult`、`cublas_ops`、`autotune`。 |
+| `--deterministic` | 無効 | 可能な限り遅い決定論的 PyTorch アルゴリズムを使用。すべての場合で同一画像を保証しない。 |
+| `--default-hashing-function` | `sha256` | 重複ファイル名/内容比較用ハッシュ関数。選択肢：`md5`、`sha1`、`sha256`、`sha512`。 |
+
+```bash
+# すべての fast 最適化を有効化（実験的）
+python main.py --fast
+
+# 特定の最適化のみ有効化
+python main.py --fast fp16_accumulation cublas_ops
+```
+
+## ComfyUI Manager
+
+セットアップ手順は [ComfyUI-Manager インストール](/ja/manager/install) を参照。
+
+| フラグ | 説明 |
+|--------|------|
+| `--enable-manager` | ComfyUI-Manager を有効化。 |
+| `--disable-manager-ui` | Manager UI とエンドポイントのみ無効化。バックグラウンドタスク（スケジュールインストールなど）は継続。`--enable-manager` が必要。 |
+| `--enable-manager-legacy-ui` | レガシー Manager UI を使用。`--enable-manager` が必要。 |
+
+## カスタムノードと API ノード
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--disable-all-custom-nodes` | 無効 | すべてのカスタムノードの読み込みを無効化。 |
+| `--whitelist-custom-nodes` `FOLDER...` | — | `--disable-all-custom-nodes` 有効時も読み込むカスタムノードフォルダ。 |
+| `--disable-api-nodes` | 無効 | API ノードを無効化し、フロントエンドのインターネット通信を防止。 |
+| `--disable-metadata` | 無効 | 出力ファイルへのプロンプトメタデータ保存を無効化。 |
+
+```bash
+# カスタムノードの問題をトラブルシュート
+python main.py --disable-all-custom-nodes
+
+# 特定のカスタムノードのみ許可
+python main.py --disable-all-custom-nodes --whitelist-custom-nodes ComfyUI-Manager
+```
+
+## フロントエンドと API
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--front-end-version` | `comfyanonymous/ComfyUI@latest` | フロントエンドバージョン。`[owner]/[repo]@[version]` 形式。GitHub releases からのダウンロードにインターネット接続が必要。バージョンは `latest` または semver（例：`1.0.0`）。 |
+| `--front-end-root` `PATH` | — | フロントエンドディレクトリのローカルパス。`--front-end-version` を上書き。 |
+| `--comfy-api-base` | `https://api.comfy.org` | ComfyUI API のベース URL。 |
+| `--database-url` | `sqlite:///<ComfyUI>/user/comfyui.db` | データベース URL。メモリ DB は `sqlite:///:memory:`。 |
+| `--enable-assets` | 無効 | アセットシステムを有効化（API ルート、DB 同期、バックグラウンドスキャン）。 |
+| `--feature-flag` `KEY[=VALUE]` | — | サーバー機能フラグを設定。`KEY` のみで true。複数回指定可能。ブール値と数値は自動変換。 |
+| `--list-feature-flags` | — | 既知の CLI 機能フラグを JSON で出力して終了。 |
+
+```bash
+# 利用可能な機能フラグを一覧表示
+python main.py --list-feature-flags
+
+# 機能フラグを設定
+python main.py --feature-flag show_signin_button=true
+```
+
+## ログとその他
+
+| フラグ | デフォルト | 説明 |
+|--------|-----------|------|
+| `--verbose` `[LEVEL]` | `INFO` | ログレベル。選択肢：`DEBUG`、`INFO`、`WARNING`、`ERROR`、`CRITICAL`。`--verbose` のみで `DEBUG`。 |
+| `--log-stdout` | 無効 | 通常のプロセス出力を stderr ではなく stdout に送信。 |
+| `--dont-print-server` | 無効 | コンソールにサーバー出力を表示しない。 |
+| `--multi-user` | 無効 | ユーザーごとのストレージを有効化。 |
+| `--quick-test-for-ci` | 無効 | CI 用クイック起動テスト。初期化後すぐに終了。 |
+
+---
+
+<Note>
+  このリファレンスは ComfyUI の [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) に基づいています。ComfyUI をアップグレードした際は、`python main.py --help` を実行するか、ローカルの [`cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) とこのページを照合して、新規または変更されたフラグがないか確認してください。
+</Note>

--- a/ja/installation/manual_install.mdx
+++ b/ja/installation/manual_install.mdx
@@ -64,6 +64,8 @@ git clone https://github.com/Comfy-Org/ComfyUI.git
     </Step>
 </Steps>
 
+高度なサーバー設定（カスタムポート、LAN アクセス、VRAM モードなど）については、[起動オプションリファレンス](/ja/development/comfyui-server/startup-flags)を参照してください。
+
 ## ComfyUI の更新方法
 
 <Steps>

--- a/snippets/ja/run-comfy.mdx
+++ b/snippets/ja/run-comfy.mdx
@@ -3,3 +3,6 @@
 ```
 cd ComfyUI
 python main.py
+```
+
+組み込みヘルプは `python main.py --help` を実行してください。すべてのコマンドラインオプションは[起動オプションリファレンス](/ja/development/comfyui-server/startup-flags)を参照してください。

--- a/snippets/run-comfy.mdx
+++ b/snippets/run-comfy.mdx
@@ -4,3 +4,5 @@ Start the application
 cd ComfyUI
 python main.py
 ```
+
+Run `python main.py --help` for built-in help, or see the [Startup Flags reference](/development/comfyui-server/startup-flags) for a complete list of command-line options.

--- a/snippets/zh/run-comfy.mdx
+++ b/snippets/zh/run-comfy.mdx
@@ -4,3 +4,5 @@
 cd ComfyUI
 python main.py
 ```
+
+运行 `python main.py --help` 查看内置帮助，或参阅[启动参数参考](/zh/development/comfyui-server/startup-flags)获取完整命令行选项列表。

--- a/zh/development/comfyui-server/comms_overview.mdx
+++ b/zh/development/comfyui-server/comms_overview.mdx
@@ -14,7 +14,7 @@ ComfyUI 默认作为 HTTP 服务器在本地运行。你可以通过编程方式
 <CodeGroup>
 ```bash
 # 不打开浏览器运行
-python main.py --headless
+python main.py --disable-auto-launch
 ```
 
 ```bash
@@ -29,12 +29,15 @@ python main.py --listen 0.0.0.0
 </CodeGroup>
 
 <Tip>
-  查看完整启动参数请运行 `python main.py --help`，或参阅[安装指南](/zh/installation/manual_install#basic-usage)。
+  查看完整启动参数请运行 `python main.py --help`，或参阅[启动参数参考](/zh/development/comfyui-server/startup-flags)。
 </Tip>
 
 ## 本部分的关键页面
 
 <CardGroup cols={2}>
+  <Card title="启动参数" icon="terminal" href="/zh/development/comfyui-server/startup-flags">
+    main.py 全部命令行启动参数完整参考。
+  </Card>
   <Card title="API 路由" icon="route" href="/zh/development/comfyui-server/comms_routes">
     可用的 HTTP 端点：提交工作流、上传文件、查询状态。
   </Card>

--- a/zh/development/comfyui-server/startup-flags.mdx
+++ b/zh/development/comfyui-server/startup-flags.mdx
@@ -1,0 +1,276 @@
+---
+title: "启动参数"
+sidebarTitle: "启动参数"
+description: "ComfyUI main.py 命令行启动参数完整参考"
+icon: "terminal"
+---
+
+使用 `python main.py` 启动 ComfyUI 时可传入命令行参数。本页记录了 [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) 中定义的全部启动参数。
+
+<Note>
+  **Windows 便携版** 用户可在 `.bat` 启动文件（如 `run_nvidia_gpu.bat`）中添加参数。详见 [Windows 便携版安装指南](/zh/installation/comfyui_portable_windows)。
+</Note>
+
+在 ComfyUI 目录下运行 `python main.py --help` 可查看内置帮助。可按需组合多个参数：
+
+```bash
+python main.py --listen 0.0.0.0 --port 8288 --disable-auto-launch --lowvram
+```
+
+## 网络与服务器
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--listen` `[IP]` | `127.0.0.1` | 监听的 IP 地址。支持逗号分隔的多个地址（如 `127.2.2.2,127.3.3.3`）。不带值时默认为 `0.0.0.0,::`（监听所有 IPv4 和 IPv6 接口）。 |
+| `--port` | `8188` | 监听端口。 |
+| `--tls-keyfile` `PATH` | — | TLS（SSL）密钥文件路径。启用 HTTPS，需配合 `--tls-certfile`。 |
+| `--tls-certfile` `PATH` | — | TLS（SSL）证书文件路径。启用 HTTPS，需配合 `--tls-keyfile`。 |
+| `--enable-cors-header` `[ORIGIN]` | 关闭 | 启用 CORS。可指定来源；不带值时默认为 `*`（允许所有来源）。 |
+| `--max-upload-size` | `100` | 最大上传大小（MB）。 |
+| `--enable-compress-response-body` | 关闭 | 启用 HTTP 响应体压缩。 |
+
+<CodeGroup>
+```bash
+# 监听所有接口（局域网访问）
+python main.py --listen
+
+# 监听指定 IP
+python main.py --listen 0.0.0.0
+
+# 自定义端口并启用 HTTPS
+python main.py --port 8443 --tls-keyfile key.pem --tls-certfile cert.pem
+```
+</CodeGroup>
+
+## 目录
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--base-directory` `PATH` | ComfyUI 根目录 | models、custom_nodes、input、output、temp、user 等目录的基础路径。 |
+| `--extra-model-paths-config` `PATH` | — | 加载一个或多个 `extra_model_paths.yaml` 文件。可多次指定。 |
+| `--output-directory` `PATH` | — | 输出目录。覆盖 `--base-directory`。 |
+| `--temp-directory` `PATH` | — | 临时目录。覆盖 `--base-directory`。 |
+| `--input-directory` `PATH` | — | 输入目录。覆盖 `--base-directory`。 |
+| `--user-directory` `PATH` | — | 用户目录（绝对路径）。覆盖 `--base-directory`。路径必须存在且可读。 |
+
+## 启动与浏览器
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--auto-launch` | 关闭 | 启动时自动在默认浏览器中打开 ComfyUI。 |
+| `--disable-auto-launch` | 关闭 | 禁用自动打开浏览器。 |
+| `--windows-standalone-build` | 关闭 | Windows 便携版便捷模式。启动时自动打开浏览器（等效于 `--auto-launch`）。 |
+
+<Note>
+  `--windows-standalone-build` 会将 `auto_launch` 设为 `true`。`--disable-auto-launch` 会覆盖该行为。以无界面服务器模式运行（不打开浏览器）请使用 `--disable-auto-launch`。
+</Note>
+
+```bash
+# 不打开浏览器运行服务器
+python main.py --disable-auto-launch
+```
+
+## 设备与 CUDA
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--cuda-device` `DEVICE_ID` | — | 使用的 CUDA 设备 ID，逗号分隔（如 `0` 或 `0,1`）。其他设备不可见。 |
+| `--default-device` `ID` | — | 默认设备 ID。其他设备仍可见。 |
+| `--cuda-malloc` | 自动（torch 2.0+） | 启用 cudaMallocAsync。与 `--disable-cuda-malloc` 互斥。 |
+| `--disable-cuda-malloc` | — | 禁用 cudaMallocAsync。与 `--cuda-malloc` 互斥。 |
+| `--directml` `[DEVICE]` | — | 使用 torch-directml。可选设备索引；不带值时默认为 `-1`。 |
+| `--oneapi-device-selector` `STRING` | — | Intel 设备的 oneAPI 设备选择器字符串。 |
+
+## 精度与推理
+
+<Note>
+  下方 **全局**、**UNET**、**VAE**、**文本编码器** 各组内的参数互斥，每组同时只能使用一个。
+</Note>
+
+### 全局浮点精度
+
+| 参数 | 说明 |
+|------|------|
+| `--force-fp32` | 全局强制 fp32。若可提升 GPU 性能请反馈。 |
+| `--force-fp16` | 全局强制 fp16。同时设置 `--fp16-unet`。 |
+
+### UNET 精度
+
+| 参数 | 说明 |
+|------|------|
+| `--fp32-unet` | 以 fp32 运行扩散模型。 |
+| `--fp64-unet` | 以 fp64 运行扩散模型。 |
+| `--bf16-unet` | 以 bf16 运行扩散模型。 |
+| `--fp16-unet` | 以 fp16 运行扩散模型。 |
+| `--fp8_e4m3fn-unet` | 以 fp8（e4m3fn）存储 UNet 权重。 |
+| `--fp8_e5m2-unet` | 以 fp8（e5m2）存储 UNet 权重。 |
+| `--fp8_e8m0fnu-unet` | 以 fp8（e8m0fnu）存储 UNet 权重。 |
+
+### VAE 精度
+
+| 参数 | 说明 |
+|------|------|
+| `--fp16-vae` | 以 fp16 运行 VAE。可能导致黑图。 |
+| `--fp32-vae` | 以 fp32 全精度运行 VAE。 |
+| `--bf16-vae` | 以 bf16 运行 VAE。 |
+| `--cpu-vae` | 在 CPU 上运行 VAE（与 VAE 精度参数不互斥）。 |
+
+### 文本编码器精度
+
+| 参数 | 说明 |
+|------|------|
+| `--fp8_e4m3fn-text-enc` | 以 fp8（e4m3fn）存储文本编码器权重。 |
+| `--fp8_e5m2-text-enc` | 以 fp8（e5m2）存储文本编码器权重。 |
+| `--fp16-text-enc` | 以 fp16 存储文本编码器权重。 |
+| `--fp32-text-enc` | 以 fp32 存储文本编码器权重。 |
+| `--bf16-text-enc` | 以 bf16 存储文本编码器权重。 |
+
+### 其他推理选项
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--fp16-intermediates` | 关闭 | 实验性：节点间中间张量使用 fp16 而非 fp32。 |
+| `--force-channels-last` | 关闭 | 推理时强制 channels-last 内存格式。 |
+| `--supports-fp8-compute` | 关闭 | 模拟设备支持 fp8 计算。 |
+| `--enable-triton-backend` | 关闭 | 在 comfy-kitchen 中启用 Triton 后端。默认启动时关闭。 |
+
+## 预览
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--preview-method` | `none` | 采样器节点的预览方式。可选：`none`、`auto`、`latent2rgb`、`taesd`。 |
+| `--preview-size` | `512` | 预览图像最大尺寸（像素）。 |
+
+## 缓存
+
+<Note>
+  缓存模式参数互斥。`--cache-ram`、`--cache-classic`、`--cache-lru`、`--cache-none` 只能选其一。
+</Note>
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--cache-ram` `[GB] [GB]` | 启用（默认模式） | RAM 压力缓存。第一个值：活跃缓存阈值（GB）；可选第二个值：非活跃缓存/固定阈值（GB）。无值时：活跃 = 系统 RAM 的 10%（最小 2 GB，最大 10 GB）；非活跃 = 系统 RAM 的 100%（最大 96 GB）。最多接受两个值。 |
+| `--cache-classic` | — | 使用旧版激进缓存策略。 |
+| `--cache-lru` `N` | `0`（关闭） | LRU 缓存，最多缓存 N 个节点结果。可能占用更多 RAM/VRAM。 |
+| `--cache-none` | — | 降低 RAM/VRAM 占用；每次运行重新执行所有节点。 |
+
+## 注意力机制
+
+<Note>
+  交叉注意力方法参数互斥。使用 xformers 时，split 和 quad 注意力会被忽略。
+</Note>
+
+| 参数 | 说明 |
+|------|------|
+| `--use-split-cross-attention` | 使用 split 交叉注意力优化。 |
+| `--use-quad-cross-attention` | 使用 sub-quadratic 交叉注意力优化。 |
+| `--use-pytorch-cross-attention` | 使用 PyTorch 2.0 交叉注意力。 |
+| `--use-sage-attention` | 使用 Sage 注意力。 |
+| `--use-flash-attention` | 使用 FlashAttention。 |
+| `--disable-xformers` | 禁用 xformers。 |
+| `--force-upcast-attention` | 强制注意力上转换。若可修复黑图请反馈。与 `--dont-upcast-attention` 互斥。 |
+| `--dont-upcast-attention` | 禁用所有注意力上转换。仅用于调试。 |
+
+## VRAM 与内存
+
+<Note>
+  VRAM 模式参数（`--gpu-only`、`--highvram`、`--lowvram`、`--novram`、`--cpu`）互斥。
+</Note>
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--gpu-only` | — | 将所有内容（文本编码器、CLIP 等）存储并运行在 GPU 上。 |
+| `--highvram` | — | 使用后不将模型卸载到 CPU，保留在 GPU 内存中。 |
+| `--lowvram` | — | 启用动态 VRAM 时无效。否则将文本编码器运行在 CPU 上。 |
+| `--novram` | — | `--lowvram` 仍不足时使用，最小化 VRAM 占用。 |
+| `--cpu` | — | 全部使用 CPU（较慢）。 |
+| `--reserve-vram` `GB` | 依系统而定 | 为操作系统和其他软件预留的 VRAM（GB）。 |
+| `--async-offload` `[NUM_STREAMS]` | Nvidia 上默认启用 | 异步权重卸载。可选流数量（默认：2）。 |
+| `--disable-async-offload` | — | 禁用异步权重卸载。 |
+| `--disable-dynamic-vram` | — | 禁用动态 VRAM，使用基于估算的模型加载。 |
+| `--enable-dynamic-vram` | Nvidia 上自动 | 在默认未启用的系统上启用动态 VRAM。 |
+| `--fast-disk` | 关闭 | 优先使用磁盘-backed 动态加载而非未固定 RAM。适合高速 NVMe。 |
+| `--force-non-blocking` | 关闭 | 强制非阻塞张量操作。可能有助于非 Nvidia 系统；可能导致部分工作流异常。 |
+| `--disable-smart-memory` | 关闭 | 积极卸载到 RAM，而非尽量保留在 VRAM 中。 |
+| `--disable-pinned-memory` | 关闭 | 禁用固定内存（pinned memory）。 |
+| `--mmap-torch-files` | 关闭 | 加载 ckpt/pt 文件时使用 mmap。 |
+| `--disable-mmap` | 关闭 | 加载 safetensors 时不使用 mmap。 |
+
+## 性能与调试
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--fast` `[OPT...]` | 关闭 | 启用可能影响质量或稳定性的实验性优化。单独使用 `--fast` 启用全部。可选项：`fp16_accumulation`、`fp8_matrix_mult`、`cublas_ops`、`autotune`。 |
+| `--deterministic` | 关闭 | 尽可能使用较慢的确定性 PyTorch 算法。不保证所有情况下图像完全一致。 |
+| `--default-hashing-function` | `sha256` | 重复文件名/内容比较使用的哈希函数。可选：`md5`、`sha1`、`sha256`、`sha512`。 |
+
+```bash
+# 启用全部 fast 优化（实验性）
+python main.py --fast
+
+# 仅启用特定优化
+python main.py --fast fp16_accumulation cublas_ops
+```
+
+## ComfyUI Manager
+
+安装说明请参阅 [ComfyUI-Manager 安装](/zh/manager/install)。
+
+| 参数 | 说明 |
+|------|------|
+| `--enable-manager` | 启用 ComfyUI-Manager。 |
+| `--disable-manager-ui` | 仅禁用 Manager UI 和端点。后台任务（定时安装等）继续运行。需要 `--enable-manager`。 |
+| `--enable-manager-legacy-ui` | 使用旧版 Manager UI。需要 `--enable-manager`。 |
+
+## 自定义节点与 API 节点
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--disable-all-custom-nodes` | 关闭 | 禁用加载所有自定义节点。 |
+| `--whitelist-custom-nodes` `FOLDER...` | — | 在启用 `--disable-all-custom-nodes` 时仍加载的自定义节点文件夹。 |
+| `--disable-api-nodes` | 关闭 | 禁用 API 节点，并阻止前端与互联网通信。 |
+| `--disable-metadata` | 关闭 | 禁用将提示词元数据保存到输出文件。 |
+
+```bash
+# 排查自定义节点问题
+python main.py --disable-all-custom-nodes
+
+# 仅允许特定自定义节点
+python main.py --disable-all-custom-nodes --whitelist-custom-nodes ComfyUI-Manager
+```
+
+## 前端与 API
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--front-end-version` | `comfyanonymous/ComfyUI@latest` | 前端版本，格式为 `[owner]/[repo]@[version]`。需联网从 GitHub releases 下载。版本可为 `latest` 或 semver（如 `1.0.0`）。 |
+| `--front-end-root` `PATH` | — | 前端目录的本地路径。覆盖 `--front-end-version`。 |
+| `--comfy-api-base` | `https://api.comfy.org` | ComfyUI API 基础 URL。 |
+| `--database-url` | `sqlite:///<ComfyUI>/user/comfyui.db` | 数据库 URL。内存数据库使用 `sqlite:///:memory:`。 |
+| `--enable-assets` | 关闭 | 启用资产系统（API 路由、数据库同步、后台扫描）。 |
+| `--feature-flag` `KEY[=VALUE]` | — | 设置服务器功能开关。仅 `KEY` 时设为 true。可重复指定。布尔值和数字会自动转换。 |
+| `--list-feature-flags` | — | 以 JSON 输出已知 CLI 功能开关并退出。 |
+
+```bash
+# 列出可用功能开关
+python main.py --list-feature-flags
+
+# 设置功能开关
+python main.py --feature-flag show_signin_button=true
+```
+
+## 日志与其他
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--verbose` `[LEVEL]` | `INFO` | 日志级别。可选：`DEBUG`、`INFO`、`WARNING`、`ERROR`、`CRITICAL`。单独使用 `--verbose` 设为 `DEBUG`。 |
+| `--log-stdout` | 关闭 | 将正常进程输出发送到 stdout 而非 stderr。 |
+| `--dont-print-server` | 关闭 | 不在控制台打印服务器输出。 |
+| `--multi-user` | 关闭 | 启用按用户隔离存储。 |
+| `--quick-test-for-ci` | 关闭 | CI 快速启动测试。初始化后立即退出。 |
+
+---
+
+<Note>
+  本参考基于 ComfyUI 的 [`comfy/cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py)。升级 ComfyUI 后，请运行 `python main.py --help` 或对照本地 [`cli_args.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/cli_args.py) 检查是否有新增或变更的参数。
+</Note>

--- a/zh/installation/manual_install.mdx
+++ b/zh/installation/manual_install.mdx
@@ -60,6 +60,8 @@ git clone https://github.com/Comfy-Org/ComfyUI.git
     </Step>
 </Steps>
 
+如需高级服务器配置（自定义端口、局域网访问、VRAM 模式等），请参阅[启动参数参考](/zh/development/comfyui-server/startup-flags)。
+
 ## 如何更新 ComfyUI
 
 <Steps>


### PR DESCRIPTION
- Added a new page for Startup Flags in the ComfyUI server documentation.
- Updated links in various sections to point to the new Startup Flags reference.
- Changed command examples in the comms_overview to use `--disable-auto-launch` instead of `--headless`.
- Enhanced tips and references across multiple languages (EN, ZH, JA) to guide users on startup options.