### PR TITLE
Add ComfyUI v0.26.0 changelog and CMS/i18n release improvements

### DIFF
--- a/.cursor/skills/cms-changelog-sync/SKILL.md
+++ b/.cursor/skills/cms-changelog-sync/SKILL.md
@@ -14,19 +14,60 @@ Push **draft** release notes to Strapi (`release-notes` content type). Docs chan
 
 ## Architecture
 
+Three **separate** steps — stop for human review between each:
+
 ```
-changelog/index.mdx              ← docs source of truth (do not shorten for CMS)
+changelog/index.mdx                    ← docs source of truth (full EN)
         │
-        ▼  pnpm cms:prepare:en / cms:prepare
-.github/scripts/cms/staging/
-  en/changelog/index.mdx         ← LLM-simplified popup EN
-  {zh,ja,ko,fr,ru,es}/…         ← translated from simplified EN
+        ▼  Step 1: pnpm cms:prepare:en
+staging/en/changelog/index.mdx         ← simplified popup EN → **review & approve**
         │
-        ▼  pnpm cms:sync
-Strapi CMS (draft only) → manual Publish → published-versions.json
+        ▼  Step 2: pnpm cms:prepare:locales
+staging/{zh,ja,ko,fr,ru,es}/…          ← translated from staging EN → **review & approve**
+        │
+        ▼  Step 3: pnpm cms:preview → cms:sync  (only after user confirms)
+Strapi CMS (draft) → manual Publish → published-versions.json
 ```
 
-**Never** edit docs `zh/changelog/` for CMS. **Never** auto-publish in Strapi.
+**Never** edit docs `zh/changelog/` for CMS. **Never** auto-publish in Strapi. **Never** use `pnpm translate` for CMS — that pipeline is for Mintlify docs only.
+
+## Three-step workflow (local)
+
+| Step | Command | What it does | Gate |
+|------|---------|--------------|------|
+| **1. Simplify EN** | `pnpm cms:prepare:en -- --force v0.26.0` | docs → LLM → `staging/en/` | Review EN staging |
+| **2. Translate** | `pnpm cms:prepare:locales -- --force v0.26.0` | `staging/en/` → `staging/{zh,ja,ko,fr,ru,es}/` | Review locale staging |
+| **3. Push CMS** | `pnpm cms:preview` then `pnpm cms:sync` | staging → Strapi **drafts** | Strapi review → `cms:publish` |
+
+`pnpm cms:prepare` without `--en-only` / `--translate-only` prints help and exits — use the step-specific scripts above.
+
+## Translation workflow (CMS staging)
+
+Step 2 only. **Input = simplified EN staging**, not docs changelog.
+
+```
+staging/en/changelog/index.mdx          ← input (Step 1 output, human-approved)
+        │
+        ▼  pnpm cms:prepare:locales -- v0.26.0
+staging/zh|ja|ko|fr|ru|es/changelog/…   ← output (popup copy per locale, ready to sync)
+        │
+        ▼  pnpm cms:sync  (Step 3, after user confirms)
+Strapi release-notes (draft)
+```
+
+| | Mintlify docs (`pnpm translate`) | CMS popup (`pnpm cms:prepare:locales`) |
+|--|----------------------------------|----------------------------------------|
+| English source | `changelog/index.mdx` (full docs) | `staging/en/changelog/index.mdx` (simplified popup) |
+| Output path | `zh/changelog/index.mdx`, etc. | `staging/zh/changelog/index.mdx`, etc. |
+| Purpose | Docs site | Strapi in-app notification |
+| Mix pipelines? | **No** | **No** |
+
+**Key points:**
+
+- `cms:prepare:locales` does **not** re-simplify English — it reads existing `staging/en/` only
+- If staging EN is missing the version, translate fails — run `cms:prepare:en` first
+- Target locales: **zh, ja, ko, fr, ru, es** (see `cms-config.json`)
+- `--force` re-translates existing locale blocks (common after manual EN edits)
 
 ## Environment (`.env.local`)
 
@@ -48,22 +89,40 @@ Config: `.github/scripts/cms/cms-config.json` → `simplify`
 
 | Rule | Value |
 |------|-------|
-| Total bullets per version | **3–5** (`max_bullets_total: 5`) |
-| Section headings max | **2** (`max_sections: 2`) |
+| Total bullets per version | **up to 10** (`max_bullets_total: 10`) |
+| Section headings max | **3** (`max_sections: 3`) |
+| Section order | **New Open-Source Model Support** → **New Node Updates** → **Partner Node Updates** |
 | Words per version | ~60–120 |
-| Bullet format | `[**Name**](pr_url): 5–12 word function` |
+| Bullet format | `[**Name**](pr_url): 6–12 words with one key trait` |
 | PR links | **Keep** when source has them; never invent URLs |
-| Sections allowed | `**New Open-Source Model Support**`, `**Partner Node Updates**` only |
-| Drop | Bug fixes, performance, Load3D, UI, internal refactors |
+| New Node Updates | Include meaningful entries from source **New Nodes** section (workflows, sockets, multimodal nodes) |
+| Drop | Bug fixes, performance, pure Load3D plumbing, internal refactors, **ComfyUI-WIKI dependency bumps** (see below) |
 
-Example staging output:
+Style: principle-only prompt in `cms-simplify-prompt.ts` (no concrete version examples — avoids LLM contamination).
+
+## ComfyUI-WIKI commits (omit from changelog)
+
+When curating `changelog/index.mdx` from ComfyUI git history, **do not add bullets** for commits routinely opened by **[ComfyUI-WIKI](https://github.com/Comfy-Org/ComfyUI-WIKI)** — they are dependency/content syncs, not core release features:
+
+| Skip | Typical commit / PR pattern |
+|------|----------------------------|
+| **Embedded docs** | `chore: update embedded docs to v…`, `comfyui-embedded-docs` in `requirements.txt` |
+| **Workflow templates** | `chore: update workflow templates to v…`, `comfyui-workflow-templates` in `requirements.txt` |
+| **Model blueprints** | `Add new model blueprints`, blueprint starter workflows in template library |
+
+Also omit standalone **frontend package semver bumps** unless tied to a user-visible fix worth its own bullet. CMS simplify must never promote WIKI-only items into popup copy even if they appear in the full docs block.
+
+Example staging shape (placeholders only):
 
 ```markdown
-**New Open-Source Model Support**
-* [**Depth Anything 3**](https://github.com/Comfy-Org/ComfyUI/pull/13853): Monocular depth estimation model
+## New Open-Source Model Support
+* [**Model Name**](source_url): Short description with 1–2 traits from the release data
 
-**Partner Node Updates**
-* [**Kling V3-Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/14528): Text-to-video generation model
+## New Node Updates
+* [**Node Name**](source_url): What the node does and why it matters
+
+## Partner Node Updates
+* [**Partner Node**](source_url): Partner scope and capability from the release data
 ```
 
 Sync adds header: `# ComfyUI vX.Y.Z` via `format-cms-content.ts`.
@@ -91,11 +150,12 @@ pnpm cms:set-attention -- cloud v0.24.0 high --save
 
 | Command | Action |
 |---------|--------|
-| `pnpm cms:prepare:en` | Simplify EN → staging (comfyui + cloud copy) |
-| `pnpm cms:prepare` | Simplify EN + translate all locales (both projects) |
-| `pnpm cms:preview -- v0.25.1` | Dry-run Strapi push (both projects) |
-| `pnpm cms:sync -- v0.25.1` | Push/update **drafts** (both projects) |
-| `pnpm cms:publish -- v0.25.1` | Publish + refresh `published-versions.json` (both) |
+| `pnpm cms:prepare:en` | **Step 1** — LLM simplify docs EN → `staging/en/` (no translation) |
+| `pnpm cms:prepare:locales` | **Step 2** — translate `staging/en/` → `staging/{zh,ja,ko,fr,ru,es}/` (does not re-simplify EN) |
+| `pnpm cms:preview -- v0.25.1` | **Step 3a** — Dry-run Strapi push |
+| `pnpm cms:sync -- v0.25.1` | **Step 3b** — Push/update **drafts** (run only after user confirms staging) |
+| `pnpm cms:publish -- v0.25.1` | Publish + refresh `published-versions.json` |
+| `pnpm cms:prepare` | Prints three-step help and exits when no mode flag is passed |
 | `pnpm cms:set-attention -- cloud v0.24.0 high` | Set attention low/high in Strapi |
 | `pnpm cms:delete-drafts --preview` | List deletable Strapi drafts |
 | `pnpm cms:delete-drafts` | Delete drafts (keeps published) |
@@ -119,44 +179,47 @@ Requires **Bun**. Loads `.env.local` automatically.
 ### New release version
 
 1. Add full `<Update>` block to `changelog/index.mdx` (docs quality — unchanged).
-2. **English first** — review popup copy before translating:
+
+2. **Step 1 — Simplify EN** — review before translating:
 
    ```bash
    pnpm cms:prepare:en -- --force v0.25.1
    ```
 
-   Inspect: `.github/scripts/cms/staging/en/changelog/index.mdx`
+   Inspect: `.github/scripts/cms/staging/en/changelog/index.mdx` → **stop until approved**
 
-3. **Translate** after EN approved:
+3. **Step 2 — Translate** — from approved staging EN only:
 
    ```bash
-   pnpm cms:prepare -- v0.25.1
+   pnpm cms:prepare:locales -- v0.25.1          # first translate
+   pnpm cms:prepare:locales -- --force v0.25.1 # re-translate after EN edits
    ```
 
-4. **Push drafts**:
+   Inspect: `.github/scripts/cms/staging/zh/changelog/index.mdx` (and other locales) → **stop until approved**
+
+4. **Step 3 — Push drafts** (only after user confirms staging):
 
    ```bash
    pnpm cms:preview -- v0.25.1
    pnpm cms:sync -- v0.25.1
    ```
 
-5. **Publish** after review (CLI or Strapi admin):
+5. **Publish** after Strapi review:
 
    ```bash
    pnpm cms:publish --preview -- v0.25.1
    pnpm cms:publish -- v0.25.1
-   # published-versions.json is refreshed automatically — commit if changed
    ```
 
-6. Commit `.github/scripts/cms/published-versions.json` after publish (auto-refreshed by `cms:publish`).
+6. Commit `.github/scripts/cms/published-versions.json` after publish.
 
 ### Catch up all unpublished versions locally
 
 ```bash
-pnpm cms:prepare:en -- --force          # all unpublished EN
-pnpm cms:prepare -- --force             # then all locales
+pnpm cms:prepare:en -- --force              # Step 1: all unpublished EN
+pnpm cms:prepare:locales -- --force         # Step 2: all locales
 pnpm cms:preview
-pnpm cms:sync
+pnpm cms:sync                               # Step 3: after review
 ```
 
 ### After prompt or config changes
@@ -193,9 +256,10 @@ Re-run with `--force`. Staging without `--force` **skips** existing `<Update>` b
 When user asks to update CMS release notes:
 
 - [ ] Confirm `changelog/index.mdx` has the new `<Update>` block
-- [ ] Run `pnpm cms:prepare:en` (with `--force` if redoing); show staging EN for review
-- [ ] Wait for user approval before `pnpm cms:prepare` (translations)
-- [ ] Run `pnpm cms:preview` then `pnpm cms:sync`
+- [ ] Omit ComfyUI-WIKI items (embedded docs, workflow templates, model blueprints) unless user explicitly asks
+- [ ] Run `pnpm cms:prepare:en`; show staging EN → **wait for user approval**
+- [ ] Run `pnpm cms:prepare:locales` (not `cms:prepare:en`) → **wait for user approval**
+- [ ] Run `pnpm cms:preview` then `pnpm cms:sync` **only after user confirms staging**
 - [ ] Remind: Strapi publish is manual; then `--write` on published-versions
 - [ ] Do **not** commit staging/ (gitignored)
 - [ ] Do **not** shorten docs changelog for CMS — staging is separate

--- a/.cursor/skills/cms-changelog-sync/SKILL.md
+++ b/.cursor/skills/cms-changelog-sync/SKILL.md
@@ -115,13 +115,13 @@ Also omit standalone **frontend package semver bumps** unless tied to a user-vis
 Example staging shape (placeholders only):
 
 ```markdown
-## New Open-Source Model Support
+**New Open-Source Model Support**
 * [**Model Name**](source_url): Short description with 1–2 traits from the release data
 
-## New Node Updates
+**New Node Updates**
 * [**Node Name**](source_url): What the node does and why it matters
 
-## Partner Node Updates
+**Partner Node Updates**
 * [**Partner Node**](source_url): Partner scope and capability from the release data
 ```
 
@@ -162,7 +162,7 @@ pnpm cms:set-attention -- cloud v0.24.0 high --save
 
 Flags (after `--`):
 
-- `--force` — re-simplify/re-translate even if staging has the version
+- `--force` — re-simplify/re-translate even if staging has the version; on **sync**, update already-**published** CMS entries (default skips published)
 - `--preview` / `--dry-run` — no API writes
 - `--project cloud` — single project only (default = both)
 - `v0.25.1` — explicit version(s)

--- a/.cursor/skills/docs-i18n-translate/SKILL.md
+++ b/.cursor/skills/docs-i18n-translate/SKILL.md
@@ -73,9 +73,19 @@ pnpm translate:check-truncation         # if long page / changelog
 ### Changelog (`changelog/index.mdx`)
 
 - Strategy: `update_blocks` (configured in `translation-config.json`)
-- Only **new/changed** `<Update label="vX">` blocks are translated
+- Only **new or changed** `<Update label="vX">` blocks are translated (by label + `translationBlockHashes`)
 - Dates in `description` are localized automatically (ja/zh/ko formats)
 - Block hashes stored in `translationBlockHashes` frontmatter
+
+**Omit from English changelog** when triaging ComfyUI commits — these are **[ComfyUI-WIKI](https://github.com/Comfy-Org/ComfyUI-WIKI)** sync PRs, not core product features:
+
+| Skip | Typical pattern |
+|------|-----------------|
+| Embedded docs | `update embedded docs to v…`, `comfyui-embedded-docs` bump |
+| Workflow templates | `update workflow templates to v…`, `comfyui-workflow-templates` bump |
+| Model blueprints | `Add new model blueprints`, template-library starter workflows |
+
+Do not add bullets for dependency-only version bumps. See also **`cms-changelog-sync`** for CMS popup rules.
 
 ```bash
 pnpm translate -- changelog/index.mdx

--- a/.github/scripts/cms/README.md
+++ b/.github/scripts/cms/README.md
@@ -79,7 +79,7 @@ Configured in `cms-config.json` → `simplify`:
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `max_bullets_total` | **10** | Bullets for the **entire version** (not per section) |
-| `max_sections` | **3** | `## New Open-Source Model Support` → `## New Node Updates` → `## Partner Node Updates` |
+| `max_sections` | **3** | `**New Open-Source Model Support**` → `**New Node Updates**` → `**Partner Node Updates**` (bold labels, not `##`) |
 
 - Section order is **fixed**: open-source models first, node updates second, partner nodes last
 - Include **all meaningful New Nodes** entries from the docs changelog (workflows, output sockets, multimodal nodes)

--- a/.github/scripts/cms/README.md
+++ b/.github/scripts/cms/README.md
@@ -4,27 +4,27 @@ Push **draft** release notes to Strapi CMS. Content is **simplified for end user
 
 ## Architecture
 
+Three separate steps — review between each; sync only after confirmation:
+
 ```
 changelog/index.mdx          ← full docs (unchanged)
         │
-        ▼
-  pnpm cms:prepare
-    1. LLM simplify EN  →  staging/en/changelog/index.mdx
-    2. Translate EN     →  staging/{zh,ja,ko,fr,ru,es}/…
+        ▼  Step 1: pnpm cms:prepare:en
+staging/en/                  ← simplified popup EN (review)
         │
-        ▼
-  pnpm cms:sync        →  Strapi drafts (reads staging only)
+        ▼  Step 2: pnpm cms:prepare:locales
+staging/{zh,ja,ko,fr,ru,es}/ ← translated from staging EN (review)
         │
-        ▼
-  Editor review → Publish → update published-versions.json
+        ▼  Step 3: pnpm cms:sync
+Strapi drafts → publish → published-versions.json
 ```
 
-| Command | Role |
-|---------|------|
-| `pnpm cms:prepare` | Simplify + translate into **staging/** (uses `TRANSLATE_API_KEY`) |
-| `pnpm cms:preview` | Dry-run CMS push |
-| `pnpm cms:sync` | Push staging → Strapi (uses `CMS_API_TOKEN`) |
-| `pnpm cms:publish` | Publish reviewed Strapi drafts → live |
+| Command | Step | Role |
+|---------|------|------|
+| `pnpm cms:prepare:en` | 1 | LLM simplify docs EN → `staging/en/` |
+| `pnpm cms:prepare:locales` | 2 | Translate `staging/en/` → other locales |
+| `pnpm cms:preview` / `cms:sync` | 3 | Push staging → Strapi drafts |
+| `pnpm cms:publish` | — | Publish reviewed Strapi drafts → live |
 
 **Docs site** (`zh/changelog/`, etc.) stays independent. **CMS** uses `.github/scripts/cms/staging/` only.
 
@@ -59,12 +59,11 @@ Persists to `attention-overrides.json` (used on sync). Or edit that file manuall
 ## Commands
 
 ```bash
-pnpm cms:prepare:en -- --force v0.25.0   # simplify EN (comfyui + cloud copy)
-pnpm cms:prepare -- v0.25.1                # translate all locales (both projects)
-pnpm cms:preview -- v0.25.1                # dry-run sync (both projects)
-pnpm cms:sync -- v0.25.1                   # push drafts (both projects)
-pnpm cms:publish -- v0.25.1                # publish + refresh published-versions.json
-pnpm cms:set-attention -- cloud v0.24.0 high --save
+pnpm cms:prepare:en -- --force v0.25.0      # Step 1: simplify EN
+pnpm cms:prepare:locales -- v0.25.1         # Step 2: translate (after EN approved)
+pnpm cms:preview -- v0.25.1                 # Step 3: dry-run sync
+pnpm cms:sync -- v0.25.1                    # Step 3: push drafts (after staging approved)
+pnpm cms:publish -- v0.25.1                 # publish + refresh published-versions.json
 ```
 
 Default: **comfyui + cloud** on prepare / sync / publish. Single project: `--project cloud`.
@@ -79,13 +78,16 @@ Configured in `cms-config.json` → `simplify`:
 
 | Key | Default | Meaning |
 |-----|---------|---------|
-| `max_bullets_total` | **5** | Bullets for the **entire version** (not per section) |
-| `max_sections` | **2** | At most `**New Open-Source Model Support**` + `**Partner Node Updates**` |
+| `max_bullets_total` | **10** | Bullets for the **entire version** (not per section) |
+| `max_sections` | **3** | `## New Open-Source Model Support` → `## New Node Updates` → `## Partner Node Updates` |
 
-- Each bullet: **[**Name**](pr_url): 5–12 word function** — rewrite, do not copy docs wording
+- Section order is **fixed**: open-source models first, node updates second, partner nodes last
+- Include **all meaningful New Nodes** entries from the docs changelog (workflows, output sockets, multimodal nodes)
+- Each bullet: **[**Name**](pr_url): 12–25 word description** — preserve model/node traits from source
 - **Keep PR links** when the source has them
 - **Drop** performance tweaks, minor fixes, Load3D/UI housekeeping
-- English only (skip translation): `pnpm cms:prepare:en -- --force v0.25.0`
+- English only (Step 1): `pnpm cms:prepare:en -- --force v0.25.0`
+- Translate only (Step 2): `pnpm cms:prepare:locales -- --force v0.25.0` — reads existing `staging/en/`, never re-simplifies
 
 ## Configuration
 

--- a/.github/scripts/cms/cms-config.json
+++ b/.github/scripts/cms/cms-config.json
@@ -25,8 +25,8 @@
     }
   ],
   "simplify": {
-    "max_bullets_total": 5,
-    "max_sections": 2
+    "max_bullets_total": 10,
+    "max_sections": 3
   },
   "locales": [
     {

--- a/.github/scripts/cms/cms-simplify-en.ts
+++ b/.github/scripts/cms/cms-simplify-en.ts
@@ -17,8 +17,8 @@ import {
 } from "./cms-simplify-prompt.ts";
 import { callTranslateApi } from "./cms-translate-client.ts";
 
-const DEFAULT_MAX_BULLETS_TOTAL = 5;
-const DEFAULT_MAX_SECTIONS = 2;
+const DEFAULT_MAX_BULLETS_TOTAL = 10;
+const DEFAULT_MAX_SECTIONS = 3;
 
 function simplifyLimits(config: CmsConfig): SimplifyLimits {
   return {

--- a/.github/scripts/cms/cms-simplify-prompt.ts
+++ b/.github/scripts/cms/cms-simplify-prompt.ts
@@ -1,43 +1,72 @@
 /**
  * LLM prompts for simplifying English changelog blocks → CMS staging.
- * Tuned for a small in-app notification popup (~3–5 bullets).
+ * Principle-only — no concrete release examples (avoids contaminating other versions).
  */
 
-export const CMS_SIMPLIFY_SYSTEM_PROMPT = `You are an expert technical writer creating ComfyUI release notes for a small in-app notification popup. Generate clear, concise release notes based strictly on the provided release data.
+export const CMS_SIMPLIFY_SYSTEM_PROMPT = `You are an expert technical writer creating ComfyUI release notes for an in-app notification popup. Generate clear release notes based strictly on the provided release data.
 
 **Critical rules:**
 - Use ONLY information from the provided release data. Do not speculate, supplement, or add details not explicitly stated
 - Keep descriptions objective and factual. Never use marketing terms like "breakthrough," "revolutionary," or "amazing"
 - If release data is incomplete or unclear, only use verifiable information. Do not fill gaps with assumptions
+- Do not copy names, links, or facts from these instructions — derive everything from the release data below
 
-**Length (strict — tiny popup, not docs):**
-- **3–5 bullet points total for the entire version** (fewer if the release is small)
-- **At most 2 section headings** when both are needed:
-  - **New Open-Source Model Support**
-  - **Partner Node Updates**
-- Do NOT add Bug Fixes, Performance, Load3D, UI, or "Other" sections — drop or skip
-- **~60–120 words total** per version
+**Output style (principles):**
+- Use **bold section labels** (e.g. \`**Partner Node Updates**\`) when the source has multiple categories — never use \`##\` markdown headings
+- One bullet per item; each bullet is a single linked or bold name plus a short description
+- Descriptions are concise but informative — not just a category label
+- Match the tone of a product changelog popup: factual, scannable, no marketing fluff
 
-**Bullet format (rewrite — do not copy source wording):**
-- * [**Name**](pr_url): Short plain description of what it does
-- **Name** = model or partner node name only (recognizable, no long compound titles)
-- **Description** = one brief phrase, **5–12 words**, stating the model/node function (e.g. "Video super-resolution model", "LLM partner node for text generation")
-- Do NOT paste long changelog sentences, technical implementation details, or node lists from the source
-- **Keep the original GitHub PR/issue link** when the source provides one — links are required for linked items
-- If the source has no URL, use **bold name only** — never invent links
-- Prefer a flat bullet list (no sections) when ≤3 bullets fit
+**Length:**
+- Stay within the bullet and section limits given in the user message
+- Use fewer bullets for small releases; use the full allowance only when the source has enough substantive items
+- Do NOT add Bug Fixes, Performance, or internal refactor sections — drop those items
 
-**What to include (top 3–5 only):**
-1. New open-source models (with PR links when available)
-2. New or updated partner / API nodes (with PR links when available)
-3. One critical user-facing item only if models/nodes are sparse
+**Section order (mandatory — never reorder):**
+1. \`**New Open-Source Model Support**\` — when the source lists new open-source models
+2. \`**New Node Updates**\` — when the source has a **New Nodes** (or equivalent) section with user-facing additions
+3. \`**Partner Node Updates**\` — when the source lists partner or API node updates; always last among these three
+
+Never place Partner Node Updates before New Open-Source Model Support. Never merge categories into a flat list. Omit a section entirely if the source has no items for it.
+
+**New Open-Source Model Support:**
+- Include every open-source model from the source (within the bullet limit)
+- Do not drop models to make room for nodes or partner items
+- Preserve 1–2 distinguishing traits per model from the source (variants, sizes, encoder, modality, key capability)
+
+**New Node Updates:**
+- When the source has a **New Nodes** section, include meaningful user-facing entries (within the bullet limit)
+- Include: new workflow nodes, save/load or I/O improvements, multimodal or video node additions
+- Skip only entries that are minor plumbing with no user workflow impact (e.g. internal loader tweaks)
+- Use \`**New Node Updates**\` as the section label
+
+**Partner Node Updates:**
+- Include partner/API node additions or updates from the source
+- Preserve scope or capability details when stated (e.g. number of new nodes, supported modality)
+- Always in the last section when other sections are present
+
+**Bullet format:**
+- Linked: * [**Name**](url_from_source): Description
+- Unlinked (no URL in source): * **Name**: Description
+- **Name** = short recognizable model, node, or partner name from the source
+- **Description** = **6–12 words**: one-line function plus one key trait from the source (variant, encoder, size, modality). Shorter is better — never pad to hit a word count
+- **Keep PR/issue links exactly as provided in the source** — never invent URLs
+- Rewrite for clarity; do not paste long source sentences verbatim
+- One link per bullet when possible; mention related sub-items in description text without extra links
+
+**What to include (priority — matches section order):**
+1. All open-source models from the source
+2. All meaningful **New Nodes** entries
+3. Partner/API node updates
 
 **What to drop:**
-- Minor fixes, refactors, dtype cleanups, internal tooling, template bumps
-- Load3D tweaks, console logging, category reverts, long technical specs
+- Minor fixes, refactors, dtype cleanups, internal tooling
+- Pure loader/plumbing changes with no workflow impact
+- Performance, stability, API housekeeping, console logging
+- **ComfyUI-WIKI dependency syncs** (even if present in source): embedded-docs version bumps, workflow-templates version bumps, model blueprint additions — these are maintained by ComfyUI-WIKI, not core release features
 
 **Response format:**
-Return ONLY the simplified markdown body. No # title, no <Update> wrapper, no code fences, no JSON, no explanations.`;
+Return ONLY the simplified markdown body. No # title, no <Update> wrapper, no code fences, no JSON, no explanations. Never use \`##\` headings.`;
 
 export interface SimplifyLimits {
   maxBulletsTotal: number;
@@ -49,10 +78,12 @@ export function buildSimplifyUserPrompt(
   limits: SimplifyLimits
 ): string {
   return [
-    "Rewrite the release note below for a **small in-app popup** — not the docs site.",
+    "Rewrite the release note below for an **in-app popup**.",
     "",
     `Hard limits: **${limits.maxBulletsTotal} bullets total**, **${limits.maxSections} section headings max**.`,
-    "Each bullet: linked **name** + 5–12 word function description. **Keep PR links** from the source. Do not copy long source text.",
+    "Section order: New Open-Source Model Support → New Node Updates → Partner Node Updates (omit empty sections).",
+    "Section labels: **bold** (e.g. **Partner Node Updates**), not ## headings.",
+    "Use only facts and links from the release data. Each bullet: **6–12 words** — one key trait, no filler.",
     "",
     "=== Release data ===",
     sourceBody.trim(),

--- a/.github/scripts/cms/format-cms-content.ts
+++ b/.github/scripts/cms/format-cms-content.ts
@@ -4,8 +4,13 @@
 
 const LEGACY_HEADERS = ["ComfyUI", "Cloud"];
 
+/** CMS popup uses bold section labels, not ## headings (matches published release-notes style). */
+export function normalizeCmsSectionHeadings(body: string): string {
+  return body.replace(/^##\s+(.+)$/gm, "**$1**");
+}
+
 export function formatCmsReleaseContent(projectLabel: string, version: string, body: string): string {
-  const trimmed = body.trim();
+  const trimmed = normalizeCmsSectionHeadings(body.trim());
   const prefix = `# ${projectLabel} v${version}`;
   if (trimmed.startsWith(prefix)) return trimmed;
   for (const label of LEGACY_HEADERS) {

--- a/.github/scripts/cms/prepare-cms-changelog.ts
+++ b/.github/scripts/cms/prepare-cms-changelog.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env bun
 /**
- * Prepare CMS changelog: LLM-simplify EN → staging, then translate to all locales.
+ * Prepare CMS changelog staging — two separate steps (run in order):
  *
- * Usage:
- *   pnpm cms:prepare           # comfyui + cloud (cloud copies comfyui staging)
- *   pnpm cms:prepare --preview
- *   pnpm cms:prepare -- v0.25.1
- *   pnpm cms:prepare -- --project cloud   # single project only
+ *   Step 1 — simplify EN only:
+ *     pnpm cms:prepare:en -- --force v0.26.0
  *
- * Staging output:
- *   comfyui → .github/scripts/cms/staging/{en,zh,…}/changelog/index.mdx
- *   cloud   → .github/scripts/cms/staging/cloud/{en,zh,…}/changelog/index.mdx
- * Docs changelog (full) is NOT modified — only staging copies for CMS.
+ *   Step 2 — translate staging EN → locales (after EN reviewed):
+ *     pnpm cms:prepare:locales -- --force v0.26.0
+ *
+ * Step 3 — push to Strapi is separate: pnpm cms:preview / cms:sync (after user confirms).
+ *
+ * Flags: --en-only | --translate-only (required via npm scripts or explicit flag)
+ *        --force --project cloud --preview v0.26.0
  */
 
 import { readFile } from "fs/promises";
@@ -30,7 +30,11 @@ import {
   loadPublishedVersions,
 } from "./published-versions.ts";
 import { prepareSimplifiedEnglish } from "./cms-simplify-en.ts";
-import { readStaging, copyProjectStaging } from "./cms-staging-io.ts";
+import {
+  blockForVersion,
+  copyProjectStaging,
+  readStaging,
+} from "./cms-staging-io.ts";
 import { prepareStagingLocale } from "./cms-staging-translate.ts";
 import { translateEnvSummary } from "./cms-translate-client.ts";
 import {
@@ -39,31 +43,65 @@ import {
   versionLabelsFromEntries,
 } from "./cms-versions.ts";
 
+export type PrepareMode = "en-only" | "translate-only";
+
 function parseArgs(argv: string[]): {
   dryRun: boolean;
   force: boolean;
-  enOnly: boolean;
+  mode: PrepareMode | null;
   versions: string[];
 } {
   let dryRun = false;
   let force = false;
   let enOnly = false;
+  let translateOnly = false;
   const versions: string[] = [];
   for (const arg of argv) {
     if (arg === "--dry-run" || arg === "--preview") dryRun = true;
     else if (arg === "--force") force = true;
     else if (arg === "--en-only") enOnly = true;
+    else if (arg === "--translate-only") translateOnly = true;
     else if (!arg.startsWith("-")) versions.push(arg.replace(/^v/i, ""));
   }
-  return { dryRun, force, enOnly, versions };
+
+  if (enOnly && translateOnly) {
+    console.error("Cannot combine --en-only and --translate-only.");
+    process.exit(1);
+  }
+
+  const mode: PrepareMode | null = enOnly
+    ? "en-only"
+    : translateOnly
+      ? "translate-only"
+      : null;
+
+  return { dryRun, force, mode, versions };
+}
+
+function printModeHelp(): void {
+  console.error(`
+CMS staging prepare — run steps in order (user confirms before cms:sync):
+
+  Step 1 — simplify EN popup copy:
+    pnpm cms:prepare:en -- --force v0.26.0
+
+  Step 2 — translate staging EN → zh/ja/ko/fr/ru/es (after EN approved):
+    pnpm cms:prepare:locales -- --force v0.26.0
+
+  Step 3 — push drafts to Strapi (after all staging reviewed):
+    pnpm cms:preview -- v0.26.0
+    pnpm cms:sync -- v0.26.0
+
+Pass --en-only or --translate-only (or use the npm scripts above).
+`);
 }
 
 async function prepareForProject(
   baseConfig: Awaited<ReturnType<typeof loadCmsConfig>>,
   projectId: string,
+  mode: PrepareMode,
   dryRun: boolean,
   force: boolean,
-  enOnly: boolean,
   explicitVersions: string[]
 ): Promise<void> {
   const config = configForProject(baseConfig, projectId);
@@ -114,61 +152,87 @@ async function prepareForProject(
   }
 
   const targetVersions = versionLabelsFromEntries(entriesToPrepare);
+  const modeLabel = mode === "en-only" ? "simplify EN" : "translate locales";
   console.log(
-    `[${projectId}] ${dryRun ? "Would prepare" : "Preparing"} CMS staging for: ${targetVersions.join(", ")}`
-  );
-
-  const { simplified, skipped: enSkipped } = await prepareSimplifiedEnglish(
-    config,
-    entriesToPrepare,
-    docsEnContent,
-    dryRun,
-    force
+    `[${projectId}] ${dryRun ? "Would" : "Preparing"} ${modeLabel} for: ${targetVersions.join(", ")}`
   );
 
   const enStagingPath = englishStagingLocale(config).changelog!;
-  const simplifiedEnContent = dryRun ? docsEnContent : await readStaging(enStagingPath);
+
+  if (mode === "en-only") {
+    const { simplified, skipped: enSkipped } = await prepareSimplifiedEnglish(
+      config,
+      entriesToPrepare,
+      docsEnContent,
+      dryRun,
+      force
+    );
+    console.log(
+      `[${projectId}] Done: en simplified=${simplified} (skipped ${enSkipped})`
+    );
+    console.log(`[${projectId}] Staging: ${enStagingPath}`);
+    console.log(`[${projectId}] Next: review staging EN, then pnpm cms:prepare:locales`);
+    return;
+  }
+
+  // translate-only — read existing simplified EN staging (never re-simplify)
+  const simplifiedEnContent = dryRun
+    ? await readStaging(enStagingPath).catch(() => docsEnContent)
+    : await readStaging(enStagingPath);
+
+  for (const target of entriesToPrepare) {
+    if (!blockForVersion(simplifiedEnContent, target.version)) {
+      throw new Error(
+        `[${projectId}] translate-only: missing staging EN block for v${target.version}. ` +
+          `Run pnpm cms:prepare:en first.`
+      );
+    }
+  }
+
+  console.log(`[${projectId}] [translate-only] reading staging EN → ${enStagingPath}`);
 
   let translated = 0;
   let translateSkipped = 0;
 
-  if (!enOnly) {
-    for (const locale of translateLocales(config)) {
-      console.log(`[${projectId}/${locale.code}] translate ← simplified en`);
-      const result = await prepareStagingLocale(
-        locale,
-        entriesToPrepare,
-        simplifiedEnContent,
-        dryRun,
-        force
-      );
-      translated += result.translated;
-      translateSkipped += result.skipped;
-    }
-  } else {
-    console.log(`[${projectId}] [en-only] skipping locale translation`);
+  for (const locale of translateLocales(config)) {
+    console.log(`[${projectId}/${locale.code}] translate ← staging en`);
+    const result = await prepareStagingLocale(
+      locale,
+      entriesToPrepare,
+      simplifiedEnContent,
+      dryRun,
+      force
+    );
+    translated += result.translated;
+    translateSkipped += result.skipped;
   }
 
   console.log(
-    `[${projectId}] Done: en simplified=${simplified} (skipped ${enSkipped})` +
-      (enOnly ? "" : `, locales translated=${translated} (skipped ${translateSkipped})`)
+    `[${projectId}] Done: locales translated=${translated} (skipped ${translateSkipped})`
   );
-  console.log(`[${projectId}] Staging: ${englishStagingLocale(config).changelog}`);
+  console.log(`[${projectId}] Staging: ${enStagingPath.replace("/en/", "/{locale}/")}`);
+  console.log(`[${projectId}] Next: review staging locales, then pnpm cms:preview / cms:sync`);
 }
 
 async function main(): Promise<void> {
   await loadEnvLocal();
   const { project: cliProject, rest } = stripProjectArg(process.argv.slice(2));
-  const { dryRun, force, enOnly, versions: explicitVersions } = parseArgs(rest);
+  const { dryRun, force, mode, versions: explicitVersions } = parseArgs(rest);
+
+  if (!mode) {
+    printModeHelp();
+    process.exit(1);
+  }
+
   const baseConfig = await loadCmsConfig();
   const projects = resolveProjects(baseConfig, cliProject);
 
   console.log(`${translateEnvSummary()}\n`);
-  console.log(`Preparing projects: ${projects.join(", ")}\n`);
+  console.log(`Mode: ${mode} | Projects: ${projects.join(", ")}\n`);
 
   const [primary, ...secondary] = projects;
 
-  await prepareForProject(baseConfig, primary!, dryRun, force, enOnly, explicitVersions);
+  await prepareForProject(baseConfig, primary!, mode, dryRun, force, explicitVersions);
 
   for (const projectId of secondary) {
     if (dryRun) {

--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -245,6 +245,20 @@
         "zh"
       ],
       "published_at": "2026-06-19T12:35:44.508Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.26.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-06-23T19:00:24.314Z"
     }
   ]
 }

--- a/.github/scripts/cms/sync-to-strapi.ts
+++ b/.github/scripts/cms/sync-to-strapi.ts
@@ -31,7 +31,7 @@ interface SyncTask {
   locale: string;
   date: string;
   body: string;
-  action: "create" | "update" | "skip";
+  action: "create" | "update" | "update-published" | "skip";
   reason?: string;
 }
 
@@ -44,14 +44,16 @@ function requireEnv(name: string): string {
   return val;
 }
 
-function parseArgs(argv: string[]): { dryRun: boolean; versions: string[] } {
+function parseArgs(argv: string[]): { dryRun: boolean; force: boolean; versions: string[] } {
   let dryRun = false;
+  let force = false;
   const versions: string[] = [];
   for (const arg of argv) {
     if (arg === "--dry-run" || arg === "--preview") dryRun = true;
+    else if (arg === "--force") force = true;
     else if (!arg.startsWith("-")) versions.push(arg.replace(/^v/i, ""));
   }
-  return { dryRun, versions };
+  return { dryRun, force, versions };
 }
 
 async function loadAllLocaleEntries(
@@ -189,7 +191,8 @@ async function planSync(
   config: CmsConfig,
   project: string,
   targetVersions: ReleaseNoteEntry[],
-  byLocale: Map<string, Map<string, ReleaseNoteEntry>>
+  byLocale: Map<string, Map<string, ReleaseNoteEntry>>,
+  force = false
 ): Promise<SyncTask[]> {
   const tasks: SyncTask[] = [];
 
@@ -219,8 +222,8 @@ async function planSync(
           locale: locale.code,
           date: entry.date,
           body: entry.body,
-          action: "skip",
-          reason: "published (CMS)",
+          action: force ? "update-published" : "skip",
+          reason: force ? undefined : "published (CMS)",
         });
         continue;
       }
@@ -338,6 +341,22 @@ async function executeTasks(
         });
         ok++;
         console.log(`Updated  ${task.project}/v${task.version} [${task.locale}] (draft)`);
+      } else if (task.action === "update-published") {
+        const published = await client.findOne(
+          config.content_type_plural,
+          {
+            [config.project_field]: task.project,
+            [config.version_field]: task.version,
+          },
+          { locale: task.locale, status: "published" }
+        );
+        if (!published?.documentId) throw new Error("published entry not found for update");
+        await client.update(config.content_type_plural, published.documentId, payload, {
+          locale: task.locale,
+          status: "published",
+        });
+        ok++;
+        console.log(`Updated  ${task.project}/v${task.version} [${task.locale}] (published)`);
       }
     } catch (err) {
       failed++;
@@ -357,6 +376,7 @@ async function syncProject(
   project: string,
   explicitVersions: string[],
   dryRun: boolean,
+  force: boolean,
   client: StrapiClient,
   registry: PublishedVersionsFile,
   attentionOverrides: Awaited<ReturnType<typeof loadAttentionOverrides>>
@@ -415,7 +435,7 @@ async function syncProject(
       `locales=[${config.locales.filter((l) => l.changelog).map((l) => l.code).join(", ")}]\n`
   );
 
-  const tasks = await planSync(client, config, project, entriesToSync, byLocale);
+  const tasks = await planSync(client, config, project, entriesToSync, byLocale, force);
   printTasks(tasks, dryRun);
 
   if (dryRun) return { ok: 0, failed: 0 };
@@ -431,7 +451,7 @@ async function syncProject(
 async function main(): Promise<void> {
   await loadEnvLocal();
   const { project: cliProject, rest } = stripProjectArg(process.argv.slice(2));
-  const { dryRun, versions: explicitVersions } = parseArgs(rest);
+  const { dryRun, force, versions: explicitVersions } = parseArgs(rest);
   const baseConfig = await loadCmsConfig();
   const projects = resolveProjects(baseConfig, cliProject);
   const registry = await loadPublishedVersions();
@@ -459,6 +479,7 @@ async function main(): Promise<void> {
       projectId,
       explicitVersions,
       dryRun,
+      force,
       client,
       registry,
       attentionOverrides

--- a/.github/scripts/cms/sync-to-strapi.ts
+++ b/.github/scripts/cms/sync-to-strapi.ts
@@ -325,22 +325,6 @@ async function executeTasks(
         }
         ok++;
         console.log(`Created  ${task.project}/v${task.version} [${task.locale}] (draft)`);
-      } else {
-        const draft = await client.findOne(
-          config.content_type_plural,
-          {
-            [config.project_field]: task.project,
-            [config.version_field]: task.version,
-          },
-          { locale: task.locale, status: "draft" }
-        );
-        if (!draft?.documentId) throw new Error("draft not found for update");
-        await client.update(config.content_type_plural, draft.documentId, payload, {
-          locale: task.locale,
-          status: "draft",
-        });
-        ok++;
-        console.log(`Updated  ${task.project}/v${task.version} [${task.locale}] (draft)`);
       } else if (task.action === "update-published") {
         const published = await client.findOne(
           config.content_type_plural,
@@ -357,6 +341,22 @@ async function executeTasks(
         });
         ok++;
         console.log(`Updated  ${task.project}/v${task.version} [${task.locale}] (published)`);
+      } else {
+        const draft = await client.findOne(
+          config.content_type_plural,
+          {
+            [config.project_field]: task.project,
+            [config.version_field]: task.version,
+          },
+          { locale: task.locale, status: "draft" }
+        );
+        if (!draft?.documentId) throw new Error("draft not found for update");
+        await client.update(config.content_type_plural, draft.documentId, payload, {
+          locale: task.locale,
+          status: "draft",
+        });
+        ok++;
+        console.log(`Updated  ${task.project}/v${task.version} [${task.locale}] (draft)`);
       }
     } catch (err) {
       failed++;

--- a/.github/scripts/i18n/README.md
+++ b/.github/scripts/i18n/README.md
@@ -36,7 +36,7 @@ output limits when translated in one shot. Two strategies avoid truncation:
 | Strategy | Use case | Split boundary | Incremental sync |
 |----------|----------|----------------|------------------|
 | `heading_sections` | Long reference pages | Level-2 `##` headings | Per-section content hash in `translationBlockHashes` |
-| `update_blocks` | Changelog | `<Update label="…">` blocks | New version labels only |
+| `update_blocks` | Changelog | `<Update label="…">` blocks | Per-block content hash in `translationBlockHashes` (new labels + EN edits) |
 
 Configure explicit paths in `translation-config.json` → `chunked_files`, or rely
 on `auto_chunk` (default: body ≥ 10k chars and ≥ 4 `##` sections) to auto-enable

--- a/.github/scripts/i18n/chunked-translate.test.ts
+++ b/.github/scripts/i18n/chunked-translate.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import {
+  blockHash,
+  documentBlockHashes,
+  getSectionSyncStatus,
+  parseDocument,
+} from "./chunked-translate.ts";
+
+const FM = `---
+title: "Changelog"
+translationBlockHashes:
+`;
+
+function enBlock(label: string, body: string, date: string): string {
+  return `<Update label="${label}" description="${date}">\n\n${body}\n\n</Update>`;
+}
+
+function targetMdx(
+  blocks: Array<{ label: string; body: string; date: string }>,
+  hashes: Record<string, string>
+): string {
+  const hashLines = Object.entries(hashes)
+    .map(([label, hash]) => `  "${label}": ${hash}`)
+    .join("\n");
+  const body = blocks.map((b) => enBlock(b.label, b.body, b.date)).join("\n\n");
+  return `${FM}${hashLines}\n---\n${body}\n`;
+}
+
+describe("getSectionSyncStatus update_blocks", () => {
+  const v026 = enBlock("v0.26.0", "* **Krea2**: first draft", "June 23, 2026");
+  const v026Edited = enBlock("v0.26.0", "* **Krea2**: option C", "June 23, 2026");
+  const v0251 = enBlock("v0.25.1", "* **Kling**", "June 16, 2026");
+
+  test("marks new version labels as pending", () => {
+    const en = `---\n---\n${v026}\n\n${v0251}\n`;
+    const target = targetMdx(
+      [{ label: "v0.25.1", body: "* Kling", date: "June 16, 2026" }],
+      { "v0.25.1": blockHash(v0251) }
+    );
+    const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
+    expect(status.pendingBlocks).toEqual(["v0.26.0"]);
+    expect(status.upToDate).toBe(false);
+  });
+
+  test("skips blocks when stored hash matches English", () => {
+    const en = `---\n---\n${v026}\n\n${v0251}\n`;
+    const enHashes = documentBlockHashes(parseDocument(en, "update_blocks").blocks);
+    const target = targetMdx(
+      [
+        { label: "v0.26.0", body: "* **Krea2**: first draft", date: "2026年6月23日" },
+        { label: "v0.25.1", body: "* Kling", date: "2026年6月16日" },
+      ],
+      enHashes
+    );
+    const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
+    expect(status.pendingBlocks).toEqual([]);
+    expect(status.upToDate).toBe(true);
+  });
+
+  test("re-translates when English block content changes", () => {
+    const en = `---\n---\n${v026Edited}\n\n${v0251}\n`;
+    const enHashes = documentBlockHashes(parseDocument(en, "update_blocks").blocks);
+    const target = targetMdx(
+      [
+        { label: "v0.26.0", body: "* **Krea2**: first draft", date: "June 23, 2026" },
+        { label: "v0.25.1", body: "* Kling", date: "June 16, 2026" },
+      ],
+      {
+        "v0.26.0": blockHash(v026),
+        "v0.25.1": enHashes["v0.25.1"]!,
+      }
+    );
+    const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
+    expect(status.pendingBlocks).toEqual(["v0.26.0"]);
+    expect(status.upToDate).toBe(false);
+  });
+
+  test("re-translates when block exists but hash entry is missing", () => {
+    const en = `---\n---\n${v026}\n\n${v0251}\n`;
+    const enHashes = documentBlockHashes(parseDocument(en, "update_blocks").blocks);
+    const target = targetMdx(
+      [
+        { label: "v0.26.0", body: "* **Krea2**: first draft", date: "June 23, 2026" },
+        { label: "v0.25.1", body: "* Kling", date: "June 16, 2026" },
+      ],
+      { "v0.25.1": enHashes["v0.25.1"]! }
+    );
+    const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
+    expect(status.pendingBlocks).toEqual(["v0.26.0"]);
+  });
+});

--- a/.github/scripts/i18n/chunked-translate.ts
+++ b/.github/scripts/i18n/chunked-translate.ts
@@ -618,18 +618,30 @@ export function getSectionSyncStatus(
   const hasOrderDrift = blockHashLabelOrderDrifts(enLabels, storedLabels);
 
   if (strategy === "update_blocks") {
+    const storedHashes = parseBlockHashesFromFrontmatter(existingFmBody);
     const existingLabels = new Set(existingDoc.blocks.map((b) => b.label));
     const pendingBlocks = enDoc.blocks
-      .filter((b) => !existingLabels.has(b.label))
+      .filter((b) => {
+        if (!existingLabels.has(b.label)) return true;
+        return storedHashes[b.label] !== enHashes[b.label];
+      })
       .map((b) => b.label);
+    const hasStructureDrift = Object.keys(storedHashes).some((k) => !(k in enHashes));
     const hasDateDrift = langCode
       ? hasChangelogDateDrift(enContent, existingContent, langCode)
       : false;
     return {
-      upToDate: pendingBlocks.length === 0 && !hasOrderDrift && !hasDateDrift,
+      upToDate:
+        pendingBlocks.length === 0 &&
+        !hasOrderDrift &&
+        !hasDateDrift &&
+        !hasStructureDrift,
       pendingBlocks,
-      needsFrontmatter: existingDoc.blocks.length === 0,
-      needsReserialize: pendingBlocks.length === 0 && (hasOrderDrift || hasDateDrift),
+      needsFrontmatter:
+        existingDoc.blocks.length === 0 || Object.keys(storedHashes).length === 0,
+      needsReserialize:
+        pendingBlocks.length === 0 &&
+        (hasOrderDrift || hasDateDrift || hasStructureDrift),
     };
   }
 

--- a/.github/workflows/cms-changelog-sync.yml
+++ b/.github/workflows/cms-changelog-sync.yml
@@ -31,14 +31,23 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Prepare changelog translations
+      - name: Simplify EN staging
         env:
           TRANSLATE_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
           TRANSLATE_API_BASE_URL: ${{ vars.TRANSLATE_API_BASE_URL }}
           TRANSLATE_API_MODEL: ${{ secrets.TRANSLATE_API_MODEL }}
           CMS_SYNC_BEFORE: ${{ github.event.before }}
           CMS_SYNC_AFTER: ${{ github.sha }}
-        run: bun .github/scripts/cms/prepare-cms-changelog.ts
+        run: bun .github/scripts/cms/prepare-cms-changelog.ts --en-only
+
+      - name: Translate staging locales
+        env:
+          TRANSLATE_API_KEY: ${{ secrets.TRANSLATE_API_KEY }}
+          TRANSLATE_API_BASE_URL: ${{ vars.TRANSLATE_API_BASE_URL }}
+          TRANSLATE_API_MODEL: ${{ secrets.TRANSLATE_API_MODEL }}
+          CMS_SYNC_BEFORE: ${{ github.event.before }}
+          CMS_SYNC_AFTER: ${{ github.sha }}
+        run: bun .github/scripts/cms/prepare-cms-changelog.ts --translate-only
 
       - name: Preview CMS sync
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,9 @@ Always load the matching skill before changing that pipeline.
              │                               │
              ▼                               ▼
    DOCS (Mintlify)                    CMS (Strapi popup)
-   pnpm translate                     pnpm cms:prepare:en
-   → zh/ ja/ ko/                      → staging/en/ (gitignored)
-   COMMIT to git                      pnpm cms:prepare → staging/{lang}/
-                                      pnpm cms:sync → Strapi draft
+   pnpm translate                     Step 1: pnpm cms:prepare:en → staging/en/
+   → zh/ ja/ ko/                      Step 2: pnpm cms:prepare:locales → staging/{lang}/
+   COMMIT to git                      Step 3: pnpm cms:sync → Strapi draft (after review)
              │                               │
              ▼                               ▼
    Mintlify site                      In-app notification
@@ -33,7 +32,7 @@ Always load the matching skill before changing that pipeline.
 
 | | Docs translation | CMS sync |
 |--|------------------|----------|
-| Command | `pnpm translate` | `pnpm cms:prepare` / `cms:sync` |
+| Command | `pnpm translate` | `pnpm cms:prepare:en` / `cms:prepare:locales` / `cms:sync` |
 | Output | `{lang}/**/*.mdx` | `.github/scripts/cms/staging/` |
 | English input | Full docs MDX | LLM-simplified popup copy |
 | Commit? | **Yes** | **No** (staging gitignored) |
@@ -53,12 +52,11 @@ pnpm translate:review                    # optional quality pass
 ### CMS — after editing `changelog/index.mdx`
 
 ```bash
-pnpm cms:prepare:en -- --force v0.25.1   # simplify EN (comfyui + cloud copy)
-pnpm cms:prepare -- v0.25.1               # translate all locales (both projects)
-pnpm cms:preview -- v0.25.1               # dry-run (both projects)
-pnpm cms:sync -- v0.25.1                  # push drafts (both projects)
-pnpm cms:publish -- v0.25.1               # publish + refresh published-versions.json
-pnpm cms:set-attention -- cloud v0.24.0 high --save   # optional high priority
+pnpm cms:prepare:en -- --force v0.25.1       # Step 1: simplify EN
+pnpm cms:prepare:locales -- v0.25.1          # Step 2: translate (after EN approved)
+pnpm cms:preview -- v0.25.1                # Step 3: dry-run
+pnpm cms:sync -- v0.25.1                   # Step 3: push drafts (after user confirms)
+pnpm cms:publish -- v0.25.1                # publish + refresh published-versions.json
 ```
 
 Default: **comfyui + cloud** together. Single project only: `--project cloud`.
@@ -80,10 +78,10 @@ Copy `.env.local.example` → `.env.local` (never commit).
 ## Agent rules
 
 1. **Do not shorten** `changelog/index.mdx` for CMS — use the staging + simplify pipeline.
-2. **Do not use** `pnpm translate` to fill CMS staging — use `pnpm cms:prepare`.
+2. **Do not use** `pnpm translate` to fill CMS staging — use `pnpm cms:prepare:en` then `cms:prepare:locales`.
 3. **Do not commit** `.github/scripts/cms/staging/` or `.github/i18n-logs/`.
 4. **Do commit** translated docs (`zh/`, `ja/`, `ko/`) and `published-versions.json` after Strapi publish.
-5. Get user approval on **staging EN** before running full `cms:prepare` (translations cost API calls).
+5. Get user approval on **staging EN** before `cms:prepare:locales`; get approval on **all staging** before `cms:sync`.
 6. Strapi publish is **manual by default** — use `bun run cms:publish` after review (not automatic on sync).
 
 ## Reference docs

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,35 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.26.0" description="June 23, 2026">
+
+**New Open-Source Model Support**
+* [**Krea2**](https://links.comfy.org/4eC8714): Aesthetically diverse open-weight **RAW** / **Turbo** pair — train LoRAs on RAW, run 8-step inference on Turbo
+* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Text-to-image model with Qwen3-VL-8B text encoder; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) node adds image editing with negative prompt and optional reference images
+* [**Qwen3-VL Text Generation**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Text generation with image understanding using Qwen3-VL 4B and 8B models
+* [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): Multi-reference support for SCAIL-2 character replacement
+
+**New Nodes**
+* [**LTX2 Context Windows**](https://github.com/Comfy-Org/ComfyUI/pull/13325): Context window sampling for LTX-2 multimodal video+audio models with IC-LoRA guide splicing
+* [**Load3DAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/14316): Mesh-only 3D loader with model_3d, camera_info, model_3d_info, width, and height outputs
+* [**Save Nodes Output Socket**](https://github.com/Comfy-Org/ComfyUI/pull/13866): Added output socket to save nodes for downstream pipeline wiring
+
+**Partner Node Updates**
+* [**Luma Rays 3.2**](https://github.com/Comfy-Org/ComfyUI/pull/14540): Seven new nodes for Luma Ray 3.2 video generation
+
+**Performance & Stability**
+* [**Krea 2**](https://github.com/Comfy-Org/ComfyUI/pull/14594): More accurate memory usage factor
+* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): Prompt users to try native formats instead of disabling dynamic VRAM
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14557): Small inference optimization
+* [**Jobs API**](https://github.com/Comfy-Org/ComfyUI/pull/14493): Added cancel endpoints (`POST /api/jobs/{job_id}/cancel`, `POST /api/jobs/cancel`)
+
+**Bug Fixes**
+* [**Assets panel**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11716): Fixed duplicate media entries when scrolling large jobs
+* [**Advanced inputs**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): Fixed connected advanced inputs hidden after collapsing the advanced section
+* [**Workflow restore**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): Fixed missing subgraph node previews after reloading backgrounded workflows
+
+</Update>
+
 <Update label="v0.25.1" description="June 16, 2026">
 
 **Partner Node Updates**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -7,7 +7,7 @@ icon: "clock-rotate-left"
 <Update label="v0.26.0" description="June 23, 2026">
 
 **New Open-Source Model Support**
-* [**Krea2**](https://links.comfy.org/4eC8714): Aesthetically diverse open-weight **RAW** / **Turbo** pair — train LoRAs on RAW, run 8-step inference on Turbo
+* [**Krea2**](https://links.comfy.org/4eC8714): Krea's open-source image model with wide aesthetic and stylistic range — open-weight **RAW** / **Turbo** pair; train LoRAs on RAW, run 8-step inference on Turbo
 * [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Text-to-image model with Qwen3-VL-8B text encoder; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) node adds image editing with negative prompt and optional reference images
 * [**Qwen3-VL Text Generation**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Text generation with image understanding using Qwen3-VL 4B and 8B models
 * [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): Multi-reference support for SCAIL-2 character replacement

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -1,11 +1,11 @@
 ---
----
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 19292673
+translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.26.0": 42c568b4
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -100,6 +100,35 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.26.0" description="2026年6月23日">
+
+**新しいオープンソースモデルのサポート**
+* [**Krea2**](https://links.comfy.org/4eC8714): 美的に多様なオープンウェイトの **RAW** / **Turbo** ペア — RAWでLoRAを学習し、Turboで8ステップの推論を実行
+* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Qwen3-VL-8Bテキストエンコーダーを備えたテキストから画像へのモデル; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) ノードがネガティブプロンプトとオプションの参照画像による画像編集を追加
+* [**Qwen3-VL テキスト生成**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Qwen3-VL 4Bおよび8Bモデルを使用した、画像理解を伴うテキスト生成
+* [**SCAIL-2 マルチリファレンス**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2キャラクター置換のためのマルチリファレンスサポート
+
+**新しいノード**
+* [**LTX2 コンテキストウィンドウ**](https://github.com/Comfy-Org/ComfyUI/pull/13325): IC-LoRAガイドスプライシングを備えた、LTX-2マルチモーダルビデオ+オーディオモデルのコンテキストウィンドウサンプリング
+* [**Load3DAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/14316): model_3d、camera_info、model_3d_info、幅、高さの出力を持つメッシュのみの3Dローダー
+* [**Save Nodes 出力ソケット**](https://github.com/Comfy-Org/ComfyUI/pull/13866): 下流パイプライン配線のために保存ノードに出力ソケットを追加
+
+**パートナーノードの更新**
+* [**Luma Rays 3.2**](https://github.com/Comfy-Org/ComfyUI/pull/14540): Luma Ray 3.2ビデオ生成用の7つの新ノード
+
+**パフォーマンスと安定性**
+* [**Krea 2**](https://github.com/Comfy-Org/ComfyUI/pull/14594): より正確なメモリ使用量係数
+* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): ダイナミックVRAMを無効にする代わりに、ネイティブフォーマットを試すようユーザーに促す
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14557): 軽微な推論最適化
+* [**Jobs API**](https://github.com/Comfy-Org/ComfyUI/pull/14493): キャンセルエンドポイントの追加 (`POST /api/jobs/{job_id}/cancel`, `POST /api/jobs/cancel`)
+
+**バグ修正**
+* [**アセットパネル**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11716): 大きなジョブをスクロールした際にメディアエントリが重複する問題を修正
+* [**詳細入力**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): 詳細セクションを折りたたんだ後、接続された詳細入力が非表示になる問題を修正
+* [**ワークフロー復元**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): バックグラウンドになったワークフローを再読み込みした後、サブグラフノードのプレビューが表示されない問題を修正
+
+</Update>
 
 <Update label="v0.25.1" description="2026年6月16日">
 

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -5,7 +5,7 @@ icon: "clock-rotate-left"
 translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.26.0": 42c568b4
+  "v0.26.0": e0ef7a1b
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -104,7 +104,7 @@ translationBlockHashes:
 <Update label="v0.26.0" description="2026年6月23日">
 
 **新しいオープンソースモデルのサポート**
-* [**Krea2**](https://links.comfy.org/4eC8714): 美的に多様なオープンウェイトの **RAW** / **Turbo** ペア — RAWでLoRAを学習し、Turboで8ステップの推論を実行
+* [**Krea2**](https://links.comfy.org/4eC8714): Kreaのオープンソース画像モデルで、幅広い美的・スタイル的範囲を持つ — オープンウェイトの **RAW** / **Turbo** ペア；RAWでLoRAを学習し、Turboで8ステップの推論を実行
 * [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Qwen3-VL-8Bテキストエンコーダーを備えたテキストから画像へのモデル; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) ノードがネガティブプロンプトとオプションの参照画像による画像編集を追加
 * [**Qwen3-VL テキスト生成**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Qwen3-VL 4Bおよび8Bモデルを使用した、画像理解を伴うテキスト生成
 * [**SCAIL-2 マルチリファレンス**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2キャラクター置換のためのマルチリファレンスサポート

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -6,7 +6,7 @@ icon: "clock-rotate-left"
 translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.26.0": 42c568b4
+  "v0.26.0": e0ef7a1b
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -105,8 +105,8 @@ translationBlockHashes:
 <Update label="v0.26.0" description="2026년 6월 23일">
 
 **새로운 오픈소스 모델 지원**
-* [**Krea2**](https://links.comfy.org/4eC8714): 심미적으로 다양한 오픈 가중치 **RAW** / **Turbo** 쌍 — RAW에서 LoRA 학습, Turbo에서 8단계 추론 실행
-* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Qwen3-VL-8B 텍스트 인코더가 포함된 텍스트 기반 이미지 생성 모델; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) 노드는 네거티브 프롬프트와 선택적 참조 이미지를 통해 이미지 편집을 추가합니다
+* [**Krea2**](https://links.comfy.org/4eC8714): 폭넓은 미적 및 스타일 범위를 제공하는 Krea의 오픈소스 이미지 모델 — 오픈 가중치 **RAW** / **Turbo** 쌍; RAW에서 LoRA 학습, Turbo에서 8단계 추론 실행
+* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Qwen3-VL-8B 텍스트 인코더가 포함된 텍스트 기반 이미지 생성 모델; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) 노드는 네거티브 프롬프트와 선택적 참조 이미지를 통해 이미지 편집 기능을 추가합니다
 * [**Qwen3-VL Text Generation**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Qwen3-VL 4B 및 8B 모델을 사용한 이미지 이해가 포함된 텍스트 생성
 * [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2 캐릭터 교체를 위한 다중 참조 지원
 
@@ -120,14 +120,14 @@ translationBlockHashes:
 
 **성능 및 안정성**
 * [**Krea 2**](https://github.com/Comfy-Org/ComfyUI/pull/14594): 더 정확한 메모리 사용 계수
-* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): 동적 VRAM을 비활성화하는 대신 네이티브 형식을 시도하도록 사용자에게 프롬프트가 표시됩니다.
+* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): 동적 VRAM을 비활성화하는 대신 네이티브 형식을 시도하도록 사용자에게 프롬프트가 표시됩니다
 * [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14557): 작은 추론 최적화
 * [**Jobs API**](https://github.com/Comfy-Org/ComfyUI/pull/14493): 취소 엔드포인트가 추가되었습니다 (`POST /api/jobs/{job_id}/cancel`, `POST /api/jobs/cancel`)
 
 **버그 수정**
 * [**에셋 패널**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11716): 큰 작업 스크롤 시 미디어 항목 복제 문제 수정
-* [**고급 입력**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): 고급 섹션 접을 때 연결된 고급 입력이 숨겨지는 문제 수정
-* [**워크플로 복원**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): 백그라운드 워크플로 다시 로드 후 서브그래프 노드 미리보기 누락 수정
+* [**고급 입력**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): 고급 섹션을 접을 때 연결된 고급 입력이 숨겨지는 문제 수정
+* [**워크플로 복원**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): 백그라운드 워크플로를 다시 로드한 후 서브그래프 노드 미리보기가 누락되는 문제 수정
 
 </Update>
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -3,9 +3,10 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 19292673
+translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.26.0": 42c568b4
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -100,6 +101,35 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.26.0" description="2026년 6월 23일">
+
+**새로운 오픈소스 모델 지원**
+* [**Krea2**](https://links.comfy.org/4eC8714): 심미적으로 다양한 오픈 가중치 **RAW** / **Turbo** 쌍 — RAW에서 LoRA 학습, Turbo에서 8단계 추론 실행
+* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): Qwen3-VL-8B 텍스트 인코더가 포함된 텍스트 기반 이미지 생성 모델; [**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) 노드는 네거티브 프롬프트와 선택적 참조 이미지를 통해 이미지 편집을 추가합니다
+* [**Qwen3-VL Text Generation**](https://github.com/Comfy-Org/ComfyUI/pull/14298): Qwen3-VL 4B 및 8B 모델을 사용한 이미지 이해가 포함된 텍스트 생성
+* [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2 캐릭터 교체를 위한 다중 참조 지원
+
+**새로운 노드**
+* [**LTX2 Context Windows**](https://github.com/Comfy-Org/ComfyUI/pull/13325): IC-LoRA 가이드 스플라이싱과 함께 LTX-2 멀티모달 비디오+오디오 모델을 위한 컨텍스트 창 샘플링
+* [**Load3DAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/14316): model_3d, camera_info, model_3d_info, 너비, 높이 출력이 있는 메시 전용 3D 로더
+* [**Save Nodes Output Socket**](https://github.com/Comfy-Org/ComfyUI/pull/13866): 다운스트림 파이프라인 연결을 위해 저장 노드에 출력 소켓이 추가되었습니다
+
+**파트너 노드 업데이트**
+* [**Luma Rays 3.2**](https://github.com/Comfy-Org/ComfyUI/pull/14540): Luma Ray 3.2 비디오 생성을 위한 7개의 새로운 노드
+
+**성능 및 안정성**
+* [**Krea 2**](https://github.com/Comfy-Org/ComfyUI/pull/14594): 더 정확한 메모리 사용 계수
+* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): 동적 VRAM을 비활성화하는 대신 네이티브 형식을 시도하도록 사용자에게 프롬프트가 표시됩니다.
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14557): 작은 추론 최적화
+* [**Jobs API**](https://github.com/Comfy-Org/ComfyUI/pull/14493): 취소 엔드포인트가 추가되었습니다 (`POST /api/jobs/{job_id}/cancel`, `POST /api/jobs/cancel`)
+
+**버그 수정**
+* [**에셋 패널**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11716): 큰 작업 스크롤 시 미디어 항목 복제 문제 수정
+* [**고급 입력**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): 고급 섹션 접을 때 연결된 고급 입력이 숨겨지는 문제 수정
+* [**워크플로 복원**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): 백그라운드 워크플로 다시 로드 후 서브그래프 노드 미리보기 누락 수정
+
+</Update>
 
 <Update label="v0.25.1" description="2026년 6월 16일">
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "translate:review": "bun .github/scripts/i18n/review-i18n.ts",
     "cms:prepare": "bun .github/scripts/cms/prepare-cms-changelog.ts",
     "cms:prepare:en": "bun .github/scripts/cms/prepare-cms-changelog.ts --en-only",
+    "cms:prepare:locales": "bun .github/scripts/cms/prepare-cms-changelog.ts --translate-only",
     "cms:delete-drafts": "bun .github/scripts/cms/delete-cms-drafts.ts",
     "cms:preview": "bun .github/scripts/cms/sync-to-strapi.ts --preview",
     "cms:sync": "bun .github/scripts/cms/sync-to-strapi.ts",

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -1,11 +1,11 @@
 ---
----
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 19292673
+translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.26.0": 42c568b4
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -100,6 +100,35 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.26.0" description="2026年6月23日">
+
+**新的开源模型支持**
+* [**Krea2**](https://links.comfy.org/4eC8714): 审美多样的开放权重 **RAW** / **Turbo** 组合 — 在 RAW 上训练 LoRA，在 Turbo 上进行 8 步推理
+* [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): 文生图模型，使用 Qwen3-VL-8B 文本编码器；[**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) 节点增加了带负面提示词和可选参考图像的图像编辑功能
+* [**Qwen3-VL 文本生成**](https://github.com/Comfy-Org/ComfyUI/pull/14298): 使用 Qwen3-VL 4B 和 8B 模型进行带图像理解的文本生成
+* [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2 角色替换的多参考支持
+
+**新节点**
+* [**LTX2 上下文窗口**](https://github.com/Comfy-Org/ComfyUI/pull/13325): LTX-2 多模态视频+音频模型的上下文窗口采样，支持 IC-LoRA 引导拼接
+* [**Load3DAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/14316): 仅网格的 3D 加载器，输出 model_3d、camera_info、model_3d_info、宽度和高度
+* [**保存节点输出接口**](https://github.com/Comfy-Org/ComfyUI/pull/13866): 为保存节点新增输出接口，以便连接下游管线
+
+**合作伙伴节点更新**
+* [**Luma Rays 3.2**](https://github.com/Comfy-Org/ComfyUI/pull/14540): 为 Luma Ray 3.2 视频生成新增七个节点
+
+**性能与稳定性**
+* [**Krea 2**](https://github.com/Comfy-Org/ComfyUI/pull/14594): 更准确的内存使用因子
+* [**Dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/14577): 提示用户尝试原生格式，而不是禁用动态 VRAM
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14557): 小幅推理优化
+* [**Jobs API**](https://github.com/Comfy-Org/ComfyUI/pull/14493): 新增取消端点 (`POST /api/jobs/{job_id}/cancel`, `POST /api/jobs/cancel`)
+
+**问题修复**
+* [**资产面板**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11716): 修复了滚动大型作业时出现重复媒体条目的问题
+* [**高级输入**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12652): 修复了折叠高级部分后已连接的高级输入被隐藏的问题
+* [**工作流恢复**](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12659): 修复了重新加载后台工作流后缺少子图节点预览的问题
+
+</Update>
 
 <Update label="v0.25.1" description="2026年6月16日">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -5,7 +5,7 @@ icon: "clock-rotate-left"
 translationSourceHash: 276f0161
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.26.0": 42c568b4
+  "v0.26.0": e0ef7a1b
   "v0.25.1": b23dd37e
   "v0.25.0": c322196d
   "v0.24.1": 3091a9fd
@@ -104,7 +104,7 @@ translationBlockHashes:
 <Update label="v0.26.0" description="2026年6月23日">
 
 **新的开源模型支持**
-* [**Krea2**](https://links.comfy.org/4eC8714): 审美多样的开放权重 **RAW** / **Turbo** 组合 — 在 RAW 上训练 LoRA，在 Turbo 上进行 8 步推理
+* [**Krea2**](https://links.comfy.org/4eC8714): Krea 的开源图像模型，审美和风格范围广泛 — 开放权重 **RAW** / **Turbo** 组合；在 RAW 上训练 LoRA，在 Turbo 上运行 8 步推理
 * [**Boogu-Image**](https://github.com/Comfy-Org/ComfyUI/pull/14523): 文生图模型，使用 Qwen3-VL-8B 文本编码器；[**TextEncodeBooguEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14529) 节点增加了带负面提示词和可选参考图像的图像编辑功能
 * [**Qwen3-VL 文本生成**](https://github.com/Comfy-Org/ComfyUI/pull/14298): 使用 Qwen3-VL 4B 和 8B 模型进行带图像理解的文本生成
 * [**SCAIL-2 Multireference**](https://github.com/Comfy-Org/ComfyUI/pull/14509): SCAIL-2 角色替换的多参考支持


### PR DESCRIPTION
## Summary

- Add **v0.26.0** release notes to `changelog/index.mdx` (Krea2, Boogu-Image, Qwen3-VL, SCAIL-2 multiref, LTX2 context windows, Load3DAdvanced, Luma Rays 3.2, perf fixes, frontend bug fixes) with ja/zh/ko translations
- Fix changelog **incremental translation**: `update_blocks` now re-translates when `translationBlockHashes` change, not only for new version labels; add unit tests
- Split CMS prepare into **`cms:prepare:en`** and **`cms:prepare:locales`**, update simplify prompt/skills (omit ComfyUI-WIKI embedded-docs / workflow-templates / blueprints), and record **v0.26.0** in `published-versions.json`
- Add **`cms:sync --force`** to update already-published Strapi release notes

## Test plan

- [ ] Mintlify preview: `changelog/index.mdx` renders v0.26.0 block correctly (links on bold titles)
- [ ] `bun test ./.github/scripts/i18n/chunked-translate.test.ts` passes
- [ ] `pnpm translate:dry-run -- changelog/index.mdx` shows 0 pending (translations up to date)
- [ ] Verify ja/zh/ko v0.26.0 blocks match EN structure (94 version blocks preserved)