### PR TITLE
fix(ko): point snippet imports to ko versions

### DIFF
--- a/ko/comfy-cli/getting-started.mdx
+++ b/ko/comfy-cli/getting-started.mdx
@@ -4,8 +4,8 @@ translationSourceHash: 81a03067
 translationFrom: comfy-cli/getting-started.mdx
 ---
 
-import InstallComfyFromCli from "/snippets/install-comfy-from-cli.mdx";
-import InstallCli from "/snippets/install-comfycli.mdx";
+import InstallComfyFromCli from "/snippets/ko/install-comfy-from-cli.mdx";
+import InstallCli from "/snippets/ko/install-comfycli.mdx";
 
 ### 개요
 

--- a/ko/development/core-concepts/models.mdx
+++ b/ko/development/core-concepts/models.mdx
@@ -6,7 +6,7 @@ translationSourceHash: ce630403
 translationFrom: development/core-concepts/models.mdx
 ---
 
-import ExternalModels from "/snippets/install/add-external-models.mdx"
+import ExternalModels from "/snippets/ko/install/add-external-models.mdx"
 
 ## 모델의 기본 개념
 

--- a/ko/get_started/first_generation.mdx
+++ b/ko/get_started/first_generation.mdx
@@ -7,7 +7,7 @@ translationSourceHash: d4f51386
 translationFrom: get_started/first_generation.mdx
 ---
 
-import InstallLink from "/snippets/install/install-link.mdx"
+import InstallLink from "/snippets/ko/install/install-link.mdx"
 
 <Note>
 이 가이드는 자신의 기기에서 ComfyUI를 실행하는 **로컬 사용자**를 대상으로 합니다. 로컬에 아무것도 설치하지 않으려면 공식 클라우드 서비스를 이용해 보세요.

--- a/ko/installation/comfyui_portable_windows.mdx
+++ b/ko/installation/comfyui_portable_windows.mdx
@@ -7,8 +7,8 @@ translationSourceHash: 76ee93db
 translationFrom: installation/comfyui_portable_windows.mdx
 ---
 
-import FirstGeneration from "/snippets/install/first-generation.mdx"
-import AddExternalModels from "/snippets/install/add-external-models.mdx"
+import FirstGeneration from "/snippets/ko/install/first-generation.mdx"
+import AddExternalModels from "/snippets/ko/install/add-external-models.mdx"
 
 **ComfyUI 포터블**은 독립적인 **Python (python_embeded)** 환경을 통합한, ComfyUI를 실행하는 데 필요한 완전한 ComfyUI Windows 버전의 독립형 패키지입니다. 압축을 풀기만 하면 바로 사용할 수 있습니다.
 

--- a/ko/installation/system_requirements.mdx
+++ b/ko/installation/system_requirements.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 3d202bd6
 translationFrom: installation/system_requirements.mdx
 ---
 
-import InstallLink from "/snippets/install/install-link.mdx"
+import InstallLink from "/snippets/ko/install/install-link.mdx"
 
 이 가이드에서는 ComfyUI를 설치하기 위한 시스템 요구사항을 소개합니다. ComfyUI는 수시로 업데이트되기 때문에 이 문서가 최신 상태로 유지되지 않을 수 있습니다. 관련 지침은 [ComfyUI](https://github.com/Comfy-Org/ComfyUI)를 참조해 주세요.
 

--- a/ko/installation/update_comfyui.mdx
+++ b/ko/installation/update_comfyui.mdx
@@ -7,8 +7,8 @@ translationSourceHash: 37fe7f31
 translationFrom: installation/update_comfyui.mdx
 ---
 
-import InstallLink from "/snippets/install/install-link.mdx"
-import UpdateRequirement from "/snippets/install/update-requirement.mdx"
+import InstallLink from "/snippets/ko/install/install-link.mdx"
+import UpdateRequirement from "/snippets/ko/install/update-requirement.mdx"
 
 다양한 섹션에서 다양한 설치 방법을 통해 ComfyUI 업데이트에 대해 다뤘지만, 이 포괄적인 가이드는 모든 업데이트 절차를 한데 모아 사용자가 ComfyUI를 명확히 업데이트하는 방법을 이해하도록 돕습니다.
 

--- a/ko/interface/appearance.mdx
+++ b/ko/interface/appearance.mdx
@@ -7,8 +7,8 @@ translationSourceHash: 03842cc7
 translationFrom: interface/appearance.mdx
 ---
 
-import UserDirectory from "/snippets/install/user-directory.mdx"
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import UserDirectory from "/snippets/ko/install/user-directory.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/credits.mdx
+++ b/ko/interface/credits.mdx
@@ -7,7 +7,7 @@ translationSourceHash: b57afa08
 translationFrom: interface/credits.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/3d.mdx
+++ b/ko/interface/settings/3d.mdx
@@ -7,7 +7,7 @@ translationSourceHash: a8b7a01b
 translationFrom: interface/settings/3d.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/about.mdx
+++ b/ko/interface/settings/about.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 23ce57df
 translationFrom: interface/settings/about.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/comfy-desktop.mdx
+++ b/ko/interface/settings/comfy-desktop.mdx
@@ -7,7 +7,7 @@ translationSourceHash: b0a5f5bd
 translationFrom: interface/settings/comfy-desktop.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/comfy.mdx
+++ b/ko/interface/settings/comfy.mdx
@@ -7,7 +7,7 @@ translationSourceHash: dc624283
 translationFrom: interface/settings/comfy.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/extension.mdx
+++ b/ko/interface/settings/extension.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 1931323f
 translationFrom: interface/settings/extension.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/lite-graph.mdx
+++ b/ko/interface/settings/lite-graph.mdx
@@ -7,7 +7,7 @@ translationSourceHash: bc88f9c1
 translationFrom: interface/settings/lite-graph.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/mask-editor.mdx
+++ b/ko/interface/settings/mask-editor.mdx
@@ -7,7 +7,7 @@ translationSourceHash: b45614ce
 translationFrom: interface/settings/mask-editor.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/settings/server-config.mdx
+++ b/ko/interface/settings/server-config.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 49fcc47e
 translationFrom: interface/settings/server-config.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/interface/shortcuts.mdx
+++ b/ko/interface/shortcuts.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 457d7181
 translationFrom: interface/shortcuts.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 {/*
 설명: "ComfyUI용 키보드 및 마우스 단축키 목록"

--- a/ko/interface/user.mdx
+++ b/ko/interface/user.mdx
@@ -7,7 +7,7 @@ translationSourceHash: 12ab3822
 translationFrom: interface/user.mdx
 ---
 
-import SettingsMenuContext from "/snippets/interface/settings-menu-context.mdx"
+import SettingsMenuContext from "/snippets/ko/interface/settings-menu-context.mdx"
 
 <SettingsMenuContext />
 

--- a/ko/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/ko/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 68826c13
 translationFrom: tutorials/audio/ace-step/ace-step-v1.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 ACE-Step는 중국 팀 StepFun과 ACE Studio가 공동 개발한 오픈소스 기반 음악 생성 모델로, 음악 창작자들에게 효율적이고 유연하며 고품질의 음악 생성 및 편집 도구를 제공하는 것을 목표로 합니다.
 

--- a/ko/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/ko/tutorials/flux/flux-1-kontext-dev.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 8783bd06
 translationFrom: tutorials/flux/flux-1-kontext-dev.mdx
 ---
 
-import PromptTechniques from "/snippets/tutorials/flux/prompt-techniques.mdx";
+import PromptTechniques from "/snippets/ko/tutorials/flux/prompt-techniques.mdx";
 import UpdateReminder from '/snippets/tutorials/update-reminder.mdx'
 
 <iframe

--- a/ko/tutorials/image/ideogram/ideogram-v4.mdx
+++ b/ko/tutorials/image/ideogram/ideogram-v4.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 95224a13
 translationFrom: tutorials/image/ideogram/ideogram-v4.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Ideogram 4.0은 Ideogram에서 출시한 최신 텍스트-to-이미지 모델로, 완전히 자체 하드웨어에서 실행되는 오픈소스 모델입니다. 이 모델은 뛰어난 포토리얼리즘 품질과 정확한 텍스트 렌더링, 정밀한 스타일 제어를 제공합니다. 일반적인 자연어 또는 **구조화된 JSON 프롬프트**를 사용해 레이아웃, 색상, 이미지 내 텍스트까지 세밀하게 제어할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image.mdx
+++ b/ko/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 30d64c5d
 translationFrom: tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 FLUX 1.1 Pro Ultra는 BlackForestLabs가 제공하는 고성능 AI 이미지 생성 도구로, 초고해상도와 효율적인 생성 기능을 갖추고 있습니다. 최대 4MP 해상도(표준 버전의 4배)를 지원하며, 단일 이미지 생성 시간은 10초 미만으로 유지됩니다. 이는 유사한 고해상도 모델에 비해 2.5배 빠른 속도입니다.
 

--- a/ko/tutorials/partner-nodes/black-forest-labs/flux-1-kontext.mdx
+++ b/ko/tutorials/partner-nodes/black-forest-labs/flux-1-kontext.mdx
@@ -6,9 +6,9 @@ translationSourceHash: 115e6de3
 translationFrom: tutorials/partner-nodes/black-forest-labs/flux-1-kontext.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import PromptTechniques from "/snippets/tutorials/flux/prompt-techniques.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import PromptTechniques from "/snippets/ko/tutorials/flux/prompt-techniques.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 FLUX.1 컨텍스트는 블랙 포레스트 랩스가 개발한 전문적인 이미지 대 이미지 편집 모델로, 이미지의 문맥을 지능적으로 이해하고 정밀하게 편집하는 데 중점을 둡니다. 
 객체 수정, 스타일 전송, 배경 교체, 캐릭터 일관성 편집, 텍스트 편집 등 복잡한 설명 없이 다양한 편집 작업을 수행할 수 있습니다. 

--- a/ko/tutorials/partner-nodes/faq.mdx
+++ b/ko/tutorials/partner-nodes/faq.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "FAQ"
 translationSourceHash: 9533cb6b
 translationFrom: tutorials/partner-nodes/faq.mdx
 ---
-import Faq from "/snippets/tutorials/partner-nodes/faq.mdx";
+import Faq from "/snippets/ko/tutorials/partner-nodes/faq.mdx";
 
 이 기사에서는 파트너 노드 사용과 관련된 일반적인 질문들을 다룹니다.
 

--- a/ko/tutorials/partner-nodes/google/gemini.mdx
+++ b/ko/tutorials/partner-nodes/google/gemini.mdx
@@ -6,8 +6,8 @@ translationSourceHash: ddd327ee
 translationFrom: tutorials/partner-nodes/google/gemini.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Google Gemini는 구글이 개발한 강력한 AI 모델로, 대화 및 텍스트 생성 기능을 지원합니다. 현재 ComfyUI는 Google Gemini API를 통합하여, ComfyUI에서 관련 노드를 직접 사용해 대화 기능을 완성할 수 있도록 지원합니다.
 

--- a/ko/tutorials/partner-nodes/google/nano-banana-pro.mdx
+++ b/ko/tutorials/partner-nodes/google/nano-banana-pro.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 84e56ae1
 translationFrom: tutorials/partner-nodes/google/nano-banana-pro.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Nano Banana Pro는 Google DeepMind의 새로운 주력 모델로, 고화질 이미지 생성과 편집을 위한 최신 기술을 제공합니다. 이 모델은 4K 생성, 텍스트 렌더링, 캐릭터 일관성 등 첨단 기능을 통해 일상적인 창작을 넘어 프로덕션 수준의 시각 자료까지 가능하게 합니다.
 

--- a/ko/tutorials/partner-nodes/hunyuan3d/model-generation.mdx
+++ b/ko/tutorials/partner-nodes/hunyuan3d/model-generation.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 655cf4c4
 translationFrom: tutorials/partner-nodes/hunyuan3d/model-generation.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Hunyuan 3D 3.0은 텐센트가 개발한 최첨단 3D 생성 모델로, 몇 분 내에 3D 콘텐츠를 제작할 수 있게 해줍니다. 기존의 3D 모델링 파이프라인보다 훨씬 낮은 진입 장벽으로 텍스트 프롬프트, 이미지 또는 스케치로부터 생산 가능한 3D 자산을 생성할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/ideogram/ideogram-v3.mdx
+++ b/ko/tutorials/partner-nodes/ideogram/ideogram-v3.mdx
@@ -6,8 +6,8 @@ translationSourceHash: d2cedd33
 translationFrom: tutorials/partner-nodes/ideogram/ideogram-v3.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Ideogram 3.0은 Ideogram이 개발한 강력한 텍스트-to-이미지 모델로, 사실적인 품질과 정확한 텍스트 렌더링, 일관된 스타일 제어로 유명합니다.
 

--- a/ko/tutorials/partner-nodes/ideogram/ideogram-v4.mdx
+++ b/ko/tutorials/partner-nodes/ideogram/ideogram-v4.mdx
@@ -6,8 +6,8 @@ translationSourceHash: beef952f
 translationFrom: tutorials/partner-nodes/ideogram/ideogram-v4.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Ideogram 4.0은 Ideogram의 최신 텍스트-to이미지 모델로, 뛰어난 사진과 같은 사실감, 정확한 텍스트 렌더링 및 정밀한 스타일 제어 기능을 제공합니다. 일반적인 자연어 또는 **구조화된 JSON 프롬프트**를 사용해 레이아웃, 색상 및 이미지 내 텍스트에 대한 세밀한 제어가 가능합니다.
 

--- a/ko/tutorials/partner-nodes/kling/kling-motion-control.mdx
+++ b/ko/tutorials/partner-nodes/kling/kling-motion-control.mdx
@@ -6,8 +6,8 @@ translationSourceHash: f28d036f
 translationFrom: tutorials/partner-nodes/kling/kling-motion-control.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Kling 2.6 모션 컨트롤은 Kuaishou가 개발한 특수 다중모달 모델로, 참조 동영상에서 캐릭터 이미지로 정밀한 모션 전송이 가능합니다. **참조 이미지**(귀하의 캐릭터)와 **모션 참조 동영상**(동작)을 결합하면 AI가 동영상의 움직임, 표정, 템포를 정적 캐릭터에 적용하면서도 캐릭터의 정체성을 유지합니다.
 

--- a/ko/tutorials/partner-nodes/luma/luma-image-to-image.mdx
+++ b/ko/tutorials/partner-nodes/luma/luma-image-to-image.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 6eadbdbe
 translationFrom: tutorials/partner-nodes/luma/luma-image-to-image.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Luma 이미지 to 이미지](/built-in-nodes/partner-node/image/luma/luma-image-to-image) 노드를 사용하면 Luma AI 기술을 활용해 텍스트 프롬프트에 따라 기존 이미지를 수정하면서도 원본 이미지의 특정 특징과 구조는 유지할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/luma/luma-image-to-video.mdx
+++ b/ko/tutorials/partner-nodes/luma/luma-image-to-video.mdx
@@ -6,8 +6,8 @@ translationSourceHash: c16eec4f
 translationFrom: tutorials/partner-nodes/luma/luma-image-to-video.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Luma 이미지에서 비디오](/built-in-nodes/partner-node/video/luma/luma-image-to-video) 노드를 사용하면 Luma AI의 고급 기술을 통해 정적 이미지를 부드럽고 역동적인 비디오로 변환할 수 있어 이미지에 생동감과 움직임을 더할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/luma/luma-text-to-image.mdx
+++ b/ko/tutorials/partner-nodes/luma/luma-text-to-image.mdx
@@ -6,8 +6,8 @@ translationSourceHash: f0284d80
 translationFrom: tutorials/partner-nodes/luma/luma-text-to-image.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Luma 텍스트-to-이미지](/built-in-nodes/partner-node/image/luma/luma-text-to-image) 노드를 사용하면 Luma AI의 고급 기술을 통해 텍스트 프롬프트로부터 고품질 이미지를 생성할 수 있으며, 사진과 같은 사실적인 콘텐츠와 예술적 스타일의 이미지를 만들 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/luma/luma-text-to-video.mdx
+++ b/ko/tutorials/partner-nodes/luma/luma-text-to-video.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 1e62e5e2
 translationFrom: tutorials/partner-nodes/luma/luma-text-to-video.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Luma 텍스트 to 비디오](/built-in-nodes/partner-node/video/luma/luma-text-to-video) 노드를 사용하면 Luma AI의 혁신적인 비디오 생성 기술을 통해 텍스트 설명을 바탕으로 고품질의 부드러운 비디오를 만들 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/moonvalley/moonvalley-video-generation.mdx
+++ b/ko/tutorials/partner-nodes/moonvalley/moonvalley-video-generation.mdx
@@ -11,8 +11,8 @@ translationFrom: tutorials/partner-nodes/moonvalley/moonvalley-video-generation.
 </Warning>
 
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 <iframe
   className="w-full aspect-video rounded-xl"

--- a/ko/tutorials/partner-nodes/openai/chat.mdx
+++ b/ko/tutorials/partner-nodes/openai/chat.mdx
@@ -6,8 +6,8 @@ translationSourceHash: e4c0b73e
 translationFrom: tutorials/partner-nodes/openai/chat.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 OpenAI는 생성형 AI에 중점을 둔 회사로, 강력한 대화 기능을 제공합니다. 현재 ComfyUI는 OpenAI API를 통합해, ComfyUI에서 관련 노드를 직접 사용해 대화 기능을 완성할 수 있게 되었습니다.
 

--- a/ko/tutorials/partner-nodes/openai/dall-e-2.mdx
+++ b/ko/tutorials/partner-nodes/openai/dall-e-2.mdx
@@ -7,9 +7,9 @@ translationSourceHash: 4a59370b
 translationFrom: tutorials/partner-nodes/openai/dall-e-2.mdx
 ---
 
-import Faq from "/snippets/tutorials/partner-nodes/faq.mdx";
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import Faq from "/snippets/ko/tutorials/partner-nodes/faq.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 ![OpenAI DALL·E 2 노드 스크린샷](/images/comfy_core/api_nodes/openai-dall-e-2.jpg)
 

--- a/ko/tutorials/partner-nodes/openai/dall-e-3.mdx
+++ b/ko/tutorials/partner-nodes/openai/dall-e-3.mdx
@@ -7,9 +7,9 @@ translationSourceHash: dcefc22c
 translationFrom: tutorials/partner-nodes/openai/dall-e-3.mdx
 ---
 
-import Faq from "/snippets/tutorials/partner-nodes/faq.mdx";
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import Faq from "/snippets/ko/tutorials/partner-nodes/faq.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 OpenAI DALL·E 3는 ComfyUI 파트너 노드 시리즈의 일부로, 사용자가 OpenAI의 **DALL·E 3** 모델을 통해 이미지를 생성할 수 있도록 합니다. 이 노드는 텍스트 기반 이미지 생성 기능을 지원합니다.
 

--- a/ko/tutorials/partner-nodes/openai/gpt-image-1.mdx
+++ b/ko/tutorials/partner-nodes/openai/gpt-image-1.mdx
@@ -7,9 +7,9 @@ translationSourceHash: 8fe84880
 translationFrom: tutorials/partner-nodes/openai/gpt-image-1.mdx
 ---
 
-import Faq from "/snippets/tutorials/partner-nodes/faq.mdx";
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import Faq from "/snippets/ko/tutorials/partner-nodes/faq.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 ![OpenAI GPT-Image-1 노드 스크린샷](/images/comfy_core/api_nodes/openai-gpt-image-1.jpg)
 

--- a/ko/tutorials/partner-nodes/overview.mdx
+++ b/ko/tutorials/partner-nodes/overview.mdx
@@ -6,8 +6,8 @@ translationSourceHash: dff896f5
 translationFrom: tutorials/partner-nodes/overview.mdx
 ---
 
-import 요구사항 from "/snippets/tutorials/partner-nodes/requirements.mdx";
-import FAQ from "/snippets/tutorials/partner-nodes/faq.mdx";
+import 요구사항 from "/snippets/ko/tutorials/partner-nodes/requirements.mdx";
+import FAQ from "/snippets/ko/tutorials/partner-nodes/faq.mdx";
 
 파트너 노드는 ComfyUI가 API 요청을 통해 폐쇄형 모델을 호출하는 새로운 방식으로, 복잡한 API 키 설정 없이 ComfyUI 사용자들이 외부의 최신 AI 모델에 접근할 수 있도록 제공합니다.
 

--- a/ko/tutorials/partner-nodes/recraft/recraft-text-to-image.mdx
+++ b/ko/tutorials/partner-nodes/recraft/recraft-text-to-image.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 89cef53b
 translationFrom: tutorials/partner-nodes/recraft/recraft-text-to-image.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Recraft Text to Image](/built-in-nodes/partner-node/image/recraft/recraft-text-to-image) 노드를 사용하면 텍스트 설명을 기반으로 Recraft AI의 이미지 생성 기술을 활용해 다양한 스타일의 고품질 이미지를 만들 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/rodin/model-generation.mdx
+++ b/ko/tutorials/partner-nodes/rodin/model-generation.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 87f76228
 translationFrom: tutorials/partner-nodes/rodin/model-generation.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Hyper3D Rodin (hyper3d.ai)은 인공지능을 통해 고품질의 프로덕션 준비가 된 3D 모델과 재료를 신속하게 생성하는 데 중점을 둔 플랫폼입니다.
 ComfyUI는 이제 해당 Rodin 모델 생성 API를 기본적으로 통합하여, ComfyUI에서 관련 노드를 편리하게 사용해 모델을 생성할 수 있게 되었습니다.

--- a/ko/tutorials/partner-nodes/runway/image-generation.mdx
+++ b/ko/tutorials/partner-nodes/runway/image-generation.mdx
@@ -6,8 +6,8 @@ translationSourceHash: f4a05542
 translationFrom: tutorials/partner-nodes/runway/image-generation.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Runway는 생성형 AI에 중점을 둔 회사로, 강력한 이미지 생성 기능을 제공합니다. 이 회사의 모델들은 스타일 전환, 이미지 확장, 디테일 제어와 같은 기능을 지원합니다. 현재 ComfyUI는 Runway API를 통합하여, ComfyUI에서 관련 노드를 직접 사용해 이미지를 생성할 수 있게 되었습니다.
 

--- a/ko/tutorials/partner-nodes/runway/video-generation.mdx
+++ b/ko/tutorials/partner-nodes/runway/video-generation.mdx
@@ -6,8 +6,8 @@ translationSourceHash: c2d34696
 translationFrom: tutorials/partner-nodes/runway/video-generation.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Runway는 생성형 AI에 중점을 둔 기업으로, 강력한 동영상 생성 기능을 제공합니다. 현재 ComfyUI는 Runway API를 통합하여, 동영상 생성을 위해 ComfyUI에서 관련 노드를 직접 사용할 수 있게 했습니다.
 

--- a/ko/tutorials/partner-nodes/sonilo/video-to-music.mdx
+++ b/ko/tutorials/partner-nodes/sonilo/video-to-music.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 828bd9ac
 translationFrom: tutorials/partner-nodes/sonilo/video-to-music.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Sonilo는 AI 기반의 비디오 음악 서비스로, 당신의 영상에 맞춰 동기화된 사운드트랙을 생성합니다. 시각적 요소와 속도, 감정적 신호를 분석해 프레임별로 타임라인에 맞춘 음악을 만들어냅니다.
 

--- a/ko/tutorials/partner-nodes/stability-ai/stable-audio.mdx
+++ b/ko/tutorials/partner-nodes/stability-ai/stable-audio.mdx
@@ -6,8 +6,8 @@ translationSourceHash: eda368b6
 translationFrom: tutorials/partner-nodes/stability-ai/stable-audio.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Stability AI Stable Audio 2.5 파트너 노드를 사용하면 Stability AI의 최신 음성 생성 모델을 활용해 텍스트 프롬프트, 오디오 변환 및 오디오 인페인팅 기능을 통해 고품질 음악을 만들 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/stability-ai/stable-diffusion-3-5-image.mdx
+++ b/ko/tutorials/partner-nodes/stability-ai/stable-diffusion-3-5-image.mdx
@@ -6,8 +6,8 @@ translationSourceHash: b8324f23
 translationFrom: tutorials/partner-nodes/stability-ai/stable-diffusion-3-5-image.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Stability AI Stable Diffusion 3.5 이미지](/built-in-nodes/partner-node/image/stability-ai/stability-ai-stable-diffusion-3-5-image) 노드를 사용하면 Stability AI의 Stable Diffusion 3.5 모델을 통해 텍스트 프롬프트나 참조 이미지를 통해 고품질의 세밀한 이미지 콘텐츠를 생성할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/stability-ai/stable-image-ultra.mdx
+++ b/ko/tutorials/partner-nodes/stability-ai/stable-image-ultra.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 3f350a0d
 translationFrom: tutorials/partner-nodes/stability-ai/stable-image-ultra.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [Stability Stable Image Ultra](/images/built-in-nodes/api_nodes/stability-ai/stability-ai-stable-image-ultra.jpg) 노드를 사용하면 Stability AI의 Stable Image Ultra 모델을 활용해 텍스트 프롬프트나 참조 이미지를 통해 고품질의 세밀한 이미지 콘텐츠를 생성할 수 있습니다.
 

--- a/ko/tutorials/partner-nodes/tripo/model-generation.mdx
+++ b/ko/tutorials/partner-nodes/tripo/model-generation.mdx
@@ -6,8 +6,8 @@ translationSourceHash: 29fbd5dc
 translationFrom: tutorials/partner-nodes/tripo/model-generation.mdx
 ---
 
-import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Tripo AI는 생성형 AI 3D 모델링에 중점을 둔 기업입니다. 사용자 친화적인 플랫폼과 API 서비스를 제공하여 텍스트 프롬프트나 2D 이미지(단일 또는 다중)를 빠르게 고품질 3D 모델로 변환할 수 있습니다.
 ComfyUI는 현재 해당 Tripo API를 기본적으로 통합하여 ComfyUI에서 관련 노드를 편리하게 사용해 모델을 생성할 수 있도록 지원합니다.

--- a/ko/tutorials/video/hunyuan/hunyuan-video-1-5.mdx
+++ b/ko/tutorials/video/hunyuan/hunyuan-video-1-5.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 0b15fd89
 translationFrom: tutorials/video/hunyuan/hunyuan-video-1-5.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [HunyuanVideo 1.5](https://github.com/Tencent/HunyuanVideo)는 텐센트의 Hunyuan팀이 개발한 경량 83억 파라미터 모델입니다. 이 모델은 소비자용 GPU(24GB VRAM)에서 플래그십 수준의 비디오 생성 성능을 제공하며, 품질을 저하시키지 않으면서 진입 장벽을 대폭 낮췄습니다.
 

--- a/ko/tutorials/video/hunyuan/hunyuan-video.mdx
+++ b/ko/tutorials/video/hunyuan/hunyuan-video.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 07e5279b
 translationFrom: tutorials/video/hunyuan/hunyuan-video.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 <video
   controls

--- a/ko/tutorials/video/kandinsky/kandinsky-5.mdx
+++ b/ko/tutorials/video/kandinsky/kandinsky-5.mdx
@@ -6,7 +6,7 @@ translationSourceHash: e88cc330
 translationFrom: tutorials/video/kandinsky/kandinsky-5.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [칸딘스키 5.0](https://huggingface.co/kandinskylab/Kandinsky-5.0-I2V-Lite-5s)은 [칸딘스키 랩](https://huggingface.co/kandinskylab)에서 개발한 비디오 및 이미지 생성용 확산 모델 패밀리입니다. 칸딘스키 5.0 T2V Lite는 경량 2B 파라미터 모델로, 최고 수준의 오픈소스 비디오 생성 모델 중 하나이며 최대 10초 길이의 비디오를 생성할 수 있습니다.
 

--- a/ko/tutorials/video/ltxv.mdx
+++ b/ko/tutorials/video/ltxv.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 7d8a0192
 translationFrom: tutorials/video/ltxv.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 [LTX-Video](https://huggingface.co/Lightricks/LTX-Video)는 lightricks가 개발한 매우 효율적인 비디오 모델입니다. 이 모델의 중요한 점은 길고 상세한 프롬프트를 제공하는 것입니다.
 

--- a/ko/tutorials/video/wan/fun-control.mdx
+++ b/ko/tutorials/video/wan/fun-control.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 04505266
 translationFrom: tutorials/video/wan/fun-control.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 ## Wan2.1-Fun-Control 소개
 

--- a/ko/tutorials/video/wan/fun-inp.mdx
+++ b/ko/tutorials/video/wan/fun-inp.mdx
@@ -6,7 +6,7 @@ translationSourceHash: c6685a1c
 translationFrom: tutorials/video/wan/fun-inp.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 ## Wan2.1-Fun-InP 소개
 

--- a/ko/tutorials/video/wan/vace.mdx
+++ b/ko/tutorials/video/wan/vace.mdx
@@ -7,7 +7,7 @@ translationFrom: tutorials/video/wan/vace.mdx
 ---
 
 import CancelBypass from '/snippets/interface/cancel-bypass.mdx'
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 <Warning>
 템플릿을 조정하고 CausVid LoRA에 대한 관련 사용법과 지침을 추가했으므로, 이 문서를 업데이트해야 하며 일정 준비 시간이 필요합니다. 그때까지는 템플릿의 참고사항을 참조해 주시기 바랍니다.

--- a/ko/tutorials/video/wan/wan-flf.mdx
+++ b/ko/tutorials/video/wan/wan-flf.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 9b049266
 translationFrom: tutorials/video/wan/wan-flf.mdx
 ---
 
-import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
+import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
 Wan FLF2V (첫 번째와 마지막 프레임 동영상 생성)는 알리바바 퉁이 완샹팀이 개발한 오픈소스 동영상 생성 모델입니다. 이 모델의 오픈소스 라이선스는 [Apache 2.0](https://github.com/Wan-Video/Wan2.1?tab=Apache-2.0-1-ov-file)입니다.
 사용자는 시작 프레임과 종료 프레임으로 두 장의 이미지만 제공하면, 모델이 자동으로 중간 전환 프레임을 생성해 논리적으로 일관되고 자연스럽게 흐르는 720p 고화질 동영상을 출력합니다.


### PR DESCRIPTION
## Problem

On the Korean docs site (docs.comfy.org/ko), some pages render parts of their content in **English** even though the page body is translated. The affected blocks are the shared snippets embedded in each page — e.g. the install-method accordion, "Adding Extra Model Paths", the settings-menu hint, and the tutorial update reminders.

The cause is that the Korean pages import these snippets from the **English snippet path** (`/snippets/...`) instead of the Korean one (`/snippets/ko/...`). The Korean snippet translations already exist under `/snippets/ko/`; the pages just weren't pointing to them. (This was an omission from the initial ko bootstrap in #1109 — the translation step translated the body text but left the `import ... from "/snippets/..."` path strings as-is. The `ja` pages already use `/snippets/ja/`.)

**Before** (live site — English snippet rendered on a Korean page):

<img width="1439" height="772" alt="image" src="https://github.com/user-attachments/assets/9cda1fc5-8e3d-46c8-ab1c-7ccd0cf32714" />

## Fix

Point the snippet imports on Korean pages to their Korean versions:

```diff
-import AddExternalModels from "/snippets/install/add-external-models.mdx"
+import AddExternalModels from "/snippets/ko/install/add-external-models.mdx"
```

This is a **path-only change** — no snippet content is added or translated, since every referenced `/snippets/ko/...` file already exists.

**After** (local `mint dev` — Korean snippet now renders):

<img width="1439" height="770" alt="image" src="https://github.com/user-attachments/assets/81e6f58f-fb3b-4330-beff-7eb1e7f4fbcf" />

## Scope

- **57 files**, **92 import statements**, **13 distinct snippets**
- By section: `installation` 3, `get_started` 1, `comfy-cli` 1, `development` 1, `interface` 12, `tutorials` 39
- Most-affected snippets: `tutorials/update-reminder` (36), `partner-nodes/req-hint` (26), `interface/settings-menu-context` (12)

## Notes

- Only the `import` path strings changed. `translationSourceHash` and other frontmatter are untouched, so this won't be overwritten by the auto-translate pipeline.
- Verified locally: no `/snippets/ko/ko/` double paths, no remaining English snippet imports on ko pages, and `mint dev` renders the previously-English blocks in Korean.