### PR TITLE
Simplify partner node pricing and sync translations

### DIFF
--- a/ja/tutorials/partner-nodes/pricing.mdx
+++ b/ja/tutorials/partner-nodes/pricing.mdx
@@ -3,48 +3,47 @@ title: "価格"
 description: "本記事では、現在提供中のパートナーノードの価格を一覧表示します。すべての価格はクレジット単位（211クレジット = 1米ドル）で表記されています。"
 sidebarTitle: "価格"
 mode: wide
-translationSourceHash: 01471717
+translationSourceHash: 48347eb0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": 845592d4
-  "Beeble": 885c0b0f
-  "BFL": c049375b
-  "Anthropic": 7966fafa
-  "Bria": c7c492a1
-  "ByteDance": c45deeb8
-  "ElevenLabs": 6adeca08
-  "Freepik": cf21eaf2
-  "Google": 22aa3ea9
-  "HappyHorse": 28d2c09d
-  "Hitpaw": 3f19a1ce
-  "Ideogram": 6b1fa01c
-  "Krea": 67613c4e
-  "Kling": ba141835
-  "Lightricks": c29a5b7e
-  "Luma": 41bd0a3f
-  "Meshy": 3a0f5a43
-  "Minimax": e2e387a5
-  "Moonvalley": 8ca8c186
-  "OpenAI": 6842a6d6
-  "OpenRouter": a437d408
-  "Pika": 117ad27b
-  "Pixverse": 6fa7019b
-  "Quiver": 199f7f57
-  "Recraft": 48d0028a
-  "Reve": 82943ad5
-  "Rodin": 69c74113
-  "Runway": f2115adb
-  "Sonilo": 9b1be9b8
-  "Stability AI": 488faf10
-  "Tencent": 5d02a5cc
-  "Topaz": 8f39ff22
-  "Tripo": 2f8e0275
-  "Vidu": 50f09885
-  "WAN": b01edeb4
-  "Wavespeed": 17bdbfd6
-  "xAI": edfd0753
-  "Other (Cloud)": 9101685b
+  "Anthropic": a7ca54bf
+  "Beeble": d1b19f61
+  "BFL": 3ff6bff0
+  "Bria": 232ed8f6
+  "ByteDance": 19edbf0b
+  "ElevenLabs": 166ecbf9
+  "Magnific": 4000e7e1
+  "Google": 7b3926a3
+  "HappyHorse": bceb584a
+  "Hitpaw": 320c0537
+  "Ideogram": d9748301
+  "Krea": fb20c257
+  "Kling": cdf2c899
+  "Lightricks": 4870964f
+  "Luma": 655207a5
+  "Meshy": 6cd06881
+  "Minimax": 28c7cf5e
+  "OpenAI": 27febd17
+  "OpenRouter": 07b4b92f
+  "Pixverse": 8612b816
+  "Quiver": b9d45a82
+  "Recraft": 7eb9a1a7
+  "Reve": 5be5c43a
+  "Rodin 3D": 2eb41834
+  "Runway": 94ec479a
+  "Sonilo": 48b9c581
+  "Stability AI": ddca722f
+  "Tencent": f1efbad9
+  "Topaz": 3eabf417
+  "Tripo": 0d9ddbf9
+  "Vidu": 8ae05bc9
+  "Wan": c51a9eef
+  "WaveSpeed": 349a7c9d
+  "xAI": 7e81e67b
+  "Cloud GPU": 103c55e6
 ---
+
 
 
 
@@ -53,1056 +52,1076 @@ translationBlockHashes:
 
 211クレジット = 1米ドル
 
+## Anthropic
+
+Anthropicのパートナーノードは、公開Anthropic APIと同じUSDベースの使用量に応じて課金されます。**クレジット = USD × 211**（ページヘッダー参照）。以下の入力および出力レートは1Kトークンあたりのもので、`ClaudeNode`の価格表示と一致しています。キャッシュの読み取りと書き込みでは、キャッシュされたトークン数に対してAnthropicの乗数（入力レートの0.1倍、1.25倍、2.0倍）が適用されます。
+
+### チャット (`ClaudeNode`)
+
+| モデル      | 入力クレジット / 1K | 5分キャッシュ書き込みクレジット / 1K | 1時間キャッシュ書き込みクレジット / 1K | キャッシュヒットクレジット / 1K | 出力クレジット / 1K |
+| :--------- | -----------------: | --------------------------: | --------------------------: | ---------------------: | :------------------ |
+| Opus 4.7   |              1.055 |                     1.31875 |                        2.11 |                 0.1055 | 5.275               |
+| Opus 4.6   |              1.055 |                     1.31875 |                        2.11 |                 0.1055 | 5.275               |
+| Sonnet 4.6 |              0.633 |                     0.79125 |                       1.266 |                 0.0633 | 3.165               |
+| Sonnet 4.5 |              0.633 |                     0.79125 |                       1.266 |                 0.0633 | 3.165               |
+| Haiku 4.5  |              0.211 |                     0.26375 |                       0.422 |                 0.0211 | 1.055               |
+
+オプションの画像は、同じモデル入力レートで課金されるトークンを追加します。
+
 ## Beeble
 
-| 製品名               | 設定                                             | クレジット       | カテゴリ |
-| :------------------------- | :---------------------------------------- | :------------ | :------- |
-| SwitchX | モデル: switchx, 出力タイプ: ビデオ, 解像度: 720p | 30.17 / 30フレーム | ビデオ    |
-| SwitchX | モデル: switchx, 出力タイプ: ビデオ, 解像度: 1080p | 90.52 / 30フレーム | ビデオ    |
-| SwitchX | モデル: switchx, 出力タイプ: 画像, 解像度: 720p  | 30.17 / run       | 画像    |
-| SwitchX | モデル: switchx, 出力タイプ: 画像, 解像度: 1080p | 90.52 / run       | 画像    |
+### ビデオ: SwitchX Video Edit
+
+| 最大解像度 | クレジット                |
+| :------- | :---------------------- |
+| 720p     | 30.17 / 30フレーム       |
+| 1080p    | 90.52 / 30フレーム       |
+
+### 画像: SwitchX Image Edit
+
+| 最大解像度 | クレジット          |
+| :------- | :---------------- |
+| 720p     | 30.17 / 実行       |
+| 1080p    | 90.52 / 実行       |
 
 ## BFL
 
-| モデル                    | クレジット                        | カテゴリ |
-| :------------------------- | :-------------------------------- | :------- |
-| flux-dev                   | 5.28 / 実行                       | 画像    |
-| flux-kontext-max           | 16.88 / 実行                      | 画像    |
-| flux-kontext-pro           | 8.44 / 実行                       | 画像    |
-| flux-pro-1.0-canny         | 10.55 / 実行                      | 画像    |
-| flux-pro-1.0-depth         | 10.55 / 実行                      | 画像    |
-| flux-pro-1.0-expand        | 10.55 / 実行                      | 画像    |
-| flux-pro-1.0-fill          | 10.55 / 実行                      | 画像    |
-| flux-tools/erase-v1        | 6.33 / 回 + 0.84 / 追加 MP        | 画像    |
-| flux-tools/vto-v1          | 7.91 / 回 + 1.06 / 追加 MP        | 画像    |
-| flux-pro-1.1               | 8.44 / 実行                       | 画像    |
-| flux-pro-1.1-ultra         | 12.66 / 実行                      | 画像    |
-| /v1/flux-pro               | 10.55 / 実行                      | 画像    |
-| flux-2-pro                 | 6.33 / 回 + 3.17 / 追加 MP        | 画像    |
-| flux-2-max                 | 14.77 / 回 + 6.33 / 追加 MP        | 画像    |
-
-## Anthropic
-
-Anthropic パートナーノードは、Anthropic 公開 API と同じUSD使用量で課金されます。**クレジット = USD × 211**（ページヘッダー参照）。以下のトークン価格は100万トークンあたりのものです。キャッシュ価格倍率は Anthropic prompt caching ドキュメントに準拠しています。
-
-### Chat (`ClaudeNode`)
-
-モデル: 100万トークンあたり
-
-| モデル | 入力クレジット / 1M | 5分キャッシュ書込クレジット / 1M | 1時間キャッシュ書込クレジット / 1M | キャッシュヒットクレジット / 1M | 出力クレジット / 1M |
-| :-------------- | ----------------: | ----------------------------: | ------------------------------: | ---------------------------: | ----------------: |
-| `claude-opus-4-7` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-6` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-5-20251101` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-1-20250805` | 3165 | 3956.25 | 6330 | 316.5 | 15825 |
-| `claude-sonnet-4-6` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-sonnet-4-5-20250929` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-haiku-4-5-20251001` | 211 | 263.75 | 422 | 21.1 | 1055 |
-
-オプションの画像は、同じモデル入力レートで課金されます。
+| ノード                       |            クレジット            |
+| :------------------------- | :---------------------------: |
+| Flux 1.1 [pro] Ultra 画像          |          12.66 / 回          |
+| Flux.1 Kontext [pro] 画像          |          8.44 / 回           |
+| Flux.1 Kontext [max] 画像          |          16.88 / 回          |
+| Flux.1 展開 画像        |          10.55 / 回          |
+| Flux.1 Fill 画像          |          10.55 / 回          |
+| Flux 消去画像           | 6.33 / 回 + 0.84 / 追加MP  |
+| Flux バーチャル試着        | 7.91 / 回 + 1.06 / 追加MP  |
+| Flux.2 [pro]               | 6.33 / 回 + 3.17 / 追加MP  |
+| Flux.2 [max]               | 14.77 / 回 + 6.33 / 追加MP |
 
 ## Bria
 
-| 製品名                 | 構成                             | クレジット     | カテゴリ |
-| :---------------------------- | :----------------------------------------- | :----------- | :-------- |
-| Bria Image Edit              | endpoint: v2/image/edit, model: fibo      | 8.44 / 実行  | 画像    |
-| Bria Image Remove Background | endpoint: v2/image/edit/remove_background | 3.8 / 実行   | 画像    |
-| Bria Video Remove Background | endpoint: v2/video/edit/remove_background | 0.89 / 秒 | ビデオ    |
-| Bria Video Green Screen     | endpoint: v2/video/edit/green_screen     | 0.89 / 秒 | ビデオ    |
-| Bria Video Replace Background | endpoint: v2/video/edit/replace_background | 0.89 / 秒 | ビデオ    |
-| Bria Transparent Video Background | endpoint: v2/video/edit/remove_background | 0.89 / 秒 | ビデオ    |
+### 画像
+
+| ノード                         | クレジット    |
+| :---------------------------- | :------------ |
+| Bria画像編集                   | 8.44 / 実行   |
+| Bria 画像背景除去               | 3.8 / 実行    |
+
+### ビデオ
+
+| ノード                                       | クレジット    |
+| :------------------------------------------- | :------------ |
+| Bria 動画背景除去                             | 0.89 / 秒     |
+| Bria ビデオグリーンスクリーン                 | 0.89 / 秒     |
+| Bria ビデオ背景置換                           | 0.89 / 秒     |
+| Bria 動画背景除去（透過）                     | 0.89 / 秒     |
 
 ## ByteDance
 
-| 製品名                                                                 | 構成                                                                                                               | クレジット               | カテゴリ |
-| :--------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- | :--------------------- | :------- |
-| BytePlus Seed Input Text Tokens（100万トークンあたり）                  | model: seed-2-0-pro-260328                                                                                         | 105.5 / 100万トークン   | Text     |
-| BytePlus Seed Input Text Tokens（100万トークンあたり）                  | model: seed-2-0-lite-260228                                                                                        | 52.75 / 100万トークン   | Text     |
-| BytePlus Seed Input Text Tokens（100万トークンあたり）                  | model: seed-2-0-mini-260215                                                                                        | 21.1 / 100万トークン    | Text     |
-| BytePlus Seed Output Text Tokens（100万トークンあたり）                 | model: seed-2-0-pro-260328                                                                                         | 633 / 100万トークン     | Text     |
-| BytePlus Seed Output Text Tokens（100万トークンあたり）                 | model: seed-2-0-lite-260228                                                                                        | 422 / 100万トークン     | Text     |
-| BytePlus Seed Output Text Tokens（100万トークンあたり）                 | model: seed-2-0-mini-260215                                                                                        | 84.4 / 100万トークン    | Text     |
-| BytePlus Seed Cache Hit Input Tokens（100万トークンあたり）             | model: seed-2-0-pro-260328                                                                                         | 21.1 / 100万トークン    | Text     |
-| BytePlus Seed Cache Hit Input Tokens（100万トークンあたり）             | model: seed-2-0-lite-260228                                                                                        | 10.55 / 100万トークン   | Text     |
-| BytePlus Seed Cache Hit Input Tokens（100万トークンあたり）             | model: seed-2-0-mini-260215                                                                                        | 4.22 / 100万トークン    | Text     |
-| BytePlus Image Generation Product                                      | model: seededit-3-0-i2i-250628                                                                                      | 6.33 / 実行            | Image    |
-| BytePlus Image Generation Product                                      | model: seedream-3-0-t2i-250415                                                                                      | 6.33 / 実行            | Image    |
-| BytePlus Image Generation Product                                      | model: seedream-4-0-250828                                                                                          | 6.33 / 実行            | Image    |
-| BytePlus Image Generation Product                                      | model: seedream-4-5-251128                                                                                          | 8.44 / 実行            | Image    |
-| BytePlus Image Generation Product                                      | model: seedream-5-0-260128                                                                                          | 7.39 / 実行            | Image    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-lite-i2v-250428, video_type: 画像から動画へ                                                     | 379.8 / 100万トークン   | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-lite-t2v-250428, video_type: テキストから動画へ                                                  | 379.8 / 100万トークン   | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-pro-250528, video_type: 画像から動画へ                                                           | 527.5 / 100万トークン   | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-pro-250528, video_type: テキストから動画へ                                                        | 527.5 / 100万トークン   | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-pro-fast-251015, video_type: 画像から動画へ                                                      | 211 / 100万トークン     | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedance-1-0-pro-fast-251015, video_type: テキストから動画へ                                                   | 211 / 100万トークン     | Video    |
-| BytePlus Video Generation Product（100万トークンあたり）                | model: seedream-4-5-251128, video_type: テキストから動画へ                                                            | 211 / 100万トークン     | Video    |
-| BytePlus Video Generation With Audio（100万トークンあたり）             | generate_audio: false, model: seedance-1-5-pro-251215                                                               | 253.2 / 100万トークン   | Video    |
-| BytePlus Video Generation With Audio（100万トークンあたり）             | generate_audio: true, model: seedance-1-5-pro-251215                                                                | 506.4 / 100万トークン   | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 720P, video_type: テキストから動画へ（動画入力なし：テキストまたは画像）                | 2.112 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 720P, video_type: 画像から動画へ（動画入力なし：テキストまたは画像）               | 2.112 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 720P, video_type: 動画から動画へ（動画入力あり）                              | 1.297 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 1080P, video_type: テキストから動画へ（動画入力なし：テキストまたは画像）               | 2.323 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 1080P, video_type: 画像から動画へ（動画入力なし：テキストまたは画像）              | 2.323 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 1080P, video_type: 動画から動画へ（動画入力あり）                             | 1.418 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 4K, video_type: テキストから動画へ（動画入力なし：テキストまたは画像）                | 1.207 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 4K, video_type: 画像から動画へ（動画入力なし：テキストまたは画像）               | 1.207 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0, resolution: 4K, video_type: 動画から動画へ（動画入力あり）                                | 0.724 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: テキストから動画へ（動画入力なし：テキストまたは画像）          | 1.690 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: 画像から動画へ（動画入力なし：テキストまたは画像）         | 1.690 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: 動画から動画へ（動画入力あり）                         | 0.995 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: テキストから動画へ（動画入力なし：テキストまたは画像）          | 1.056 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: 画像から動画へ（動画入力なし：テキストまたは画像）         | 1.056 / Kトークン      | Video    |
-| BytePlus Video Generation Product（Kトークンあたり）                    | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: 動画から動画へ（動画入力あり）                         | 0.634 / Kトークン      | Video    |
+以下のクレジットはComfyUIパートナーノードの価格設定に対応しています（**211クレジット = 1米ドル**）。
 
-> **Seedance 2.0 トークン計算方式：** 出力トークン = (入力ビデオ時間 + 出力ビデオ時間) × 出力ビデオの長さ × 出力ビデオの幅 × 出力ビデオのフレームレート ÷ 1024。テキスト、画像、またはオーディオが入力の場合、入力時間は 0 として計算します。Seedance 2.0 の出力フレームレートは 24fps です。動画から動画への入力には、最低トークン使用量の制限が適用されます。
+### LLM: ByteDance Seed
+
+100万トークンあたり。以下の料金はプロンプト長 **[0, 128]K** に対応しています。より長いプロンプトは上位のティアが適用されます。
+
+| モデル                               | 入力クレジット / 100万 | キャッシュヒットクレジット / 100万 | 出力クレジット / 100万 |
+| :----------------------------------- | --------------------: | ------------------------------: | :-------------------- |
+| Seed 2.0 Pro (`seed-2-0-pro-260328`)   |                 105.5 |                           21.1  | 633                   |
+| Seed 2.0 Lite (`seed-2-0-lite-260228`) |                 52.75 |                          10.55  | 422                   |
+| Seed 2.0 Mini (`seed-2-0-mini-260215`) |                  21.1 |                           4.22  | 84.4                  |
+
+オプションの画像と動画は、入力レートで入力トークンが追加されます。
+
+### 画像: ByteDance Seedream 4.5 & 5.0
+
+正常に生成された画像1枚あたり。
+
+| モデル                                    | クレジット / 画像 |
+| :---------------------------------------- | :---------------: |
+| seedream 5.0 lite (`seedream-5-0-260128`) |       7.39        |
+| seedream-4-5-251128                       |       8.44        |
+| seedream-4-0-250828                       |       6.33        |
+
+### 画像: ByteDance Image（非推奨）
+
+| モデル                    | クレジット / 画像 |
+| :------------------------ | :---------------- |
+| seedream-3-0-t2i-250415   | 6.33              |
+
+### ビデオ: Seedance 2.0
+
+480pと720pは同じレートを共有します。FastとMiniは1080pまたは4Kをサポートしません。
+
+推定トークン消費量:
+
+`(入力ビデオ時間 + 出力ビデオ時間) × 出力ビデオ幅 × 出力ビデオ高さ × 出力ビデオフレームレート ÷ 1024`
+
+入力がテキスト、画像、またはオーディオのみの場合、入力ビデオ時間 = 0 です。APIからの実際の使用量が優先されます。
+
+| モデル             | 解像度  | ビデオ入力 | クレジット / 1Kトークン |
+| :---------------- | :------ | :--------- | --------------------: |
+| Seedance 2.0      | 480p, 720p | なし       |                 2.112 |
+| Seedance 2.0      | 480p, 720p | あり       |                 1.297 |
+| Seedance 2.0      | 1080p   | なし       |                 2.323 |
+| Seedance 2.0      | 1080p   | あり       |                 1.418 |
+| Seedance 2.0      | 4k      | なし       |                 1.207 |
+| Seedance 2.0      | 4k      | あり       |                 0.724 |
+| Seedance 2.0 Fast | 480p, 720p | なし       |                 1.690 |
+| Seedance 2.0 Fast | 480p, 720p | あり       |                 0.996 |
+| Seedance 2.0 Mini | 480p, 720p | なし       |                 1.056 |
+| Seedance 2.0 Mini | 480p, 720p | あり       |                 0.634 |
+
+**ビデオ入力**とは、参照ビデオが接続されていることを意味します。テキスト、画像、オーディオの参照はビデオ入力なしとしてカウントされます。
+
+動画から動画への入力には、最低トークン使用量が適用される場合があります。Seedance 2.0は24fpsで出力します。
+
+### ビデオ: Seedance 1.x
+
+トークン単位で課金されます（Seedance 2.0と同じ推定式）。Seedance 2.0とは異なり、**トークンレートは解像度によって変わりません**。解像度はクリップが使用するトークン数を変えるだけです（式の幅×高さにより）。そのため、高解像度ほどコストが高くなります。
+
+**トークンレート**
+
+| モデル                        | 条件                    | クレジット / 100万トークン |
+| :--------------------------- | :---------------------- | :---------------------- |
+| seedance-1-5-pro-251215      | `generate_audio: false` | 253.2                   |
+| seedance-1-5-pro-251215      | `generate_audio: true`  | 506.4                   |
+| seedance-1-0-pro-250528      | —                       | 527.5                   |
+| seedance-1-0-pro-fast-251015 | —                       | 211                     |
+
+**おおよそのクレジット / 10秒**（`duration ÷ 10` でスケール。範囲はアスペクト比を示します。）
+
+| モデル                        | 解像度 | オーディオ生成 | クレジット / 10秒 |
+| :--------------------------- | :----- | :------------- | :--------------- |
+| seedance-1-5-pro-251215      | 480p   | オフ           | 25.32            |
+| seedance-1-5-pro-251215      | 480p   | オン           | 50.64            |
+| seedance-1-5-pro-251215      | 720p   | オフ           | 54.86            |
+| seedance-1-5-pro-251215      | 720p   | オン           | 109.72           |
+| seedance-1-5-pro-251215      | 1080p  | オフ           | 122.38 – 124.49  |
+| seedance-1-5-pro-251215      | 1080p  | オン           | 244.76 – 249.0   |
+| seedance-1-0-pro-250528      | 480p   | —              | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p   | —              | 107.61 – 118.16  |
+| seedance-1-0-pro-250528      | 1080p  | —              | 248.98 – 257.42  |
+| seedance-1-0-pro-fast-251015 | 480p   | —              | 18.99 – 21.1     |
+| seedance-1-0-pro-fast-251015 | 720p   | —              | 44.31 – 48.53    |
+| seedance-1-0-pro-fast-251015 | 1080p  | —              | 99.17 – 103.39   |
+| seedance-1-0-lite-i2v-250428 | 480p   | —              | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p   | —              | 78.07 – 86.51    |
+| seedance-1-0-lite-i2v-250428 | 1080p  | —              | 179.35 – 185.68  |
+
+**ByteDance参照画像から動画生成**（480pと720pのみ）:
+
+| モデル                        | 解像度 | クレジット / 10秒 |
+| :--------------------------- | :----- | :--------------- |
+| seedance-1-0-pro-250528      | 480p   | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p   | 107.61 – 118.16  |
+| seedance-1-0-lite-i2v-250428 | 480p   | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p   | 78.07 – 86.51    |
 
 ## ElevenLabs
 
-| 製品名                           | 構成                                              | クレジット     | カテゴリ |
-| :-------------------------------------- | :---------------------------------------------------------- | :----------- | :-------- |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-dialogue, model: eleven_v3            | 50.64 / 実行 | オーディオ    |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-speech, model: eleven_multilingual_v2 | 50.64 / 実行 | オーディオ    |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-speech, model: eleven_v3              | 50.64 / 実行 | オーディオ    |
-| 11labs Speech-to-Text                  | endpoint: v1/speech-to-text, model: scribe_v2              | 92.84 / 実行 | オーディオ    |
-| 11labs Speech-to-Text Keyterm          | endpoint: v1/speech-to-text, model: scribe_v2              | 18.57 / 実行 | オーディオ    |
-| 11labs Speech-to-Text エンティティ検出 | endpoint: scribe_v2, model: v1/speech-to-text              | 27.85 / 実行 | オーディオ    |
-| 11labs Speech-to-Speech Per Minute     | endpoint: v1/speech-to-speech                              | 50.64 / 分 | オーディオ    |
-| 11labs Sound Generation Per Minute     | endpoint: v1/sound-generation                              | 29.54 / 分 | オーディオ    |
-| 11labs Audio Isolation Per Minute      | endpoint: v1/audio-isolation                               | 50.64 / 分 | オーディオ    |
-| 11labs Add Voice                       | endpoint: v1/voices/add                                    | 31.65 / 実行 | オーディオ    |
+| ノード                           | クレジット          |
+| :------------------------------- | :------------------ |
+| ElevenLabs テキスト読み上げ      | 50.64 / 1K chars    |
+| ElevenLabs テキストから対話へ    | 50.64 / 1K chars    |
+| ElevenLabs 音声からテキストへ    | 1.54 / min          |
+| ElevenLabs スピーチ・トゥ・スピーチ | 50.64 / min         |
+| ElevenLabs テキストから効果音へ  | 29.54 / min         |
+| ElevenLabs ボイスアイソレーション | 50.64 / min         |
+| ElevenLabs インスタントボイスクローン | 31.65 / 実行      |
 
-## Freepik
+## Magnific
 
-| 製品名                 | 構成                     | クレジット     | カテゴリ |
-| :---------------------------- | :--------------------------------- | :----------- | :-------- |
-| Freepik Image Per Generation | endpoint: magnific-relight        | 23.21 / 実行 | 画像    |
-| Freepik Image Per Generation | endpoint: magnific-style-transfer | 23.21 / 実行 | 画像    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-creative  | 61.19 / 実行 | 画像    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-faithful  | 78.07 / 実行 | 画像    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-flexible  | 94.95 / 実行 | 画像    |
-| Freepik Image Cost           | NA                                | 211 / 実行   | 画像    |
+### 画像：アップスケール
+
+**Magnific Image Upscale (Creative)** と **Magnific Image Upscale (Precise V2)** は同じ課金体系です。アップスケーリングは 2x ステップで実行されます（`2x` = 1 ステップ、`4x` = 2、`8x` = 3、`16x` = 4）。各ステップ後、ピクセル数は ×4 になります。各ステップは、そのステップ時点の入力メガピクセルで価格が決まります。
+
+| ステップ時の入力MP | クレジット / 2xステップ |
+| :--------------- | :---------------- |
+| ≤1.3             | 35.91             |
+| ≤3.0             | 71.82             |
+| ≤6.4             | 107.73            |
+| >6.4             | 430.88            |
+
+**総クレジット** = あなたの`scale_factor`に対する全ステップの合計。例：**4x** で 1 MP の画像 → ステップ1（1 MP、35.91）+ ステップ2（4 MP、107.73）= **143.64 クレジット**。
+
+### 画像：編集
+
+| ノード                                    | クレジット     |
+| :-------------------------------------- | :---------- |
+| Magnific画像スタイル転送           | 23.21 / 実行 |
+| Magnific画像リライティング                  | 23.21 / 実行 |
+| Magnific画像スキンエンハンサー (creative) | 61.19 / 実行 |
+| Magnific画像スキンエンハンサー (faithful) | 78.07 / 実行 |
+| Magnific画像スキンエンハンサー (flexible) | 94.95 / 実行 |
 
 ## Google
 
-| 製品名                                | 構成                                              | クレジット            | カテゴリ |
-| :------------------------------------------ | :---------------------------------------------------------- | :------------------ | :-------- |
-| prod-v1-Veo 2 Product                       | model: veo-2.0-generate-001                                | 105.5 / 実行        | 画像    |
-| prod-v1-Veo 2 Product                       | model: veo-3.0-generate-preview                            | 158.25 / 実行       | 画像    |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash-image                              | 63.3 / 100万トークン   | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash                                    | 63.3 / 100万トークン   | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-pro                                      | 263.75 / 100万トークン | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-flash-image-preview                      | 105.5 / 100万トークン  | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-pro-preview                              | 422 / 100万トークン    | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-image-preview                          | 422 / 100万トークン    | テキスト |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-preview                                | 422 / 100万トークン    | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 527.5 / 100万トークン  | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 527.5 / 100万トークン  | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 2110 / 100万トークン   | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 633 / 100万トークン    | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 2532 / 100万トークン   | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 2532 / 100万トークン   | テキスト |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 2532 / 100万トークン   | テキスト |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 100万トークン   | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 100万トークン   | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 100万トークン | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 105.5 / 100万トークン  | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 100万トークン    | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 100万トークン    | 画像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 100万トークン    | 画像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-2.5-flash-image                              | 6330 / 100万トークン   | 画像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-flash-image-preview                      | 12660 / 100万トークン  | 画像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-pro-preview                              | 25320 / 100万トークン  | 画像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3-pro-image-preview                          | 25320 / 100万トークン  | 画像    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 2K      | 21.31 / 実行        | 画像    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 4K      | 32.49 / 実行        | 画像    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 100万トークン   | ビデオ    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 100万トークン   | ビデオ    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 100万トークン | ビデオ    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 100万トークン    | ビデオ    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 100万トークン    | ビデオ    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 100万トークン    | ビデオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 211 / 100万トークン    | オーディオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 211 / 100万トークン    | オーディオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 100万トークン | オーディオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 100万トークン    | オーディオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 100万トークン    | オーディオ    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 100万トークン    | オーディオ    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: false, model: veo-3.0-fast-generate-001     | 168.8 / 実行        | ビデオ    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: false, model: veo-3.0-generate-001          | 337.6 / 実行        | ビデオ    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: true, model: veo-3.0-fast-generate-001      | 253.2 / 実行        | ビデオ    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: true, model: veo-3.0-generate-001           | 675.2 / 実行        | ビデオ    |
-| Google Veo2 Video Generation                | NA                                                         | 105.5 / 実行        | ビデオ    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.0-fast-generate-001     | 21.1 / 実行         | 画像    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.0-generate-001          | 42.2 / 実行         | 画像    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.1-fast-generate-preview | 21.1 / 実行         | 画像    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.1-generate-preview
+### チャット：Google Gemini
+
+トークンベースの課金です。思考トークンは出力テキストレートを使用します。
+
+| モデル                                                   | 入力クレジット / 1K | 出力クレジット / 1K |
+| :------------------------------------------------------ | -----------------: | :------------------ |
+| Gemini 3.1 Pro (`gemini-3.1-pro-preview`)               |              0.422 | 2.532               |
+| Gemini 3.1 Flash-Lite (`gemini-3.1-flash-lite-preview`) |            0.05275 | 0.3165              |
+| Gemini 2.5 Pro (`gemini-2.5-pro`)                       |            0.26375 | 2.11                |
+| Gemini 2.5 Flash (`gemini-2.5-flash`)                   |             0.0633 | 0.5275              |
+
+### 画像：Nano Banana
+
+トークンベースの課金です。
+
+| モデル                                            | 入力クレジット / 1K | 出力（テキスト）クレジット / 1K | 出力（画像）クレジット / 1K |
+| :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
+| Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image-preview`)   |              0.422 |                      2.532 | 25.32                       |
+| Nano Banana 2 (`gemini-3.1-flash-image-preview`) |             0.1055 |                      0.633 | 12.66                       |
+
+### ビデオ：Google Veo
+
+総クレジット = **（クレジット / 秒）× 時間**。
+
+| モデル                                  | 解像度  | generate_audio | クレジット / 秒 |
+| :------------------------------------- | :---------- | :------------- | :------------ |
+| veo-2.0-generate-001                   | —           | —              | 105.5         |
+| veo-3.1-lite                           | 720p        | false          | 6.33          |
+| veo-3.1-lite                           | 720p        | true           | 10.55         |
+| veo-3.1-lite                           | 1080p       | false          | 10.55         |
+| veo-3.1-lite                           | 1080p       | true           | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | false          | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | true           | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | false          | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | true           | 25.32         |
+| veo-3.1-fast-generate                  | 4k          | false          | 52.75         |
+| veo-3.1-fast-generate                  | 4k          | true           | 63.3          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | false          | 42.2          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | true           | 84.4          |
+| veo-3.1-generate                       | 4k          | false          | 84.4          |
+| veo-3.1-generate                       | 4k          | true           | 126.6         |
+| veo-3.0-fast-generate-001              | —           | false          | 21.1          |
+| veo-3.0-fast-generate-001              | —           | true           | 31.65         |
 
 ## HappyHorse
 
-| 製品名                           | 構成                                   | クレジット   | カテゴリ |
-| :------------------------------ | :------------------------------------- | :---------- | :------- |
-| HappyHorse ビデオ生成製品        | モデル: happyhorse1.0, 解像度: 720P    | 29.54 / 秒  | ビデオ   |
-| HappyHorse ビデオ生成製品        | モデル: happyhorse1.0, 解像度: 1080P   | 50.64 / 秒  | ビデオ   |
-| HappyHorse ビデオ生成製品        | モデル: happyhorse1.1, 解像度: 720P    | 42.24 / 秒  | ビデオ   |
-| HappyHorse ビデオ生成製品        | モデル: happyhorse1.1, 解像度: 1080P   | 54.31 / 秒  | ビデオ   |
+総クレジット = **(クレジット / 秒) × `duration`**。
 
-HappyHorse 1.1は、テキストから動画へ、画像から動画へ、参照から動画に同じ価格で対応しています。
+| モデル          | 解像度 | クレジット / 秒 |
+| :------------- | :----- | :------------- |
+| HappyHorse 1.0 | 720P   | 29.54          |
+| HappyHorse 1.0 | 1080P  | 50.64          |
+| HappyHorse 1.1 | 720P   | 42.24          |
+| HappyHorse 1.1 | 1080P  | 54.31          |
+
+**HappyHorse 動画編集**は **HappyHorse 1.0** のみ対応しています。同じレートで課金されます。総クレジット = **(クレジット / 秒) × 出力時間**（3～15秒、入力ビデオに依存）。
 
 ## Hitpaw
 
-### 動画強化
+### 動画: HitPaw 動画強化
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: &lt;30fps | 2.11 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: 30-60fps | 4.22 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: 60-120fps | 8.44 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: ≥120fps | 12.66 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: &lt;30fps | 3.17 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: 30-60fps | 6.33 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: 60-120fps | 12.66 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: ≥120fps | 18.99 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: &lt;30fps | 4.22 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: 30-60fps | 8.23 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: 60-120fps | 16.46 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: ≥120fps | 24.69 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: &lt;30fps | 5.28 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: 30-60fps | 10.76 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: 60-120fps | 21.31 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: ≥120fps | 32.07 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: &lt;30fps | 6.96 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: 30-60fps | 13.93 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: 60-120fps | 27.85 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: ≥120fps | 41.78 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: &lt;30fps | 3.17 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: 30-60fps | 6.54 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: 60-120fps | 13.08 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: ≥120fps | 19.41 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: &lt;30fps | 4.22 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: 30-60fps | 8.44 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: 60-120fps | 16.88 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: ≥120fps | 25.32 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: &lt;30fps | 5.49 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: 30-60fps | 10.97 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: 60-120fps | 21.94 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: ≥120fps | 32.92 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: &lt;30fps | 7.17 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: 30-60fps | 14.35 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: 60-120fps | 28.49 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: ≥120fps | 42.83 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: &lt;30fps | 9.28 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: 30-60fps | 18.57 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: 60-120fps | 37.14 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: ≥120fps | 55.7 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: &lt;30fps | 3.17 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: 30-60fps | 6.33 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: 60-120fps | 12.66 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: ≥120fps | 18.99 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: &lt;30fps | 5.28 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: 30-60fps | 10.55 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: 60-120fps | 21.1 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: ≥120fps | 31.65 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: &lt;30fps | 8.02 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: 30-60fps | 15.82 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: 60-120fps | 31.65 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: ≥120fps | 47.48 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: &lt;30fps | 11.82 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: 30-60fps | 23.84 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: 60-120fps | 47.48 / 秒 | ビデオ |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: ≥120fps | 71.32 / 秒 | ビデオ |
+総クレジット = **(クレジット / 秒) × ビデオの長さ**。レートは入力FPSに依存します。
 
-### 写真強化
+**Portrait Restore / General Restore** (Portrait Restore 1x/2x、General Restore 1x/2x/4x):
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: &lt;8MP | 2.11 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 8-12MP | 4.22 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 12-24MP | 6.33 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 24-48MP | 14.77 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 48-108MP | 29.54 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 108-216MP | 50.64 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 216-432MP | 101.28 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: &lt;8MP | 4.22 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 8-12MP | 6.33 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 12-24MP | 8.44 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 24-34MP | 12.66 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: &lt;8MP | 10.55 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 8-12MP | 12.66 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 12-24MP | 16.88 / 実行 | 画像 |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 24-34MP | 31.65 / 実行 | 画像 |
+| 解像度 | FPS       | クレジット / 秒 |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 2.11          |
+| 720P       | 30–60fps  | 4.22          |
+| 720P       | 60–120fps | 8.44          |
+| 720P       | ≥120fps   | 12.66         |
+| 1080P      | &lt;30fps | 3.17          |
+| 1080P      | 30–60fps  | 6.33          |
+| 1080P      | 60–120fps | 12.66         |
+| 1080P      | ≥120fps   | 18.99         |
+| 2K         | &lt;30fps | 4.22          |
+| 2K         | 30–60fps  | 8.23          |
+| 2K         | 60–120fps | 16.46         |
+| 2K         | ≥120fps   | 24.69         |
+| 4K         | &lt;30fps | 5.28          |
+| 4K         | 30–60fps  | 10.76         |
+| 4K         | 60–120fps | 21.31         |
+| 4K         | ≥120fps   | 32.07         |
+| 8K         | &lt;30fps | 6.96          |
+| 8K         | 30–60fps  | 13.93         |
+| 8K         | 60–120fps | 27.85         |
+| 8K         | ≥120fps   | 41.78         |
+
+**Ultra HD** (Ultra HD Model 2x):
+
+| 解像度 | FPS       | クレジット / 秒 |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 3.17          |
+| 720P       | 30–60fps  | 6.54          |
+| 720P       | 60–120fps | 13.08         |
+| 720P       | ≥120fps   | 19.41         |
+| 1080P      | &lt;30fps | 4.22          |
+| 1080P      | 30–60fps  | 8.44          |
+| 1080P      | 60–120fps | 16.88         |
+| 1080P      | ≥120fps   | 25.32         |
+| 2K         | &lt;30fps | 5.49          |
+| 2K         | 30–60fps  | 10.97         |
+| 2K         | 60–120fps | 21.94         |
+| 2K         | ≥120fps   | 32.92         |
+| 4K         | &lt;30fps | 7.17          |
+| 4K         | 30–60fps  | 14.35         |
+| 4K         | 60–120fps | 28.49         |
+| 4K         | ≥120fps   | 42.83         |
+| 8K         | &lt;30fps | 9.28          |
+| 8K         | 30–60fps  | 18.57         |
+| 8K         | 60–120fps | 37.14         |
+| 8K         | ≥120fps   | 55.7          |
+
+**Generative** (Generative Model 1x; 最大4K):
+
+| 解像度 | FPS       | クレジット / 秒 |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 3.17          |
+| 720P       | 30–60fps  | 6.33          |
+| 720P       | 60–120fps | 12.66         |
+| 720P       | ≥120fps   | 18.99         |
+| 1080P      | &lt;30fps | 5.28          |
+| 1080P      | 30–60fps  | 10.55         |
+| 1080P      | 60–120fps | 21.1          |
+| 1080P      | ≥120fps   | 31.65         |
+| 2K         | &lt;30fps | 8.02          |
+| 2K         | 30–60fps  | 15.82         |
+| 2K         | 60–120fps | 31.65         |
+| 2K         | ≥120fps   | 47.48         |
+| 4K         | &lt;30fps | 11.82         |
+| 4K         | 30–60fps  | 23.84         |
+| 4K         | 60–120fps | 47.48         |
+| 4K         | ≥120fps   | 71.32         |
+
+### 画像: HitPaw 一般画像強化
+
+**Generative Portrait**:
+
+| メガピクセル | クレジット / 実行 |
+| :--------- | :------------ |
+| &lt;8MP    | 4.22          |
+| 8–12MP     | 6.33          |
+| 12–24MP    | 8.44          |
+| 24–34MP    | 12.66         |
+
+**Generative**:
+
+| メガピクセル | クレジット / 実行 |
+| :--------- | :------------ |
+| &lt;8MP    | 10.55         |
+| 8–12MP     | 12.66         |
+| 12–24MP    | 16.88         |
+| 24–34MP    | 31.65         |
 
 ## Ideogram
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: DEFAULT     | 45.26 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: QUALITY     | 60.35 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: TURBO       | 30.17 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: BALANCED                  | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: DEFAULT                   | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: QUALITY                   | 27.16 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: TURBO                     | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: DEFAULT | 45.26 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: QUALITY | 60.35 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: TURBO   | 30.17 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: BALANCED              | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: DEFAULT               | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: QUALITY               | 27.16 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: TURBO                 | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: DEFAULT                | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: QUALITY                | 27.16 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: TURBO                  | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: BALANCED                 | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: DEFAULT                  | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: QUALITY                  | 27.16 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: TURBO                    | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: BALANCED    | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: DEFAULT     | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: QUALITY     | 27.16 / 実行 | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: TURBO       | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: remix, rendering_speed: TURBO                                | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: TURBO                 | 9.05 / 実行  | 画像    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: DEFAULT               | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: QUALITY               | 30.17 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2                                             | 24.14 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2_turbo                                       | 15.09 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1                                         | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1_turbo                                   | 6.03 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a                                        | 12.07 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a_turbo                                  | 7.54 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2                                         | 24.14 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2_turbo                                   | 15.09 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2                                          | 24.14 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2_turbo                                    | 15.09 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1                                            | 18.1 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1_turbo                                      | 6.03 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a                                           | 12.07 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a_turbo                                     | 7.54 / 実行  | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2                                            | 24.14 / 実行 | 画像    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2_turbo                                      | 15.09 / 実行 | 画像    |
+| ノード       | ターボ | キャラクター参照 | レンダリング速度 | クレジット / 画像 |
+| :----------- | :----- | :--------------- | :--------------- | :---------------- |
+| Ideogram V1  | なし   | —                | —                | 18.1              |
+| Ideogram V1  | あり   | —                | —                | 6.03              |
+| Ideogram V2  | なし   | —                | —                | 24.14             |
+| Ideogram V2  | あり   | —                | —                | 15.09             |
+| Ideogram V3  | —      | なし             | TURBO            | 9.05              |
+| Ideogram V3  | —      | なし             | DEFAULT          | 18.1              |
+| Ideogram V3  | —      | なし             | QUALITY          | 27.16             |
+| Ideogram V3  | —      | あり             | TURBO            | 30.17             |
+| Ideogram V3  | —      | あり             | DEFAULT          | 45.26             |
+| Ideogram V3  | —      | あり             | QUALITY          | 60.35             |
+| Ideogram V4  | —      | —                | TURBO            | 9.05              |
+| Ideogram V4  | —      | —                | DEFAULT          | 18.1              |
+| Ideogram V4  | —      | —                | QUALITY          | 30.17             |
 
 ## Krea
 
-| 商品名 | 設定 | クレジット | カテゴリ |
-| :----- | :--- | :--------- | :------- |
-| Krea 2 Image Generation | model: krea-2-medium-turbo | 3.2 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-medium-turbo、画像スタイル参照あり | 3.7 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-medium-turbo、ムードボードあり | 4.2 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-medium | 6.4 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-medium、画像スタイル参照あり | 7.4 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-medium、ムードボードあり | 8.5 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-large | 12.7 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-large、画像スタイル参照あり | 13.8 / 実行 | 画像 |
-| Krea 2 Image Generation | model: krea-2-large、ムードボードあり | 14.8 / 実行 | 画像 |
+| モデル | スタイル参照 | ムードボード | クレジット/実行 |
+| :----- | :---------- | :----------- | :------------- |
+| Krea 2 Medium Turbo | なし | なし | 3.17 |
+| Krea 2 Medium Turbo | あり | なし | 3.69 |
+| Krea 2 Medium Turbo | - | あり | 4.22 |
+| Krea 2 Medium | なし | なし | 6.33 |
+| Krea 2 Medium | あり | なし | 7.39 |
+| Krea 2 Medium | - | あり | 8.44 |
+| Krea 2 Large | なし | なし | 12.66 |
+| Krea 2 Large | あり | なし | 13.72 |
+| Krea 2 Large | - | あり | 14.77 |
 
 ## Kling
 
-| 製品名                              | 構成                                                         | クレジット    | カテゴリ |
-| :---------------------------------- | :----------------------------------------------------------- | :------------ | :------- |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v1                                   | 103.39 / 実行 | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v1-5                                 | 103.39 / 実行 | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v1-6                                 | 103.39 / 実行 | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v2-1                                 | 103.39 / 実行 | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v2-1-master                          | 295.4 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v2-5-turbo                           | 73.85 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: pro, model: kling-v2-master                            | 295.4 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v1                                   | 29.54 / 秒   | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v1-5                                 | 59.08 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v1-6                                 | 59.08 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v2-1                                 | 59.08 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v2-1-master                          | 295.4 / 実行  | ビデオ   |
-| prod-v1-Kling Video Generation Product | mode: std, model: kling-v2-master                            | 295.4 / 実行  | ビデオ   |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v2-6, sound: off                     | 14.77 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v2-6, sound: on                      | 29.54 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-v3, no_sound: true           | 23.63 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-v3, no_sound: false          | 35.45 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-v3, no_sound: true            | 17.72 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-v3, no_sound: false           | 26.59 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-omni, no_sound: true              | 23.63 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-omni, no_sound: false             | 29.54 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: std, model: kling-v3-omni, no_sound: true              | 17.72 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: std, model: kling-v3-omni, no_sound: false             | 23.63 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-4k                                | 88.62 / 秒   | ビデオ   |
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-3.0-turbo | 23.63 / 秒 | ビデオ |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-3.0-turbo | 29.54 / 秒 | ビデオ |
-| Kling Omni Video Product                  | generate_with_video: false, mode: pro, model: kling-video-o1 | 23.63 / 秒  | ビデオ   |
-| Kling Omni Video Product                  | generate_with_video: false, mode: std, model: kling-video-o1 | 17.72 / 秒  | ビデオ   |
-| Kling Omni Video Product                  | generate_with_video: true, mode: pro, model: kling-video-o1  | 35.45 / 秒  | ビデオ   |
-| Kling Omni Video Product                  | generate_with_video: true, mode: std, model: kling-video-o1  | 26.59 / 秒  | ビデオ   |
-| Kling Video Extension Product             | NA                                                           | 59.08 / 実行  | ビデオ   |
-| Kling Lip Sync Product                    | NA                                                           | 14.77 / 実行  | 画像     |
-| Kling Motion Control Product              | mode: std, model: kling-v2-6                                 | 14.77 / 実行  | 画像     |
-| Kling Motion Control Product              | mode: pro, model: kling-v2-6                                 | 23.63 / 実行  | 画像     |
-| Kling Virtual Try On                      | model: kolors-virtual-try-on-v1                              | 14.77 / 実行  | 画像     |
-| Kling Virtual Try On                      | model: kolors-virtual-try-on-v1-5                            | 14.77 / 実行  | 画像     |
-| Kling Image Generation Product            | model: kling-v1, operation: text_to_image                    | 0.74 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v1, operation: image_to_image                   | 0.74 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v1-5, operation: text_to_image                  | 2.95 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v1-5, operation: image_to_image                 | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v2, operation: text_to_image                    | 2.95 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v2-new, operation: image_to_image_restyle       | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v2-1, operation: text_to_image                  | 2.95 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: text_to_image         | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 2k, operation: text_to_image         | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: image_to_image        | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 2k, operation: image_to_image        | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: image_editing         | 11.82 / 実行  | 画像     |
-| Kling Image Generation Product            | model: kling-v3, specs: 4k, operation: image_editing         | 11.82 / 実行  | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: text_to_image    | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 2k, operation: text_to_image    | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: image_to_image   | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 2k, operation: image_to_image   | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: image_editing    | 11.82 / 実行  | 画像     |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 4k, operation: image_editing    | 11.82 / 実行  | 画像     |
-| Kling Image Generation Product            | model: kling-image-o1, operation: text_to_image               | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-image-o1, operation: image_to_image              | 5.91 / 実行   | 画像     |
-| Kling Image Generation Product            | model: kling-image-o1, operation: image_editing               | 5.91 / 実行   | 画像     |
-| Kling Image Generation w/ N               | model: kling-v1, operation: text_to_image                    | 0.74 / 実行   | 画像     |
-| Kling Image Generation w/ N               | model: kling-v1, operation: image_to_image                   | 0.74 / 実行   | 画像     |
-| Kling Image Generation w/ N               | model: kling-v1-5, operation: text_to_image                  | 2.95 / 実行   | 画像     |
-| Kling Image Generation w/ N               | model: kling-v1-5, operation: image_to_image                 | 5.91 / 実行   | 画像     |
-| Kling Image Generation w/ N               | model: kling-v2, operation: text_to_image                    | 2.95 / 実行   | 画像     |
-| Kling Credits                             | type: image                                                  | 0.74 / 実行   | 画像     |
-| Kling Credits                             | type: video                                                  | 29.54 / 実行  | 画像     |
-| Kling Camera Control Product              | type: text-to-video                                           | 29.54 / 実行  | ビデオ   |
-| Kling Camera Control Product              | type: image-to-video                                          | 103.39 / 実行 | ビデオ   |
-| Kling Avatar Product                      | mode: std                                                     | 11.82 / 秒   | ビデオ   |
-| Kling Avatar Product                      | mode: pro                                                     | 23.63 / 秒   | ビデオ   |
-| Kling 2.6 Audio Product                   | mode: text-to-video, no_sound: true                           | 14.77 / 秒   | ビデオ   |
-| Kling 2.6 Audio Product                   | mode: text-to-video, no_sound: false                          | 29.54 / 秒   | ビデオ   |
-| Kling 2.6 Audio Product                   | mode: image-to-video, no_sound: true                          | 14.77 / 秒   | ビデオ   |
-| Kling 2.6 Audio Product                   | mode: image-to-video, no_sound: false                         | 29.54 / 秒   | ビデオ   |
+### ビデオ: クレジット / 秒
+
+総クレジット = **(クレジット / 秒) × `duration`**。ただし、**Kling 3.0 Omni Edit Video** および **Klingモーションコントロール** は除きます（出力1秒あたりの課金。Edit では duration は入力ビデオに従います）。
+
+#### kling-video-o1
+
+| タスク                 | 解像度 | クレジット / 秒 |
+| :------------------- | :--------- | :------------ |
+| 生成           | 720p       | 17.72         |
+| 生成           | 1080p      | 23.63         |
+| ビデオからビデオへ、編集 | 720p       | 26.59         |
+| ビデオからビデオへ、編集 | 1080p      | 35.45         |
+
+#### kling-v3-omni
+
+| タスク                 | 解像度 | オーディオ生成 | クレジット / 秒 |
+| :------------------- | :--------- | :------------- | :------------ |
+| 生成           | 720p       | false          | 17.72         |
+| 生成           | 720p       | true           | 23.63         |
+| 生成           | 1080p      | false          | 23.63         |
+| 生成           | 1080p      | true           | 29.54         |
+| 生成           | 4k         | false, true    | 88.62         |
+| ビデオからビデオへ、編集 | 720p       | —              | 26.59         |
+| ビデオからビデオへ、編集 | 1080p      | —              | 35.45         |
+
+#### kling-3.0-turbo
+
+常にオーディオを生成します。オーディオの切り替えは無視されます。
+
+| 解像度 | クレジット / 秒 |
+| :--------- | :------------ |
+| 720p       | 23.63         |
+| 1080p      | 29.54         |
+
+#### kling-v3
+
+| タスク       | 解像度 | オーディオ生成 | クレジット / 秒 |
+| :--------- | :--------- | :------------- | :------------ |
+| 生成 | 720p       | false          | 17.72         |
+| 生成 | 720p       | true           | 26.59         |
+| 生成 | 1080p      | false          | 23.63         |
+| 生成 | 1080p      | true           | 35.45         |
+| 生成 | 4k         | false, true    | 88.62         |
+
+| タスク           | モード | クレジット / 秒 |
+| :------------- | :--- | :------------ |
+| モーションコントロール | std  | 26.59         |
+| モーションコントロール | プロ  | 35.45         |
+
+#### kling-v2-6
+
+| タスク           | オーディオ生成 | モード | クレジット / 秒 |
+| :------------- | :------------- | :--- | :------------ |
+| 生成     | false          | —    | 14.77         |
+| 生成     | true           | —    | 29.54         |
+| モーションコントロール | —              | std  | 14.77         |
+| モーションコントロール | —              | プロ  | 23.63         |
+
+#### レガシー (v2-5-turbo, v2-master, v1.x)
+
+| モデル                                        | モード     | クレジット / 秒 |
+| :------------------------------------------- | :------- | :------------ |
+| kling-v2-5-turbo                             | プロ      | 14.77         |
+| kling-v2-master, kling-v2-1-master           | std, プロ | 59.08         |
+| kling-v1-5, kling-v1-6, kling-v2-1           | std      | 11.82         |
+| kling-v1                                     | std      | 5.91          |
+| kling-v1, kling-v1-5, kling-v1-6, kling-v2-1 | プロ      | 20.68         |
+
+#### Kling Avatar 2.0
+
+| モード | クレジット / 秒 |
+| :--- | :------------ |
+| std  | 11.82         |
+| プロ  | 23.63         |
+
+**Kling テキスト/画像から動画へ（カメラコントロール）**: 固定 **5s**、`kling-v1` std または `kling-v1-5` プロ（レガシーテーブル）を使用。
+
+### ビデオ: クレジット / 実行
+
+| モデル      | タスク                       | クレジット / 実行 |
+| :--------- | :------------------------- | :------------ |
+| kling-v1-6 | ほとんどのエフェクトシーン         | 59.08         |
+| kling-v1-6 | `dizzydizzy`, `bloombloom` | 103.39        |
+| —          | ビデオ拡張               | 59.08         |
+| —          | リップシンク                   | 21.1          |
+
+### 画像
+
+| モデル                                                | 解像度 | 画像入力 | クレジット       |
+| :--------------------------------------------------- | :--------- | :---------- | :------------ |
+| kling-image-o1                                       | 1K, 2K     | —           | 5.91 / 画像  |
+| kling-image-o1                                       | 4K         | —           | 11.82 / 画像 |
+| kling-v3-omni                                        | 1K, 2K     | —           | 5.91 / 画像  |
+| kling-v3-omni                                        | 4K         | —           | 11.82 / 画像 |
+| kling-v3                                             | —          | なし          | 5.91 / 画像  |
+| kling-v2                                             | —          | なし、あり     | 2.95 / 画像  |
+| kling-v1-5                                           | —          | なし          | 2.95 / 画像  |
+| kling-v1-5                                           | —          | あり         | 5.91 / 画像  |
+| kolors-virtual-try-on-v1, kolors-virtual-try-on-v1-5 | —          | —           | 147.7 / 実行   |
+
+画像の総クレジット = **(クレジット / 画像) × `n`**（**Kling 3.0 Image** の場合）。**Kling 3.0 Omni Image** の場合は `series_amount` を乗算（`kling-image-o1` は常に ×1）。
 
 ## Lightricks
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-fast, 解像度: 1920x1080 | 8.44 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-fast, 解像度: 2560x1440 | 16.88 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-fast, 解像度: 3840x2160 | 33.76 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-pro, 解像度: 1920x1080 | 12.66 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-pro, 解像度: 2560x1440 | 25.32 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: 画像からビデオ, モデル: ltx-2-pro, 解像度: 3840x2160 | 50.64 / 実行 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-fast, 解像度: 1920x1080 | 8.44 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-fast, 解像度: 2560x1440 | 16.88 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-fast, 解像度: 3840x2160 | 33.76 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-pro, 解像度: 1920x1080 | 12.66 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-pro, 解像度: 2560x1440 | 25.32 / 秒 | ビデオ |
-| Ltx ビデオ生成プロダクト | エンドポイント: テキストからビデオ, モデル: ltx-2-pro, 解像度: 3840x2160 | 50.64 / 実行 | ビデオ |
+### ビデオ: クレジット / 秒
+
+総クレジット = **(クレジット / 秒) × `duration`** .
+
+| モデル        | 解像度      | クレジット      |
+| :----------- | :--------- | :----------- |
+| LTX-2 (Pro)  | 1080p      | 12.66 / 秒  |
+| LTX-2 (Pro)  | 1440p      | 25.32 / 秒  |
+| LTX-2 (Pro)  | 4K         | 50.64 / 秒  |
+| LTX-2 (Fast) | 1080p      | 8.44 / 秒   |
+| LTX-2 (Fast) | 1440p      | 16.88 / 秒  |
+| LTX-2 (Fast) | 4K         | 33.76 / 秒  |
+
+解像度は `1920x1080`, `2560x1440`, `3840x2160` に対応します。10秒を超える再生時間は、**LTX-2 (Fast)** 、1080p、25 FPS でのみご利用いただけます。
 
 ## Luma
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| prod-v1-Luma Video Generation Product               | model: ray-1-6                                                                                   | 0.97 / 秒   | ビデオ    |
-| prod-v1-Luma Video Generation Product               | model: ray-2                                                                                     | 1.93 / 秒   | ビデオ    |
-| prod-v1-Luma Video Generation Product               | model: ray-flash-2                                                                               | 0.66 / 秒   | ビデオ    |
-| Luma Image Generations (millions of pixels) Product | model: photon-1                                                                                  | 2.2 / 実行  | 画像    |
-| Luma Image Generations (millions of pixels) Product | model: photon-flash-1                                                                            | 0.57 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: text-to-image                                                                | 8.52 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-to-image                                                               | 9.16 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 1                                     | 9.16 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 2                                     | 9.79 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 3                                     | 10.42 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 4                                     | 11.06 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 5                                     | 11.69 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 6                                     | 12.32 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 7                                     | 12.96 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 8                                     | 13.59 / 実行 | 画像    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 9                                     | 14.22 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: text-to-image                                                            | 21.10 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-to-image                                                           | 21.73 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 1                                 | 21.73 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 2                                 | 22.37 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 3                                 | 23.00 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 4                                 | 23.63 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 5                                 | 24.27 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 6                                 | 24.90 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 7                                 | 25.53 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 8                                 | 26.16 / 実行 | 画像    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 9                                 | 26.80 / 実行 | 画像    |
+### ビデオ
 
-### Luma Ray 3.2 Video
+固定の **/run** 価格は、各 `duration` の選択肢に対するノードバッジと一致します。**編集**と**リフレーム**は **(クレジット / 秒) × ビデオ長** で課金されます。**ray-1-6** は常に **105.50 / 実行** です。
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Luma Ray 3.2 Video Generation | resolution: 360p, duration: 5s | 12.66 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 360p, duration: 10s | 37.98 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 540p, duration: 5s | 31.65 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 540p, duration: 10s | 94.95 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 720p, duration: 5s | 63.30 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 720p, duration: 10s | 189.90 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 1080p, duration: 5s | 253.20 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Generation | resolution: 1080p, duration: 10s | 759.60 / 実行 | ビデオ |
-| Luma Ray 3.2 Video Edit | resolution: 360p | 113.94 (5s) - 227.88 (10s) / 実行 | ビデオ |
-| Luma Ray 3.2 Video Edit | resolution: 540p | 151.92 (5s) - 303.84 (10s) / 実行 | ビデオ |
-| Luma Ray 3.2 Video Edit | resolution: 720p | 227.88 (5s) - 455.76 (10s) / 実行 | ビデオ |
-| Luma Ray 3.2 Video Edit | resolution: 1080p | 455.76 (5s) - 911.52 (10s) / 実行 | ビデオ |
-| Luma Ray 3.2 Video Reframe | resolution: 360p | 6.33 / 秒 | ビデオ |
-| Luma Ray 3.2 Video Reframe | resolution: 540p | 12.66 / 秒 | ビデオ |
-| Luma Ray 3.2 Video Reframe | resolution: 720p | 25.32 / 秒 | ビデオ |
-| Luma Ray 3.2 Video Reframe | resolution: 1080p | 75.96 / 秒 | ビデオ |
+| モデル       | タスク       | 解像度 | クレジット                                         |
+| :---------- | :--------- | :--------- | :------------------------------------------------ |
+| ray-3.2     | 生成 | 360p       | 12.66 / 実行 (5秒), 37.98 / 実行 (10秒)               |
+| ray-3.2     | 生成 | 540p       | 31.65 / 実行 (5秒), 94.95 / 実行 (10秒)               |
+| ray-3.2     | 生成 | 720p       | 63.30 / 実行 (5秒), 189.90 / 実行 (10秒)              |
+| ray-3.2     | 生成 | 1080p      | 253.20 / 実行 (5秒), 759.60 / 実行 (10秒)             |
+| ray-3.2     | 編集       | 360p       | 22.79 / 秒                                       |
+| ray-3.2     | 編集       | 540p       | 30.38 / 秒                                       |
+| ray-3.2     | 編集       | 720p       | 45.58 / 秒                                       |
+| ray-3.2     | 編集       | 1080p      | 91.15 / 秒                                       |
+| ray-3.2     | リフレーム    | 360p       | 6.33 / 秒                                        |
+| ray-3.2     | リフレーム    | 540p       | 12.66 / 秒                                       |
+| ray-3.2     | リフレーム    | 720p       | 25.32 / 秒                                       |
+| ray-3.2     | リフレーム    | 1080p      | 75.96 / 秒                                       |
+| ray-2       | 生成 | 540p       | 120.27 / 実行 (5秒), 217.33 / 実行 (9秒)              |
+| ray-2       | 生成 | 720p       | 215.22 / 実行 (5秒), 386.13 / 実行 (9秒)              |
+| ray-2       | 生成 | 1080p      | 478.97 / 実行 (5秒), 865.10 / 実行 (9秒)              |
+| ray-2       | 生成 | 4K         | 1922.21 / 実行 (5秒), 3460.40 / 実行 (9秒)            |
+| ray-flash-2 | 生成 | 540p       | 42.20 / 実行 (5秒), 75.96 / 実行 (9秒)                |
+| ray-flash-2 | 生成 | 720p       | 71.74 / 実行 (5秒), 128.71 / 実行 (9秒)               |
+| ray-flash-2 | 生成 | 1080p      | 166.69 / 実行 (5秒), 299.62 / 実行 (9秒)              |
+| ray-flash-2 | 生成 | 4K         | 660.43 / 実行 (5秒), 1192.15 / 実行 (9秒)             |
+| ray-1-6     | 生成 | —          | 105.50 / 実行                                      |
+
+**Luma Ray 3.2** の画像から動画への変換と動画延長は、常に **5秒** の価格で課金されます。レガシー画像から動画への変換では、**ray-2** / **ray-flash-2** 行の **5秒** または **9秒** の価格が使用されます。
+
+### 画像
+
+| モデル          | タスク       | クレジット                              |
+| :------------- | :--------- | :----------------------------------- |
+| photon-flash-1 | —          | 0.57 / 実行                           |
+| photon-1       | —          | 2.19 / 実行                           |
+| uni-1          | 生成 | 8.52 / 実行 + 0.63 / 参照画像 (≤ 9)  |
+| uni-1          | 編集       | 9.16 / 実行 + 0.63 / 参照画像 (≤ 8)  |
+| uni-1-max      | 生成 | 21.10 / 実行 + 0.63 / 参照画像 (≤ 9) |
+| uni-1-max      | 編集       | 21.73 / 実行 + 0.63 / 参照画像 (≤ 8) |
+
+参照画像の追加料金は、クレジットに変換する前にUSDで小数点第4位に丸められます。
 
 ## Meshy
 
-| 製品名                | 構成                                                       | クレジット      | カテゴリ   |
-| :-------------------- | :--------------------------------------------------------- | :------------- | :--------- |
-| Meshy Retexture         | NA                                                          | 84.4 / 実行  | 3D         |
-| Meshy Rigging           | NA                                                          | 42.2 / 実行  | 3D         |
-| Meshy Remesh            | NA                                                          | 42.2 / 実行  | 3D         |
-| Meshy Animation         | NA                                                          | 25.32 / 実行 | 3D         |
-| Meshy Multi Image to 3D | should_texture: false                                       | 42.2 / 実行  | 画像       |
-| Meshy Multi Image to 3D | should_texture: true                                        | 126.6 / 実行 | 画像       |
-| Meshy Text to 3D        | mode: preview, model: latest                                | 168.8 / 実行 | 3D         |
-| Meshy Text to 3D        | mode: preview, model: meshy-5                               | 42.2 / 実行  | 3D         |
-| Meshy Text to 3D        | mode: refine, model: latest                                 | 84.4 / 実行  | 3D         |
-| Meshy Image to 3D       | model: latest, model_type: lowpoly, should_texture: false   | 168.8 / 実行 | 画像       |
-| Meshy Image to 3D       | model: latest, model_type: lowpoly, should_texture: true    | 253.2 / 実行 | 画像       |
-| Meshy Image to 3D       | model: latest, model_type: standard, should_texture: false  | 168.8 / 実行 | 画像       |
-| Meshy Image to 3D       | model: latest, model_type: standard, should_texture: true   | 253.2 / 実行 | 画像       |
-| Meshy Image to 3D       | model: meshy-5, model_type: lowpoly, should_texture: false  | 168.8 / 実行 | 画像       |
-| Meshy Image to 3D       | model: meshy-5, model_type: lowpoly, should_texture: true   | 253.2 / 実行 | 画像       |
-| Meshy Image to 3D       | model: meshy-5, model_type: standard, should_texture: false | 42.2 / 実行  | 画像       |
-| Meshy Image to 3D       | model: meshy-5, model_type: standard, should_texture: true  | 126.6 / 実行 | 画像       |
+| ノード                        | should_texture | クレジット      |
+| :-------------------------- | :------------- | :------------- |
+| Meshy: Text to Model        | —              | 168.8 / 実行 |
+| Meshy: Refine Draft Model   | —              | 84.4 / 実行  |
+| Meshy: Image to Model       | いいえ         | 168.8 / 実行 |
+| Meshy: Image to Model       | はい           | 253.2 / 実行 |
+| Meshy: Multi-Image to Model | いいえ         | 42.2 / 実行  |
+| Meshy: Multi-Image to Model | はい           | 126.6 / 実行 |
+| Meshy: Rig Model            | —              | 42.2 / 実行  |
+| Meshy: Animate Model        | —              | 25.32 / 実行 |
+| Meshy: Texture Model        | —              | 84.4 / 実行  |
+
+**Meshy: Text to Model** はドラフトメッシュを作成します。返された `meshy_task_id` に対して **Meshy: Refine Draft Model** を実行してテクスチャを適用します。**Meshy: Image to Model** と **Meshy: Multi-Image to Model** は、`should_texture` が有効な場合、1ステップでテクスチャを適用できます。
 
 ## Minimax
 
-| 製品名 | 構成 | クレジット | カテゴリ |
+| ノード | モデル | 解像度 | クレジット |
 | :--- | :--- | :--- | :--- |
-| prod-v1-Minimax Video Product                   | model: i2v-01-director                                           | 90.73 / 実行  | ビデオ    |
-| prod-v1-Minimax Video Product                   | model: i2v-01-live                                               | 90.73 / 実行  | ビデオ    |
-| prod-v1-Minimax Video Product                   | model: i2v-01                                                    | 90.73 / 実行  | ビデオ    |
-| prod-v1-Minimax Video Product                   | model: s2v-01                                                    | 137.15 / 実行 | ビデオ    |
-| prod-v1-Minimax Video Product                   | model: t2v-01-director                                           | 90.73 / 実行  | ビデオ    |
-| prod-v1-Minimax Video Product                   | model: t2v-01                                                    | 90.73 / 実行  | ビデオ    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 10, model: minimax-hailuo-02, resolution: 768P | 118.16 / 実行 | ビデオ    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 6, model: minimax-hailuo-02, resolution: 1080P | 103.39 / 実行 | ビデオ    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 6, model: minimax-hailuo-02, resolution: 768P  | 59.08 / 実行  | ビデオ    |
+| MiniMax テキストからビデオへ | T2V-01, T2V-01-Director | — | 90.73 / 実行 |
+| MiniMax 画像から動画へ | I2V-01, I2V-01-Director, I2V-01-live | — | 90.73 / 実行 |
+| MiniMax Hailuo 動画 | MiniMax-Hailuo-02 | 768P | 59.08 / 実行 (6秒), 118.16 / 実行 (10秒) |
+| MiniMax Hailuo 動画 | MiniMax-Hailuo-02 | 1080P | 103.39 / 実行 (6秒) |
 
-## Moonvalley
-
-<Warning>
-  **サービス利用不可**：Moonvalley API サービスは現在提供されていません。以下のノードは非推奨となっており、正常に動作しない可能性があります。
-</Warning>
-
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Moonvalley Image-to-Video 5s  | NA            | 316.5 / 実行  | ビデオ    |
-| Moonvalley Image-to-Video 10s | NA            | 633 / 実行    | ビデオ    |
-| Moonvalley Text-to-Video 5s   | NA            | 316.5 / 実行  | ビデオ    |
-| Moonvalley Text-to-Video 10s  | NA            | 633 / 実行    | ビデオ    |
-| Moonvalley Video-to-Video 5s  | NA            | 474.75 / 実行 | ビデオ    |
-| Moonvalley Video-to-Video 10s | NA            | 844 / 実行    | ビデオ    |
+**MiniMax Hailuo 動画**は1080Pでは **6秒** のみサポートしています。
 
 ## OpenAI
 
-OpenAI パートナーノードは、公開 API と同じ米ドル建ての従量課金です。**クレジット = 米ドル × 211**（ページ冒頭参照）。テキストモデルの米ドル単価は OpenAI の **[API 料金](https://developers.openai.com/api/docs/pricing)** の **Standard** ティア（そのページに公開されている 100 万トークンあたり）に合わせています。画像トークン係数は `comfy_api_nodes/nodes_openai.py` と一致します。DALL·E と Sora の固定価格はノードの `price_badge` 式と一致します。最終請求は実際のトークン数・秒数・キャッシュ適用などに依存します。
+**クレジット = USD × 211。** DALL·E と Sora は、画像1枚あたりまたは秒数あたりの固定レートを使用します。**OpenAI GPT Image 2** と **OpenAI ChatGPT** は、APIトークン使用量に基づいて課金されます。
 
-### DALL·E 2（`OpenAIDalle2`）
+### 画像: DALL·E
 
-生成画像 1 枚あたり（`n` 枚のときは枚数分）。
+**DALL·E 2** は **256×256**、**512×512**、または **1024×1024** をサポートしています。総クレジット = **(1画像あたりのクレジット) × `n`**。**DALL·E 3** は **`quality`** (`standard` / `hd`) を追加し、**1024×1024** またはポートレート **1024×1792** / **1792×1024** をサポートしています。
 
-| 製品名               | 構成            | クレジット / 枚 | カテゴリ |
-| :------------------- | :-------------- | :-------------- | :------- |
-| OpenAI DALL·E 2 画像 | size: 256x256   | 3.38            | Image    |
-| OpenAI DALL·E 2 画像 | size: 512x512   | 3.80            | Image    |
-| OpenAI DALL·E 2 画像 | size: 1024x1024 | 4.22            | Image    |
+| ノード            | 品質        | サイズ                 | クレジット      |
+| :-------------- | :------- | :------------------- | :----------- |
+| OpenAI DALL·E 2 | —        | 256x256              | 3.38 / 画像  |
+|                 | —        | 512x512              | 3.80 / 画像  |
+|                 | —        | 1024x1024            | 4.22 / 画像  |
+| OpenAI DALL·E 3 | スタンダード | 1024x1024            | 8.44 / 実行  |
+|                 | スタンダード | 1024x1792, 1792x1024 | 16.88 / 実行 |
+|                 | hd       | 1024x1024            | 16.88 / 実行 |
+|                 | hd       | 1024x1792, 1792x1024 | 25.32 / 実行 |
 
-### DALL·E 3（`OpenAIDalle3`）
+### 画像: GPT Image
 
-| 製品名               | 構成                                               | クレジット / 実行 | カテゴリ |
-| :------------------- | :------------------------------------------------- | :---------------- | :------- |
-| OpenAI DALL·E 3 画像 | quality: standard, size: 1024x1024                 | 8.44              | Image    |
-| OpenAI DALL·E 3 画像 | quality: standard, size: 1024x1792 または 1792x1024 | 16.88             | Image    |
-| OpenAI DALL·E 3 画像 | quality: hd, size: 1024x1024                       | 16.88             | Image    |
-| OpenAI DALL·E 3 画像 | quality: hd, size: 1024x1792 または 1792x1024       | 25.32             | Image    |
+生成後のAPIトークン使用量に基づいて課金されます。`quality` (`low` / `medium` / `high`) によっておおよそのバッジが決定されます。実際のコストは以下のトークン数に従います。
 
-### GPT Image 1 / 1.5 / 2（`OpenAIGPTImage1`）
+| モデル          | トークンタイプ  | クレジット / 1M |
+| :------------ | :------------- | :----------- |
+| gpt-image-1   | 入力           | 2110         |
+| gpt-image-1   | 出力 (画像)    | 8440         |
+| gpt-image-1.5 | 入力           | 1688         |
+| gpt-image-1.5 | 出力 (画像)    | 6752         |
+| gpt-image-2   | 入力           | 1688         |
+| gpt-image-2   | 出力 (画像)    | 6330         |
 
-API のトークン使用量に基づきます。100 万トークンあたりのクレジット = 米ドル × 211（ノードの `calculate_tokens_price_image_1` / `calculate_tokens_price_image_1_5` ヘルパーと同じ）。
+非推奨の **OpenAI GPT Image 2** ノード (古い実装) は、同じモデルとレートを使用します。
 
-| 製品名                              | 構成                 | クレジット / 100 万トークン | カテゴリ |
-| :---------------------------------- | :------------------- | :-------------------------- | :------- |
-| OpenAI GPT Image 入力（テキスト/画像） | model: gpt-image-1   | 2110（$10 / 1M）            | Image    |
-| OpenAI GPT Image 出力（画像）       | model: gpt-image-1   | 8440（$40 / 1M）            | Image    |
-| OpenAI GPT Image 入力（テキスト/画像） | model: gpt-image-1.5 | 1688（$8 / 1M）             | Image    |
-| OpenAI GPT Image 出力（画像）       | model: gpt-image-1.5 | 6752（$32 / 1M）            | Image    |
-| OpenAI GPT Image 入力（画像）       | model: gpt-image-2   | 1688（$8 / 1M）             | Image    |
-| OpenAI GPT Image キャッシュ入力（画像） | model: gpt-image-2   | 422（$2 / 1M）              | Image    |
-| OpenAI GPT Image 入力（テキスト）   | model: gpt-image-2   | 1055（$5 / 1M）             | Image    |
-| OpenAI GPT Image キャッシュ入力（テキスト） | model: gpt-image-2   | 263.75（$1.25 / 1M）        | Image    |
-| OpenAI GPT Image 出力（画像）       | model: gpt-image-2   | 6330（$30 / 1M）            | Image    |
+### チャット
 
-UI では品質（`low` / `medium` / `high`）ごとに概算の **米ドルレンジ** を表示します。実額はトークン数によります。
+トークンベースの課金です。バッジレートは **1Kトークンあたり** です。表は **1Mトークンあたり** です。
 
-### チャット（`OpenAIChatNode`）
+| モデル        | 入力クレジット / 1M | 出力クレジット / 1M |
+| :----------- | -----------------: | :------------------ |
+| gpt-5.5      |               1055 | 6330                |
+| gpt-5.5-pro  |               6330 | 37980               |
+| gpt-5        |             263.75 | 2110                |
+| gpt-5-mini   |              52.75 | 422                 |
+| gpt-5-nano   |              10.55 | 84.4                |
+| gpt-4.1      |                422 | 1688                |
+| gpt-4.1-mini |               84.4 | 337.6               |
+| gpt-4.1-nano |               21.1 | 84.4                |
+| o3           |               2110 | 8440                |
+| o4-mini      |              232.1 | 928.4               |
+| o1           |               3165 | 12660               |
+| o1-pro       |              31650 | 126600              |
 
-ノードで選べるモデル: `gpt-5.5`、`gpt-5.5-pro`、`gpt-5`、`gpt-5-mini`、`gpt-5-nano`、`gpt-4.1`、`gpt-4.1-mini`、`gpt-4.1-nano`、`o3`、`o4-mini`、`o1`、`o1-pro`。Standard ティア、100 万トークンあたり。「キャッシュ入力」は OpenAI が掲載するキャッシュ入力単価（該当なしは「—」）。短コンテキストと長コンテキストの両方の価格が設定されているモデルでは、リクエストが短コンテキストの上限を超えると長コンテキスト料金が適用されます。
+オプションの画像とファイルは、同じモデルレートで入力トークンに追加されます。
 
-| モデル                       | 入力クレジット / 1M | キャッシュ入力クレジット / 1M | 出力クレジット / 1M |
-| :--------------------------- | ------------------: | --------------------------: | ------------------: |
-| gpt-5.5（短コンテキスト）     | 1055                | 105.5                       | 6330                |
-| gpt-5.5（長コンテキスト）     | 2110                | 211                         | 9495                |
-| gpt-5.5-pro（短コンテキスト） | 6330                | —                           | 37980               |
-| gpt-5.5-pro（長コンテキスト） | 12660               | —                           | 56970               |
-| gpt-5                        | 263.75              | 26.38                       | 2110                |
-| gpt-5-mini                   | 52.75               | 5.28                        | 422                 |
-| gpt-5-nano                   | 10.55               | 1.06                        | 84.4                |
-| gpt-4.1                      | 422                 | 105.5                       | 1688                |
-| gpt-4.1-mini                 | 84.4                | 21.1                        | 337.6               |
-| gpt-4.1-nano                 | 21.1                | 5.28                        | 84.4                |
-| o3                           | 422                 | 105.5                       | 1688                |
-| o4-mini                      | 232.1               | 58.03                       | 928.4               |
-| o1                           | 3165                | 1582.5                      | 12660               |
-| o1-pro                       | 31650               | —                           | 126600              |
+### ビデオ: Sora
 
-オプションの画像やファイルは、同じモデル入力レートでトークンとして課金されます。
+<Warning>
+  **非推奨**: OpenAI は 2026年9月に Sora v2 API の提供を停止する予定です。このノードはその日以降に動作しなくなる可能性があります。
+</Warning>
 
-### Sora ビデオ（`OpenAIVideoSora2`）
+総クレジット = **(1秒あたりのクレジット) × `duration`** (`duration` は 4、8、または 12)。
 
-米ドルは **（秒あたり単価）×（秒数）** です。秒数は 4、8、12 から選択可能。クレジット = 米ドル × 211。
+| モデル      | サイズ                 | クレジット      |
+| :--------- | :------------------- | :----------- |
+| sora-2     | 720x1280, 1280x720   | 21.10 / 秒  |
+| sora-2-pro | 720x1280, 1280x720   | 63.30 / 秒  |
+| sora-2-pro | 1024x1792, 1792x1024 | 105.50 / 秒 |
 
-| 製品名                   | 構成                                               | クレジット / 秒 | カテゴリ |
-| :----------------------- | :------------------------------------------------- | :-------------- | :------- |
-| OpenAI Sora ビデオ生成   | model: sora-2, size: 720x1280 または 1280x720      | 21.10           | Video    |
-| OpenAI Sora ビデオ生成   | model: sora-2-pro, size: 720x1280 または 1280x720  | 63.30           | Video    |
-| OpenAI Sora ビデオ生成   | model: sora-2-pro, size: 1024x1792 または 1792x1024 | 105.50          | Video    |
-
-例: `sora-2`、1280x720、8 秒 → 約 **168.8** クレジット（$0.10 × 8 × 211）。
+`sora-2` は 720x1280 と 1280x720 のみをサポートしています。
 
 ## OpenRouter
 
-### OpenRouter LLM（`OpenRouterLLMNode`）
+バッジレートは **1Kトークンあたり**、表は **100万トークンあたり** です。最終請求額はAPIの使用量に応じて決まります。
 
-100 万トークンあたり。
-
-| モデル                              | 入力クレジット / 1M | 出力クレジット / 1M |
-| :----------------------------------- | -----------------: | ------------------: |
-| `anthropic/claude-opus-4.7`          |               1055 |                5275 |
-| `openai/gpt-5.5-pro`                 |               6330 |               37980 |
-| `openai/gpt-5.5`                     |               1055 |                6330 |
-| `google/gemini-3.5-flash`            |              316.5 |                1899 |
-| `x-ai/grok-4.20`                     |             263.75 |               527.5 |
-| `x-ai/grok-4.3`                      |             263.75 |               527.5 |
-| `deepseek/deepseek-v4-pro`           |             91.785 |              183.57 |
-| `deepseek/deepseek-v4-flash`         |             23.632 |              47.264 |
-| `deepseek/deepseek-v3.2`             |             53.172 |              79.758 |
-| `qwen/qwen3.6-max-preview`           |             219.44 |             1316.64 |
-| `qwen/qwen3.6-plus`                  |            68.575 |              411.45 |
-| `qwen/qwen3.6-flash`                 |           39.5625 |             237.375 |
-| `mistralai/mistral-large-2512`       |              105.5 |               316.5 |
-| `mistralai/mistral-medium-3-5`       |              316.5 |              1582.5 |
-| `z-ai/glm-4.6`                       |              90.73 |              367.14 |
-| `z-ai/glm-5`                         |              126.6 |              405.12 |
-| `moonshotai/kimi-k2.6`               |             154.03 |              736.39 |
-| `moonshotai/kimi-k2-thinking`        |              126.6 |               527.5 |
-| `perplexity/sonar-pro`               |                633 |                3165 |
-| `perplexity/sonar-reasoning-pro`     |                422 |                1688 |
-| `perplexity/sonar-deep-research`     |                422 |                1688 |
-
-## Pika
-
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/i2v, resolution: 1080p        | 211 / 実行   | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/i2v, resolution: 720p         | 126.6 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikaframes, resolution: 1080p | 211 / 実行   | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikaframes, resolution: 720p  | 52.75 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikascenes, resolution: 1080p | 316.5 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikascenes, resolution: 720p  | 84.4 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/t2v, resolution: 1080p        | 211 / 実行   | ビデオ |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/t2v, resolution: 720p         | 126.6 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/i2v, resolution: 1080p        | 94.95 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/i2v, resolution: 720p         | 42.2 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikaframes, resolution: 1080p | 63.3 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikaframes, resolution: 720p  | 42.2 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikascenes, resolution: 1080p | 105.5 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikascenes, resolution: 720p  | 63.3 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/t2v, resolution: 1080p        | 94.95 / 実行 | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/t2v, resolution: 720p         | 42.2 / 実行  | ビデオ |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/pikaffects, resolution: 720p      | 94.95 / 実行 | ビデオ |
-| Pika Basic Video Product                           | endpoint: generate/pikadditions                      | 63.3 / 実行  | ビデオ |
-| Pika Basic Video Product                           | endpoint: generate/pikaffects                        | 94.95 / 実行 | ビデオ |
-| Pika Basic Video Product                           | endpoint: generate/pikaswaps                         | 63.3 / 実行  | ビデオ |
+| モデル                                                          | 入力クレジット / 1M | 出力クレジット / 1M |
+| :------------------------------------------------------------- | :----------------- | :------------------ |
+| anthropic/claude-opus-4.7                                      | 1055               | 5275                |
+| openai/gpt-5.5-pro                                             | 6330               | 37980               |
+| openai/gpt-5.5                                                 | 1055               | 6330                |
+| google/gemini-3.5-flash                                        | 316.5              | 1899                |
+| x-ai/grok-4.20, x-ai/grok-4.3                                  | 263.75             | 527.5               |
+| deepseek/deepseek-v4-pro                                       | 91.785             | 183.57              |
+| deepseek/deepseek-v4-flash                                     | 23.632             | 47.264              |
+| deepseek/deepseek-v3.2                                         | 53.172             | 79.758              |
+| qwen/qwen3.6-max-preview                                       | 219.44             | 1316.64             |
+| qwen/qwen3.6-plus                                              | 68.575             | 411.45              |
+| qwen/qwen3.6-flash                                             | 39.5625            | 237.375             |
+| mistralai/mistral-large-2512                                   | 105.5              | 316.5               |
+| mistralai/mistral-medium-3-5                                   | 316.5              | 1582.5              |
+| z-ai/glm-4.6                                                   | 90.73              | 367.14              |
+| z-ai/glm-5                                                     | 126.6              | 405.12              |
+| moonshotai/kimi-k2.6                                           | 154.03             | 736.39              |
+| moonshotai/kimi-k2-thinking                                    | 126.6              | 527.5               |
+| perplexity/sonar-pro                                           | 633                | 3165                |
+| perplexity/sonar-reasoning-pro, perplexity/sonar-deep-research | 422                | 1688                |
 
 ## Pixverse
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: fast, 品質: 360p | 189.9 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: fast, 品質: 540p | 189.9 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: fast, 品質: 720p | 253.2 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 1080p | 253.2 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 360p | 94.95 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 540p | 94.95 / 実行 | ビデオ |
-| Pixverse 5秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 720p | 126.6 / 実行 | ビデオ |
-| Pixverse 8秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 360p | 189.9 / 実行 | ビデオ |
-| Pixverse 8秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 540p | 189.9 / 実行 | ビデオ |
-| Pixverse 8秒ビデオ製品 | モデル: v3.5, モーションモード: ノーマル, 品質: 720p | 253.2 / 実行 | ビデオ |
+モデル **v3.5**（APIで固定；選択不可）。
+
+**1080p**は**ノーマル**モーションで**5s**に制限されています。**8s**クリップは**ノーマル**モーションのみサポートします（fastはノーマルに強制されます）。
+
+| モデル | 再生時間 | モーションモード | 品質 | クレジット |
+| :---- | :------- | :---------- | :--------- | :---------- |
+| v3.5  | 5s       | fast        | 360p, 540p | 189.9 / 回 |
+|       | 5s       | fast        | 720p       | 253.2 / 回 |
+|       | 5s       | ノーマル      | 360p, 540p | 94.95 / 回 |
+|       | 5s       | ノーマル      | 720p       | 126.6 / 回 |
+|       | 5s       | ノーマル      | 1080p      | 253.2 / 回 |
+|       | 8s       | ノーマル      | 360p, 540p | 189.9 / 回 |
+|       | 8s       | ノーマル      | 720p       | 253.2 / 回 |
 
 ## Quiver
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| QuiverテキストからSVGへ | モデル: arrow-1.1 | 60.35 / 実行 | 画像 |
-| Quiver画像からSVGへ | モデル: arrow-1.1 | 45.26 / 実行 | 画像 |
-| QuiverテキストからSVGへ | モデル: arrow-1.1-max | 75.43 / 実行 | 画像 |
-| Quiver画像からSVGへ | モデル: arrow-1.1-max | 60.35 / 実行 | 画像 |
+### 画像
+
+| モデル         | クレジット     |
+| :------------ | :---------- |
+| arrow-1.1     | 60.35 / 実行 |
+| arrow-1.1-max | 75.43 / 実行 |
+| arrow-preview | 90.52 / 実行 |
 
 ## Recraft
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Recraft スタイル作成 | endpoint: v2/style/create | 8.44 / 回 | Image |
-| Recraft テキストから画像へ | endpoint: v2/auto/text-to-image | 8.44 / 回 | Image |
-| Recraft 画像から画像へ | endpoint: v2/auto/image-to-image | 8.44 / 回 | Image |
-| Recraft Inpainting | endpoint: v2/auto/inpainting | 8.44 / 回 | Image |
-| Recraft テキストからベクターへ | endpoint: v2/auto/text-to-vector | 16.88 / 回 | Image |
-| Recraft ベクトル化画像 | endpoint: v2/auto/vectorize-image | 2.11 / 回 | Image |
-| Recraft 背景置換 | endpoint: v2/image/replace-background | 8.44 / 回 | Image |
-| Recraft 背景除去 | endpoint: v2/image/remove-background | 2.11 / 回 | Image |
-| Recraft Crisp Upscale | endpoint: v2/image/crisp-upscale | 0.84 / 回 | Image |
-| Recraft Creative Upscale | endpoint: v2/image/creative-upscale | 52.75 / 回 | Image |
-| Recraft V4 テキストから画像生成 | model: recraftv4 | 8.44 / 回 | Image |
-| Recraft V4 テキストから画像生成 | model: recraftv4_pro | 52.75 / 回 | Image |
-| Recraft V4 テキストからベクター生成 | model: recraftv4 | 16.88 / 回 | Image |
-| Recraft V4 テキストからベクター生成 | model: recraftv4_pro | 63.30 / 回 | Image |
+### 画像
+
+特に記載がない限り、実行ごとの固定料金です。 **`n`** が付いているノードは、**(クレジット / 画像) × `n`** が請求されます。v3 生成ノードは、API リクエストでモデル **recraftv3** を送信します（ノード内では選択不可）。
+
+| モデル          | ノード                                                                                | クレジット                    |
+| :------------- | :----------------------------------------------------------------------------------- | :--------------------------- |
+| recraftv4_pro  | Recraft V4 テキストから画像生成                                                       | 52.75 / 画像 (× `n`)         |
+| recraftv4_pro  | Recraft V4 テキストからベクター生成                                                    | 63.30 / 画像 (× `n`)         |
+| recraftv4      | Recraft V4 テキストから画像生成                                                       | 8.44 / 画像 (× `n`)          |
+| recraftv4      | Recraft V4 テキストからベクター生成                                                    | 16.88 / 画像 (× `n`)         |
+| recraftv3      | Recraft テキストから画像へ, Recraft 画像から画像へ, Recraft画像インペインティング         | 8.44 / 画像 (× `n`)          |
+| recraftv3      | Recraft テキストからベクターへ                                                         | 16.88 / 画像 (× `n`)         |
+| —              | Recraft スタイル作成                                                                  | 8.44 / 実行                  |
+| —              | Recraft 背景置換                                                                      | 8.44 / 実行                  |
+| —              | Recraft ベクトル化画像, Recraft 背景除去                                               | 2.11 / 実行                  |
+| —              | Recraft シャープ高解像度アップスケール画像                                               | 0.84 / 実行                  |
+| —              | Recraft Creative アップスケール画像                                                    | 52.75 / 実行                 |
 
 ## Reve
 
-> 表示価格はベース価格です（test\_time\_scaling=1、後処理なし）。アップスケーリングまたは背景除去が有効な場合、実際のコストが高くなる場合があります。
+### 画像
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| Reve画像生成 | model: reve-create@20250915 | 7.24 / 実行 | 画像 |
-| Reve画像編集 | model: reve-edit@20250915 | 12.07 / 実行 | 画像 |
-| Reve画像編集 | model: reve-edit-fast@20251030 | 2.11 / 実行 | 画像 |
-| Reve画像リミックス | model: reve-remix@20250915 | 12.07 / 実行 | 画像 |
-| Reve画像リミックス | model: reve-remix-fast@20251030 | 2.11 / 実行 | 画像 |
+以下のクレジットはおおよその**基本**レートです（`test_time_scaling=1`、upscale オフ）。**`test_time_scaling` > 1**、**upscale**、および**背景を削除**は、API からの実際の請求額を増やす可能性があります。
 
-## Rodin
+| モデル                                   | ノード                              | upscale | クレジット     |
+| :-------------------------------------- | :-------------------------------- | :------ | :---------- |
+| reve-create@20250915                    | Reve画像生成                 | オフ     | 7.24 / 実行  |
+|                                         |                                   | 2x      | 9.64 / 実行  |
+|                                         |                                   | 3x      | 12.47 / 実行 |
+|                                         |                                   | 4x      | 16.08 / 実行 |
+| reve-edit@20250915, reve-remix@20250915 | Reve画像編集, Reve画像リミックス | オフ     | 12.07 / 実行 |
+|                                         |                                   | 2x      | 14.47 / 実行 |
+|                                         |                                   | 3x      | 17.28 / 実行 |
+|                                         |                                   | 4x      | 20.91 / 実行 |
+| reve-edit-fast@20251030                 | Reve画像編集                   | —       | 2.11 / 実行  |
+| reve-remix-fast@20251030                | Reve画像リミックス                  | —       | 2.11 / 実行  |
 
-### Hyper3D Rodin (Gen-2)
+Fast 編集/リミックス モデルは固定の基本レートを使用します。upscale は表示される見積もりを変更しません。
 
-| 製品名                         | 構成 | クレジット     | カテゴリ |
-| :----------------------------- | :--- | :------------- | :------- |
-| Rodin 3D Generation (no addons)   | NA   | 84.4 / 実行    | 3D       |
-| Rodin 3D Generation (with AddOns) | NA   | 253.2 / 実行   | 3D       |
+## Rodin 3D
 
-### Hyper3D Rodin Gen-2.5 (`Rodin3D_Gen25_Image` / `Rodin3D_Gen25_Text`)
+| 世代 | ノード                                                                                                    | モード         | addon_highpack | クレジット      |
+| :--- | :-------------------------------------------------------------------------------------------------------- | :------------- | :------------- | :-------------- |
+| Gen-2.5 | Rodin 3D Gen-2.5 - 画像から3Dへ, Rodin 3D Gen-2.5 - テキストから3Dへ                                      | 通常, 高速     | オフ           | 158.25 / 回     |
+| Gen-2.5 |                                                                                                           | エクストリームハイ | オフ        | 316.5 / 回      |
+| Gen-2.5 |                                                                                                           | 任意           | オン           | +168.8 / 回     |
+| Gen-2   | Rodin 3D 生成 - 通常生成, 詳細生成, スムーズ生成, スケッチ生成, Gen-2 生成                                | —              | —              | 84.4 / 回       |
 
-| 製品名                          | 構成                               | クレジット       | カテゴリ |
-| :------------------------------ | :--------------------------------- | :--------------- | :------- |
-| Rodin Gen-2.5 (Regular/Fast)    | mode: Regular または Fast          | 158.25 / 実行    | 3D       |
-| Rodin Gen-2.5 (Extreme-High)    | mode: Extreme-High                 | 316.5 / 実行     | 3D       |
-| Rodin Gen-2.5 HighPack アドオン | addon_highpack: true               | +168.8 / 実行    | 3D       |
+**HighPack** (`addon_highpack`) は、そのモードのGen-2.5基本レートに加えて **168.8** クレジットを追加します。
 
 ## Runway
 
-| 製品名 | 構成 | クレジット | カテゴリ |
-| :--- | :--- | :--- | :--- |
-| prod-v1-Runway ビデオ生成プロダクト | model: gen3a_turbo | 15.09 / 秒 | ビデオ |
-| prod-v1-Runway ビデオ生成プロダクト | model: gen4_turbo  | 10.55 / 秒 | ビデオ |
-| prod-v1-Runway ビデオ生成プロダクト | model: aleph2     | 84.48 / 秒 | ビデオ |
-| RunwayML 画像生成プロダクト       | model: gen4_image     | 24.14 / 回 | 画像 |
-| Runway 最初と最後のフレーム生成プロダクト | model: gen4_turbo | 15.09 / 秒 | ビデオ |
+### ビデオ
+
+Gen3a Turbo、Gen4 Turbo、First-Last-Frame: **5秒** または **10秒**。総クレジット = **(クレジット/秒) × `duration`**。
+
+| モデル        | クレジット      |
+| :----------- | :------------ |
+| gen3a_turbo  | 15.09 / 秒   |
+| gen4_turbo   | 15.09 / 秒   |
+| aleph2       | 84.48 / 秒   |
+
+**Runway Aleph2 Keyframe** と **Runway Aleph2 Prompt Image** はヘルパーノードであり、別途料金は発生しません。費用は **Runway Aleph2 Video to Video** にかかります。
+
+### 画像
+
+| モデル      | クレジット      |
+| :--------- | :------------ |
+| gen4_image | 23.21 / 実行  |
 
 ## Sonilo
 
-| 製品名                | 構成                              | クレジット    | カテゴリ |
-| :-------------------- | :-------------------------------- | :------------ | :------- |
-| Sonilo Music Generate | model: sonilo, type: video-to-music | 1.9 / 秒      | オーディオ |
-| Sonilo Music Generate | model: sonilo, type: text-to-music  | 1.055 / 秒    | オーディオ |
+テキストから音楽生成：総クレジット = **(クレジット / 秒) × `duration`**（1～360秒）。
+
+| ノード                  | クレジット      |
+| :---------------------- | :-------------- |
+| Sonilo 動画から音楽生成 | 1.9 / 秒        |
+| Sonilo テキストから音楽生成 | 0.5275 / 秒    |
 
 ## Stability AI
 
-| 製品名                               | 構成                                                                          | クレジット   | カテゴリ |
-| :----------------------------------- | :---------------------------------------------------------------------------- | :---------- | :------- |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/core                                   | 6.33 / 実行  | 画像    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/ultra                                  | 16.88 / 実行 | 画像    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/conservative                            | 84.4 / 実行  | 画像    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/creative                                | 126.6 / 実行 | 画像    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/fast                                    | 4.22 / 実行  | 画像    |
-| Stability AI SD3 Image Products            | model: sd3.5-large                                                            | 13.71 / 実行 | 画像    |
-| Stability AI SD3 Image Products            | model: sd3.5-large-turbo                                                      | 8.44 / 実行  | 画像    |
-| Stability AI SD3 Image Products            | model: sd3.5-medium                                                           | 7.39 / 実行  | 画像    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/audio-to-audio, model: stable-audio-2.5 | 42.2 / 実行  | オーディオ    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/インペイント, model: stable-audio-2.5        | 42.2 / 実行  | オーディオ    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/text-to-audio, model: stable-audio-2.5  | 42.2 / 実行  | オーディオ    |
+### 画像
+
+| ノード                                      | モデル        | クレジット      |
+| :---------------------------------------- | :----------- | :----------- |
+| Stability AI Stable Image Ultra           |              | 16.88 / 回  |
+| Stability AI Stable Diffusion 3.5 Image   | SD3.5-large  | 13.715 / 回 |
+|                                           | SD3.5-medium | 7.385 / 回  |
+| Stability AI アップスケール（コンサバティブ）         |              | 84.4 / 回   |
+| Stability AI アップスケール クリエイティブ             |              | 126.6 / 回  |
+| Stability AI 高速アップスケール                 |              | 4.22 / 回   |
+
+### オーディオ
+
+| モデル             | クレジット    |
+| :---------------- | :--------- |
+| stable-audio-2.5  | 42.2 / 回 |
 
 ## Tencent
 
-| 製品名                       | 構成                                              | クレジット   | カテゴリ |
-| :--------------------------- | :------------------------------------------------ | :----------- | :------- |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Geometry | 63.3 / 実行  | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: LowPoly  | 126.6 / 実行 | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Normal   | 105.5 / 実行 | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Sketch   | 105.5 / 実行 | 3D       |
-| Tencent 3D Face Count        | custom_face_count: true, endpoint: hunyuan/3d-pro | 42.2 / 実行  | 3D       |
-| Tencent 3D PBR               | enable_pbr: true, endpoint: hunyuan/3d-pro        | 42.2 / 実行  | 3D       |
-| Tencent 3D Multiview Images  | endpoint: hunyuan/3d-pro, multi_view: true        | 42.2 / 実行  | 画像     |
-| Tencent 3D                   | endpoint: hunyuan/3d-part                         | 126.6 / 実行 | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-texture-edit                 | 126.6 / 実行 | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-uv                           | 42.2 / 実行  | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-smart-topology               | 211 / 実行   | 3D       |
+**`3.1`** は **`3.0`** と同じレートを使用しますが、LowPolyをサポートしていません。
+
+### 3D: 生成
+
+| model | generate_type | クレジット     |
+| :---- | :------------ | :---------- |
+| 3.0   | Geometry      | 63.3 / 実行  |
+|       | Normal        | 105.5 / 実行 |
+|       | LowPoly       | 126.6 / 実行 |
+
+アドオンは基本レートに積み重ねられます：
+
+| model | option                         | クレジット      |
+| :---- | :----------------------------- | :----------- |
+| 3.0   | PBR（`pbr`がオン）                 | +42.2 / 実行  |
+|       | カスタム `face_count`（≠ 500000） | +42.2 / 実行  |
+|       | マルチビュー画像が接続     | +42.2 / 実行  |
+
+マルチビューは、`image_left`、`image_right`、または `image_back` が接続されている場合にのみ **Hunyuan3D: Image(s) to Model** に適用されます。
+
+### 3D: 後処理
+
+| Node                       | クレジット      |
+| :------------------------- | :----------- |
+| Hunyuan3D: Model to UV     | 42.2 / 実行   |
+| Hunyuan3D: Smart Topology  | 211 / 実行    |
+
+**Hunyuan3D: 3D Texture Edit** と **Hunyuan3D: 3D Part** はそれぞれ **126.6 / 実行** です。
 
 ## Topaz
 
-### 画像強調
+### 画像
 
-| 製品名                           | 設定                               | クレジット     | カテゴリ |
-| :------------------------------- | :--------------------------------- | :------------- | :------- |
-| Topaz画像強化 (Reimagine)        | 入力解像度：720p（1280×720）       | 13.93 / 回     | 画像     |
-| Topaz画像強化 (Reimagine)        | 入力解像度：1080p（1920×1080）     | 27.85 / 回     | 画像     |
-| Topaz画像強化 (Reimagine)        | 入力解像度：1440p（2560×1440）     | 27.85 / 回     | 画像     |
-| Topaz画像強化 (Reimagine)        | 入力解像度：4K（3840×2160）        | 69.63 / 回     | 画像     |
+レートはTopaz APIがポーリング時に返します（**APIクレジット × 0.08** USD）。入力解像度ごとの一般的な料金：
 
-### ビデオ強調
+| モデル     | 入力解像度          | クレジット     |
+| :-------- | :------------------ | :---------- |
+| Reimagine | 720p (1280×720)     | 13.93 / 実行 |
+|           | 1080p (1920×1080)   | 27.85 / 実行 |
+|           | 1440p (2560×1440)   | 27.85 / 実行 |
+|           | 4K (3840×2160)      | 69.63 / 実行 |
 
-| 製品名             | 設定                                                                               | クレジット       | カテゴリ |
-| :----------------- | :--------------------------------------------------------------------------------- | :--------------- | :------- |
-| Topazビデオ強調    | モデル：Starlight Precise 2.5（slp-2.5）、アップスケーラー解像度：FullHD（1080p）   | 12.99 / 秒       | ビデオ   |
-| Topazビデオ強調    | モデル：Starlight Precise 2.5（slp-2.5）、アップスケーラー解像度：4K（2160p）       | 28.08 / 秒       | ビデオ   |
-| Topazビデオ強調    | モデル：Starlight (Astra) Fast（slf-1）、アップスケーラー解像度：FullHD（1080p）    | 6.50 / 秒        | ビデオ   |
-| Topazビデオ強調    | モデル：Starlight (Astra) Fast（slf-1）、アップスケーラー解像度：4K（2160p）        | 14.16 / 秒       | ビデオ   |
-| Topazビデオ強調    | モデル：Starlight (Astra) Creative（slc-1）、アップスケーラー解像度：FullHD（1080p） | 43.62 / 秒       | ビデオ   |
-| Topazビデオ強調    | モデル：Starlight (Astra) Creative（slc-1）、アップスケーラー解像度：4K（2160p）     | 77.99 / 秒       | ビデオ   |
-| Topazビデオ強調    | 補間モデル：apo-8、入力解像度：720p                                                  | 2.55 / 秒        | ビデオ   |
-| Topazビデオ強調    | 補間モデル：apo-8、入力解像度：1080p                                                 | 5.57 / 秒        | ビデオ   |
-| Topazビデオ強調    | 補間モデル：apo-8、入力解像度：4K                                                    | 21.59 / 秒       | ビデオ   |
-| Topazビデオ強調    | モデル：Astra 2（ast-2）、解像度：1080p                                                | 1.688 / フレーム | ビデオ   |
-| Topazビデオ強調    | モデル：Astra 2（ast-2）、解像度：4K                                                    | 2.813 / フレーム | ビデオ   |
+### ビデオ
+
+ノードに表示されるおおよそのレートは、**ソースフレームあたり**（秒あたりではありません）です。総クレジット ≈ **(クレジット / ソースフレーム) × 入力フレーム数**。**apo-8** 補間を有効にすると、アップスケールレートにソースフレームあたり **~0.14**（1080p）または **~0.28**（4K）が追加されます。
+
+| upscaler_model             | upscaler_resolution | クレジット / ソースフレーム |
+| :------------------------- | :------------------ | :------------------ |
+| Starlight (Astra) Fast     | FullHD (1080p)      | ~0.43               |
+|                            | 4K (2160p)          | ~0.85               |
+| Starlight Precise 2.5      | FullHD (1080p)      | ~0.70               |
+|                            | 4K (2160p)          | ~1.54               |
+| Astra 2                    | FullHD (1080p)      | ~1.72               |
+|                            | 4K (2160p)          | ~2.85               |
+| Starlight (Astra) Creative | FullHD (1080p)      | ~2.25               |
+|                            | 4K (2160p)          | ~3.99               |
+
+アップスケーラー**無効**で **apo-8** 補間のみの場合：UIには **補間のみ** と表示されます。料金はポーリング時にAPI見積もりから計算されます。
+
+**Topaz Video Enhance (レガシー)** は非推奨です。実行前の固定見積もりはなく、料金はポーリング時にAPI見積もりから計算されます。
 
 ## Tripo
 
-| 製品名                             | 設定                                                                               | クレジット       | カテゴリ |
-| :--------------------------------------- | :-------------------------------------------------------------------------------  | :------------ | :------- |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: 詳細, type: image_to_model              | 84.4 / run    | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: 詳細, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: 詳細, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: スタンダード, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: スタンダード, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.0-20240919, texture_quality: スタンダード, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: 詳細, type: image_to_model     | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: 詳細, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: 詳細, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: スタンダード, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: スタンダード, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v2.5-20250123, texture_quality: スタンダード, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: 詳細, type: image_to_model     | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: 詳細, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: 詳細, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: スタンダード, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: スタンダード, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.0-20250812, texture_quality: スタンダード, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: 詳細, type: image_to_model               | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: 詳細, type: multiview_to_model           | 84.4 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: 詳細, type: text_to_model                | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: スタンダード, type: image_to_model               | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: スタンダード, type: multiview_to_model           | 63.3 / run  | 3D       |
-| Tripo 生成 (テクスチャ付き) プロダクト | model: v3.1, texture_quality: スタンダード, type: text_to_model                | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.0-20240919, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.0-20240919, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.0-20240919, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.5-20250123, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.5-20250123, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v2.5-20250123, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.0-20250812, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.0-20250812, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.0-20250812, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.1, type: image_to_model                                         | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.1, type: multiview_to_model                                     | 42.2 / run  | 3D       |
-| Tripo 生成 (テクスチャなし) プロダクト   | model: v3.1, type: text_to_model                                          | 21.1 / run  | 3D       |
-| Tripo スタイル プロダクト                      | NA                                                                        | 10.55 / run | 3D       |
-| Tripo 四角形 プロダクト               | NA                                                                        | 10.55 / run | 3D       |
-| Tripo テクスチャ追加 プロダクト                | texture_quality: 詳細                                                 | 42.2 / run  | 3D       |
-| Tripo テクスチャ追加 プロダクト                | texture_quality: スタンダード                                                 | 21.1 / run  | 3D       |
-| Tripo 後処理 プロダクト            | type: animate_retarget                                                    | 21.1 / run  | 3D       |
-| Tripo 後処理 プロダクト            | type: animate_rig                                                         | 52.75 / run | 3D       |
-| Tripo 後処理 プロダクト            | type: stylize_model                                                       | 42.2 / run  | 3D       |
-| Tripo 変換 プロダクト                    | convert_format: 高度な機能                                                  | 21.1 / run  | 3D       |
-| Tripo 変換 プロダクト                    | convert_format: 基本                                                     | 10.55 / run | 3D       |
-| Tripo V1-4 生成 プロダクト            | type: image_to_model                                                      | 63.3 / run  | 3D       |
-| Tripo V1-4 生成 プロダクト            | type: refine_model                                                        | 63.3 / run  | 3D       |
-| Tripo V1-4 生成 プロダクト            | type: text_to_model                                                       | 42.2 / run  | 3D       |
-| Tripo ジオメトリ品質 プロダクト           | geometry_quality: 詳細                                                | 42.2 / run  | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: text_to_model, output_mode: Geometry のみ                | 63.3 / run    | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: text_to_model, output_mode: テクスチャ付き, texture_quality: スタンダード | 84.4 / run    | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: text_to_model, output_mode: テクスチャ付き, texture_quality: 詳細 | 105.5 / run   | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: image_to_model, output_mode: Geometry のみ               | 84.4 / run    | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: image_to_model, output_mode: テクスチャ付き, texture_quality: スタンダード | 105.5 / run   | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: image_to_model, output_mode: テクスチャ付き, texture_quality: 詳細 | 126.6 / run   | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: multiview_to_model, output_mode: Geometry のみ           | 84.4 / run    | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: multiview_to_model, output_mode: テクスチャ付き, texture_quality: スタンダード | 105.5 / run   | 3D       |
-| Tripo P1 生成 プロダクト              | model: P1-20260311, type: multiview_to_model, output_mode: テクスチャ付き, texture_quality: 詳細 | 126.6 / run   | 3D       |
+レガシー生成価格はおおよその値です。ノードはTripo内部のクレジットをUSDに変換します：**クレジット × 0.01**。
 
-| Tripo 3Dインポート プロダクト | NA | 無料 | 3D |
+### 生成: v1.4
+
+| モデルバージョン | ノード                                              | クレジット    |
+| :--------------- | :-------------------------------------------------- | :------------ |
+| v1.4-20240625    | Tripo: テキストからモデル                           | 42.2 / 実行   |
+|                  | Tripo: 画像からモデル、Tripo: マルチビューからモデル | 63.3 / 実行   |
+
+v1.4の価格は一律です。`texture`、`quad`、品質設定を変更しても推定値は変わりません。
+
+**Tripo: Refine Draftモデル**（v1.4ドラフトのみ）：**63.3 / 実行**。
+
+### 生成: v2.0 / v2.5
+
+`model_version` **v2.0-20240919** または **v2.5-20250123**。`texture`または`pbr`はテクスチャありとみなされます。v2.0およびv2.5では、**`geometry_quality: detailed`は価格に影響しません**。
+
+**Tripo: テキストからモデル**
+
+| texture | texture_quality | クレジット    |
+| :------ | :-------------- | :------------ |
+| オフ    | スタンダード    | 21.1 / 実行   |
+| オン    | スタンダード    | 42.2 / 実行   |
+| オン    | 詳細            | 63.3 / 実行   |
+
+**Tripo: 画像からモデル**および**Tripo: マルチビューからモデル**
+
+| texture | texture_quality | クレジット    |
+| :------ | :-------------- | :------------ |
+| オフ    | スタンダード    | 42.2 / 実行   |
+| オン    | スタンダード    | 63.3 / 実行   |
+| オン    | 詳細            | 84.4 / 実行   |
+
+| オプション | クレジット     |
+| :--------- | :------------- |
+| `quad`     | +10.55 / 実行  |
+
+`quad`は**Tripo: テキストからモデル**と**Tripo: 画像からモデル**にのみ適用されます。
+
+### 生成: v3.0 / v3.1
+
+同じノードで`model_version`が**v3.0-20250812**または**v3.1-20260211**の場合。**`geometry_quality: detailed`** は、以下のテクスチャ行に加えて**+42.2 / 実行**を追加します。
+
+**Tripo: テキストからモデル**
+
+| texture | texture_quality | geometry_quality | クレジット     |
+| :------ | :-------------- | :--------------- | :------------- |
+| オフ    | スタンダード    | スタンダード     | 21.1 / 実行    |
+| オフ    | スタンダード    | 詳細             | 63.3 / 実行    |
+| オン    | スタンダード    | スタンダード     | 42.2 / 実行    |
+| オン    | 詳細            | スタンダード     | 63.3 / 実行    |
+| オン    | スタンダード    | 詳細             | 84.4 / 実行    |
+| オン    | 詳細            | 詳細             | 105.5 / 実行   |
+
+**Tripo: 画像からモデル**および**Tripo: マルチビューからモデル**
+
+| texture | texture_quality | geometry_quality | クレジット     |
+| :------ | :-------------- | :--------------- | :------------- |
+| オフ    | スタンダード    | スタンダード     | 42.2 / 実行    |
+| オフ    | スタンダード    | 詳細             | 84.4 / 実行    |
+| オン    | スタンダード    | スタンダード     | 63.3 / 実行    |
+| オン    | 詳細            | スタンダード     | 84.4 / 実行    |
+| オン    | スタンダード    | 詳細             | 105.5 / 実行   |
+| オン    | 詳細            | 詳細             | 126.6 / 実行   |
+
+`quad`アドオン (+10.55 / 実行) は**Tripo: テキストからモデル**と**Tripo: 画像からモデル**にのみ適用されます。
+
+### 生成: P1
+
+| model       | output_mode   | texture_quality | クレジット（テキスト） | クレジット（画像/マルチビュー） |
+| :---------- | :------------ | :-------------- | :--------------------- | :----------------------------- |
+| P1-20260311 | ジオメトリのみ | —               | 63.3 / 実行            | 84.4 / 実行                    |
+|             | テクスチャあり   | スタンダード      | 84.4 / 実行            | 105.5 / 実行                   |
+|             | テクスチャあり   | 詳細            | 105.5 / 実行           | 126.6 / 実行                   |
+
+### 後処理
+
+| ノード                         | クレジット           |
+| :----------------------------- | :------------------------------- |
+| Tripo: テクスチャモデル         | 21.1 / 実行（スタンダード）、42.2 / 実行（詳細） |
+| Tripo: リグモデル               | 52.75 / 実行                     |
+| Tripo: リターゲットリグモデル   | 21.1 / 実行                      |
+| Tripo: モデル変換               | 10.55 / 実行（基本）、21.1 / 実行（高度な機能） |
+| Tripo: モデルインポート         | 無料                             |
+
+**Tripo: モデル変換**は、`quad`がオン、`face_limit`が設定、`texture_size` ≠ 4096、`texture_format` ≠ JPEG、`flatten_bottom`または`pivot_to_center_bottom`がオン、`flatten_bottom_threshold` ≠ 0、または`scale_factor` ≠ 1の場合、**21.1 / 実行**がかかります。それ以外の場合は**10.55 / 実行**。
 
 ## Vidu
 
-### ビデオ生成 — Q3
+### ビデオ：Q3
 
-| 製品名                             | 設定                                       | クレジット       | カテゴリ |
-| :--------------------------------- | :----------------------------------------- | :-------------- | :------- |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-pro, 解像度: 1080P         | 33.76 / 秒     | ビデオ   |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-pro, 解像度: 720P          | 31.65 / 秒     | ビデオ   |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-pro, 解像度: 540P          | 14.77 / 秒     | ビデオ   |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-turbo, 解像度: 1080P       | 16.88 / 秒     | ビデオ   |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-turbo, 解像度: 720P        | 12.66 / 秒     | ビデオ   |
-| Vidu Q3 ビデオ生成プロダクト       | モデル: vidu-q3-turbo, 解像度: 540P        | 8.44 / 秒      | ビデオ   |
+総クレジット = **(クレジット / 秒) × `duration`**。
 
-### ビデオ生成 — Q2
+| モデル        | 解像度 | クレジット/秒 |
+| :----------- | :----- | :------------ |
+| viduq3-turbo | 720p   | 12.66         |
+|              | 1080p  | 16.88         |
+| viduq3-pro   | 720p   | 31.65         |
+|              | 1080p  | 33.76         |
+|              | 2K     | 42.2          |
 
-> オフピーク価格は通常価格の半額です。小数点以下は切り上げます。
+**2K** は **viduq3-pro** を使用した **Vidu Q3 画像から動画生成** のみで利用可能です。
 
-| 製品名                             | 設定                                                                               | クレジット                                | カテゴリ |
-| :--------------------------------- | :--------------------------------------------------------------------------------- | :--------------------------------------- | :------- |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-turbo, タイプ: img2video / start-end2video, 解像度: 540P                 | 開始時 6.33, 以降 +2.11/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-turbo, タイプ: img2video / start-end2video, 解像度: 720P                 | 開始時 8.44, 2秒後から +10.55/秒          | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-turbo, タイプ: img2video / start-end2video, 解像度: 1080P                | 開始時 36.92, 以降 +10.55/秒              | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: img2video / start-end2video, 解像度: 540P                   | 開始時 8.44, 2秒後から +5.28/秒           | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: img2video / start-end2video, 解像度: 720P                   | 開始時 15.82, 以降 +10.55/秒              | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: img2video / start-end2video, 解像度: 1080P                  | 開始時 58.03, 以降 +15.82/秒              | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro-fast, タイプ: img2video / start-end2video, 解像度: 720P              | 開始時 8.44, 以降 +2.11/秒                | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro-fast, タイプ: img2video / start-end2video, 解像度: 1080P             | 開始時 16.88, 以降 +4.22/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: text2video, 解像度: 540P                                       | 開始時 10.55, 以降 +2.11/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: text2video, 解像度: 720P                                       | 開始時 15.82, 以降 +5.28/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: text2video, 解像度: 1080P                                      | 開始時 21.1, 以降 +10.55/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: reference2video, 解像度: 540P                                  | 開始時 15.82, 以降 +5.28/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: reference2video, 解像度: 720P                                  | 開始時 26.38, 以降 +5.28/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2, タイプ: reference2video, 解像度: 1080P                                 | 開始時 79.12, 以降 +10.55/秒              | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: reference2video, 解像度: 540P                              | 開始時 21.1, 以降 +5.28/秒                | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: reference2video, 解像度: 720P                              | 開始時 31.65, 以降 +5.28/秒               | ビデオ   |
-| Vidu Q2 ビデオ生成プロダクト       | モデル: q2-pro, タイプ: reference2video, 解像度: 1080P                             | 開始時 89.67, 以降 +10.55/秒              | ビデオ   |
+### ビデオ：Q2
 
-### ビデオ生成 — Q1
+**リニアノード**（マルチフレームを除く）：**ベース + (クレジット/秒) × (`duration` − 1)**。
 
-| 製品名                             | 設定                                                                                             | クレジット    | カテゴリ |
-| :--------------------------------- | :----------------------------------------------------------------------------------------------- | :----------- | :------- |
-| Vidu Q1 ビデオ生成プロダクト       | モデル: vidu-q1, タイプ: reference2video, スタイル: 一般, 持続時間: 5s, 解像度: 1080P              | 84.4 / 回    | ビデオ   |
-| Vidu Q1 ビデオ生成プロダクト       | モデル: vidu-q1, タイプ: img2video, スタイル: 一般, 持続時間: 5s, 解像度: 1080P                    | 84.4 / 回    | ビデオ   |
-| Vidu Q1 ビデオ生成プロダクト       | モデル: vidu-q1, タイプ: start-end2video, スタイル: 一般, 持続時間: 5s, 解像度: 1080P              | 84.4 / 回    | ビデオ   |
-| Vidu Q1 ビデオ生成プロダクト       | モデル: vidu-q1, タイプ: text2video, スタイル: 一般, 持続時間: 5s, 解像度: 1080P                   | 84.4 / 回    | ビデオ   |
-| Vidu Q1 ビデオ生成プロダクト       | モデル: vidu-q1, タイプ: text2video, スタイル: アニメ, 持続時間: 5s, 解像度: 1080P                 | 84.4 / 回    | ビデオ   |
+**マルチフレーム：** **`frames` × ベース + (クレジット/秒) × 各セグメント期間の合計**（拡張/マルチフレームのベース列を使用）。
 
-### ビデオ生成 — Vidu 2.0
+**参照**（`viduq2`）：`audio` がオンの場合、**+15.825 / 回** を追加。
 
-| 製品名                              | 設定                                                                    | クレジット      | カテゴリ |
-| :---------------------------------- | :---------------------------------------------------------------------- | :------------- | :------- |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: img2video, 持続時間: 4S, 解像度: 360P         | 21.1 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: img2video, 持続時間: 4S, 解像度: 720P         | 42.2 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: img2video, 持続時間: 4S, 解像度: 1080P        | 105.5 / 回     | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: img2video, 持続時間: 8S, 解像度: 720P         | 105.5 / 回     | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: reference2video, 持続時間: 4S, 解像度: 360P   | 84.4 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: reference2video, 持続時間: 4S, 解像度: 720P   | 84.4 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: start-end2video, 持続時間: 4S, 解像度: 360P   | 21.1 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: start-end2video, 持続時間: 4S, 解像度: 720P   | 42.2 / 回      | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: start-end2video, 持続時間: 4S, 解像度: 1080P  | 105.5 / 回     | ビデオ   |
-| Vidu 2.0 ビデオ生成プロダクト       | モデル: vidu-2.0, タイプ: start-end2video, 持続時間: 8S, 解像度: 720P   | 105.5 / 回     | ビデオ   |
+| モデル           | 解像度 | 1秒後のクレジット/秒 | ベース（1秒）リニアノード | ベース（1秒）拡張/マルチフレーム |
+| :-------------- | :----- | :--------------------- | :----------------------- | :---------------------------- |
+| viduq2          | 720p   | 5.275                  | 15.825                   | —                             |
+|                 | 1080p  | 10.55                  | 21.1                     | —                             |
+| viduq2-pro-fast | 720p   | 2.11                   | 8.44                     | —                             |
+|                 | 1080p  | 4.22                   | 16.88                    | —                             |
+| viduq2-pro      | 720p   | 10.55                  | 15.825                   | 31.65                         |
+|                 | 1080p  | 15.825                 | 58.025                   | 63.3                          |
+| viduq2-turbo    | 1080p  | 10.55                  | 36.925                   | 42.2                          |
+|                 | 720p   | 5.275（拡張/MF）；10.55（I2V/開始-終了、2秒後） | — | 15.825 |
 
-### 画像生成
+上記の **viduq2** リニアベースは**テキストから動画へ**用です。**参照から動画**は同じ秒単位レートを使用しますが、ベースは **26.375**（720p）または **79.125**（1080p）です。
 
-| 製品名                        | 設定                                                                         | クレジット      | カテゴリ |
-| :---------------------------- | :--------------------------------------------------------------------------- | :------------- | :------- |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: テキストから画像へ, 解像度: 1080P                      | 6.33 / 回      | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: テキストから画像へ, 解像度: 2K                        | 8.44 / 回      | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: テキストから画像へ, 解像度: 4K                        | 10.55 / 回     | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 1–3, 解像度: 1080P              | 8.44 / 回      | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 1–3, 解像度: 2K                 | 12.66 / 回     | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 1–3, 解像度: 4K                 | 21.1 / 回      | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 4–7, 解像度: 1080P              | 10.55 / 回     | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 4–7, 解像度: 2K                 | 16.88 / 回     | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq2, タイプ: 参照画像, 参照画像数: 4–7, 解像度: 4K                 | 31.65 / 回     | 画像     |
-| Vidu 画像生成プロダクト       | モデル: viduq1, タイプ: 参照画像, 参照画像数: 1–7, 解像度: 1080P              | 21.1 / 回      | 画像     |
+**viduq2-pro-fast**、**viduq2-pro**、**viduq2-turbo** のリニアベースは**画像から動画へ**および**開始/終了フレームから動画生成**用です。**viduq2-turbo** の **720p** をこれらのノードで使用する場合：1秒目は **8.44**（I2V）、2秒目は **10.55**（I2Vでは固定；開始/終了の最小期間は2秒）、その後は **+10.55 / 秒**。**5.275 / 秒** のレートは拡張とマルチフレームにのみ適用され、I2V や開始/終了には適用されません。
 
-### 動画拡張
+### ビデオ：Q1
 
-| 製品名                          | 設定                              | クレジット                     | カテゴリ |
-| :------------------------------ | :-------------------------------- | :---------------------------- | :------- |
-| Vidu 動画拡張プロダクト         | モデル: q2-turbo, 解像度: 540P    | 開始時 10.55, 以降 +2.11/秒   | ビデオ   |
-| Vidu 動画拡張プロダクト         | モデル: q2-turbo, 解像度: 720P    | 開始時 15.82, 以降 +5.28/秒   | ビデオ   |
-| Vidu 動画拡張プロダクト         | モデル: q2-turbo, 解像度: 1080P   | 開始時 42.2, 以降 +10.55/秒   | ビデオ   |
-| Vidu 動画拡張プロダクト         | モデル: q2-pro, 解像度: 540P      | 開始時 15.82, 以降 +5.28/秒   | ビデオ   |
-| Vidu 動画拡張プロダクト         | モデル: q2-pro, 解像度: 720P      | 開始時 31.65, 以降 +10.55/秒  | ビデオ   |
-| Vidu 動画拡張プロダクト         | モデル: q2-pro, 解像度: 1080P    | 開始時 63.3, 以降 +15.82/秒   | ビデオ   |
+**1080p** 固定の **5秒**。
 
-### その他の機能
+| モデル   | クレジット    |
+| :------ | :----------- |
+| viduq1  | 84.4 / 回    |
 
-| 製品名                      | 設定   | クレジット      | カテゴリ |
-| :-------------------------- | :----- | :------------- | :------- |
-| Vidu リップシンクプロダクト | —      | 21.1 / 5秒     | ビデオ   |
-| Vidu モーションシンクプロダクト | —      | 10.55 / 秒     | ビデオ   |
+## Wan
 
-## WAN
+| モデル                                                          | 解像度 | クレジット                |
+| :------------------------------------------------------------- | :----- | :----------------------- |
+| wan2.5-t2i-preview, wan2.5-i2i-preview                         | —      | 6.33 / 回               |
+| wan2.7-t2v, wan2.7-i2v                                         | 720P   | 21.1 / 秒               |
+|                                                                | 1080P  | 31.65 / 秒              |
+| wan2.7-i2v (継続)                                      | 720P   | 21.1 / 秒 (範囲)       |
+|                                                                | 1080P  | 31.65 / 秒 (範囲)      |
+| wan2.7-videoedit                                               | 720P   | 21.1 / 秒 (入出力)    |
+|                                                                | 1080P  | 31.65 / 秒 (入出力)   |
+| wan2.7-r2v                                                     | 720P   | 21.1 / 秒 (範囲)       |
+|                                                                | 1080P  | 31.65 / 秒 (範囲)      |
+| wan2.5-t2v-preview, wan2.5-i2v-preview                         | 480p   | 10.55 / 秒              |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 720p   | 21.1 / 秒              |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 1080p  | 31.65 / 秒             |
+| wan2.6-r2v                                                     | 720p   | 21.1 / 秒 (範囲)       |
+|                                                                | 1080p  | 31.65 / 秒 (範囲)      |
 
-| 製品名                     | 構成                                        | クレジット     | カテゴリ |
-| :------------------------- | :------------------------------------------ | :------------- | :------- |
-| Wan画像生成プロダクト       | モデル: wan2.5-i2i-preview                  | 6.33 / 実行    | 画像     |
-| Wan画像生成プロダクト       | モデル: wan2.5-t2i-preview                  | 6.33 / 実行    | 画像     |
-| Wan画像生成プロダクト       | モデル: wan2.6-t2i                          | 6.33 / 実行    | 画像     |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-i2v-preview, 解像度: 1080P | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-i2v-preview, 解像度: 480P  | 10.55 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-i2v-preview, 解像度: 720P  | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-t2v-preview, 解像度: 1080P | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-t2v-preview, 解像度: 480P  | 10.55 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.5-t2v-preview, 解像度: 720P  | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-i2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-i2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-r2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-r2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-t2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.6-t2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-i2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-i2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-r2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-r2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-t2v, 解像度: 1080P         | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-t2v, 解像度: 720P          | 21.1 / 秒     | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-videoedit, 解像度: 1080P   | 31.65 / 秒    | ビデオ   |
-| Wanビデオ生成プロダクト     | モデル: wan2.7-videoedit, 解像度: 720P    | 21.1 / 秒     | ビデオ   |
+## WaveSpeed
 
-## Wavespeed
-
-| 製品名              | 構成                               | クレジット      | カテゴリ |
-| :------------------ | :--------------------------------- | :-------------- | :------- |
-| Wavespeed Flashvsr  | 解像度: 1080p                       | 18.99 / 実行    | 画像     |
-| Wavespeed Flashvsr  | 解像度: 2k                          | 25.32 / 実行    | 画像     |
-| Wavespeed Flashvsr  | 解像度: 4k                          | 33.76 / 実行    | 画像     |
-| Wavespeed Flashvsr  | 解像度: 720p                        | 12.66 / 実行    | 画像     |
-| Wavespeed Image     | endpoint: seedvr2                   | 2.11 / 実行     | 画像     |
-| Wavespeed Image     | endpoint: ultimate-image-upscaler   | 12.66 / 実行    | 画像     |
+| モデル     | 解像度      | クレジット      |
+| :--------- | :---------- | :-------------- |
+| flashvsr   | 720p        | 2.532 / 秒      |
+|            | 1080p       | 3.798 / 秒      |
+|            | 2K          | 5.064 / 秒      |
+|            | 4K          | 6.752 / 秒      |
+| SeedVR2    | —           | 2.11 / 回       |
+| Ultimate   | —           | 12.66 / 回      |
 
 ## xAI
 
 <Note>
-動画エンドポイントはモデレートされたコンテンツに対して課金されます。
+ビデオエンドポイントはモデレーション済みのコンテンツに対して課金されます。
 </Note>
-| 製品名                                       | 設定                                                                                                     | クレジット   | カテゴリ |
-| :------------------------------------------- | :------------------------------------------------------------------------------------------------------ | :----------- | :------- |
-| xAI 画像生成                                 | endpoint: v1/images/generations, model: grok-imagine-image-beta, resolution: 1k                         | 6.96 / run   | 画像     |
-| xAI 画像生成                                 | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 1k                      | 10.55 / run  | 画像     |
-| xAI 画像生成                                 | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 2k                      | 14.77 / run  | 画像     |
-| xAI 画像編集出力                             | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 6.96 / run   | 画像     |
-| xAI 画像編集出力                             | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 1k                            | 10.55 / run  | 画像     |
-| xAI 画像編集出力                             | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 2k                            | 14.77 / run  | 画像     |
-| xAI 画像編集入力                             | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 0.42 / run   | 画像     |
-| xAI 画像編集入力                             | endpoint: v1/images/edits, model: grok-imagine-image-quality                                           | 2.11 / run   | 画像     |
-| xAI ビデオ生成出力（秒単位）                 | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 38.19 / sec  | ビデオ   |
-| xAI ビデオ生成出力（秒単位）                 | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p                       | 38.19 / sec  | ビデオ   |
-| xAI ビデオ生成出力（秒単位）                 | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 480p                     | 24.14 / sec  | ビデオ   |
-| xAI ビデオ生成出力（秒単位）                 | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 720p                     | 42.24 / sec  | ビデオ   |
-| xAI ビデオ生成出力（秒単位）                 | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 1080p                    | 75.43 / sec  | ビデオ   |
-| xAI ビデオ生成入力画像                       | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, type: image-to-video                 | 3.02 / sec   | ビデオ   |
-| xAI ビデオ生成入力画像                       | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p, type: image-to-video | 0.42 / sec   | ビデオ   |
-| xAI ビデオ生成入力画像                       | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p, type: image-to-video | 0.42 / sec   | ビデオ   |
-| xAI ビデオ編集入出力（秒単位）               | endpoint: v1/videos/edits, model: grok-imagine-video-beta, resolution: 480p                             | 40.3 / sec   | ビデオ   |
-| xAI 画像編集入力                             | endpoint: v1/images/edits, model: v1/images/edits, resolution: 1k                                       | 0.42 / run   | 画像     |
-| xAI ビデオ編集入出力（秒単位）               | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 40.3 / sec   | ビデオ   |
-| xAI クレジット                               | NA                                                                                                      | 2.11 / run   | 画像     |
 
-## その他（クラウド）
+### 画像
 
-| 製品名         | 構成                     | クレジット    | カテゴリ |
-| :------------- | :----------------------- | :------------ | :------- |
-| GPU時間製品    | gpu_type: rtx_pro_6000   | 0.27 / sec    | 画像     |
+| モデル                     | 解像度 | タスク   | クレジット                                      |
+| :------------------------- | :----- | :------- | :-------------------------------------------- |
+| grok-imagine-image-quality | 1K     | 生成     | 10.55 / 出力画像                               |
+|                            | 2K     | 生成     | 14.77 / 出力画像                               |
+| grok-imagine-image-pro     | —      | 生成     | 14.77 / 出力画像                               |
+| grok-imagine-image         | —      | 生成     | 4.22 / 出力画像                                |
+| grok-imagine-image-quality | 1K     | 編集     | 2.11 入力 + 10.55 / 出力画像                   |
+|                            | 2K     | 編集     | 2.11 入力 + 14.77 / 出力画像                   |
+| grok-imagine-image-pro     | —      | 編集     | 0.422 入力 + 14.77 / 出力画像                |
+| grok-imagine-image         | —      | 編集     | 0.422–1.266 入力 + 4.22 / 出力画像           |
+
+### ビデオ
+
+| モデル                         | 解像度 | クレジット                                                       |
+| :----------------------------- | :----- | :------------------------------------------------------------- |
+| grok-imagine-video             | 480p   | 10.55 / 秒出力 (+0.422 入力画像)                                |
+|                                | 720p   | 14.77 / 秒出力 (+0.422 入力画像)                                |
+| grok-imagine-video-1.5         | 480p   | 24.14 / 秒出力 (+3.02 入力画像)                                 |
+|                                | 720p   | 42.24 / 秒出力 (+3.02 入力画像)                                 |
+|                                | 1080p  | 75.43 / 秒出力 (+3.02 入力画像)                                 |
+| grok-imagine-video (編集)      | —      | 12.66 / 秒 (入力 + 出力ビデオ)                                   |
+| grok-imagine-video (参照)      | 480p   | 15.09 / 秒出力 + 0.603 / 参照画像                               |
+|                                | 720p   | 21.12 / 秒出力 + 0.603 / 参照画像                               |
+| grok-imagine-video (拡張)      | —      | 6.03–45.26 入力 + 15.09 × 拡張秒出力 / 実行                     |
+
+## クラウド GPU
+
+| GPUタイプ       | クレジット    |
+| :------------- | :------------ |
+| rtx_pro_6000   | 0.27 / 秒     |

--- a/ko/tutorials/partner-nodes/pricing.mdx
+++ b/ko/tutorials/partner-nodes/pricing.mdx
@@ -3,48 +3,47 @@ title: "가격 정책"
 description: "이 문서에는 현재 파트너 노드의 가격 정책이 나와 있습니다. 모든 가격은 크레딧 단위로 표시됩니다(211 크레딧 = 1 USD)."
 sidebarTitle: "가격 정책"
 mode: wide
-translationSourceHash: 01471717
+translationSourceHash: 48347eb0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": 845592d4
-  "Beeble": 885c0b0f
-  "BFL": c049375b
-  "Anthropic": 7966fafa
-  "Bria": c7c492a1
-  "ByteDance": c45deeb8
-  "ElevenLabs": 6adeca08
-  "Freepik": cf21eaf2
-  "Google": 22aa3ea9
-  "HappyHorse": 28d2c09d
-  "Hitpaw": 3f19a1ce
-  "Ideogram": 6b1fa01c
-  "Krea": 67613c4e
-  "Kling": ba141835
-  "Lightricks": c29a5b7e
-  "Luma": 41bd0a3f
-  "Meshy": 3a0f5a43
-  "Minimax": e2e387a5
-  "Moonvalley": 8ca8c186
-  "OpenAI": 6842a6d6
-  "OpenRouter": a437d408
-  "Pika": 117ad27b
-  "Pixverse": 6fa7019b
-  "Quiver": 199f7f57
-  "Recraft": 48d0028a
-  "Reve": 82943ad5
-  "Rodin": 69c74113
-  "Runway": f2115adb
-  "Sonilo": 9b1be9b8
-  "Stability AI": 488faf10
-  "Tencent": 5d02a5cc
-  "Topaz": 8f39ff22
-  "Tripo": 2f8e0275
-  "Vidu": 50f09885
-  "WAN": b01edeb4
-  "Wavespeed": 17bdbfd6
-  "xAI": edfd0753
-  "Other (Cloud)": 9101685b
+  "Anthropic": a7ca54bf
+  "Beeble": d1b19f61
+  "BFL": 3ff6bff0
+  "Bria": 232ed8f6
+  "ByteDance": 19edbf0b
+  "ElevenLabs": 166ecbf9
+  "Magnific": 4000e7e1
+  "Google": 7b3926a3
+  "HappyHorse": bceb584a
+  "Hitpaw": 320c0537
+  "Ideogram": d9748301
+  "Krea": fb20c257
+  "Kling": cdf2c899
+  "Lightricks": 4870964f
+  "Luma": 655207a5
+  "Meshy": 6cd06881
+  "Minimax": 28c7cf5e
+  "OpenAI": 27febd17
+  "OpenRouter": 07b4b92f
+  "Pixverse": 8612b816
+  "Quiver": b9d45a82
+  "Recraft": 7eb9a1a7
+  "Reve": 5be5c43a
+  "Rodin 3D": 2eb41834
+  "Runway": 94ec479a
+  "Sonilo": 48b9c581
+  "Stability AI": ddca722f
+  "Tencent": f1efbad9
+  "Topaz": 3eabf417
+  "Tripo": 0d9ddbf9
+  "Vidu": 8ae05bc9
+  "Wan": c51a9eef
+  "WaveSpeed": 349a7c9d
+  "xAI": 7e81e67b
+  "Cloud GPU": 103c55e6
 ---
+
 
 
 
@@ -53,1072 +52,1076 @@ translationBlockHashes:
 
 211 크레딧 = 1 USD
 
+## Anthropic
+
+Anthropic 파트너 노드는 공개 Anthropic API와 동일한 기본 USD 사용량을 청구합니다. **크레딧 = USD × 211**(페이지 헤더 참조). 아래 입력 및 출력 요금은 `ClaudeNode` 가격 표시와 일치하는 1K 토큰 기준입니다. 캐시 읽기 및 쓰기는 캐시된 토큰 수에 대해 Anthropic 승수(입력 요금의 0.1배, 1.25배, 2.0배)를 사용합니다.
+
+### 채팅(`ClaudeNode`)
+
+| 모델       | 입력 크레딧 / 1K | 5분 캐시 쓰기 크레딧 / 1K | 1시간 캐시 쓰기 크레딧 / 1K | 캐시 적중 크레딧 / 1K | 출력 크레딧 / 1K |
+| :--------- | ----------------: | -------------------------: | -------------------------: | --------------------: | ----------------: |
+| Opus 4.7   |           1.055 |                    1.31875 |                       2.11 |                0.1055 |             5.275 |
+| Opus 4.6   |           1.055 |                    1.31875 |                       2.11 |                0.1055 |             5.275 |
+| Sonnet 4.6 |           0.633 |                    0.79125 |                      1.266 |                0.0633 |             3.165 |
+| Sonnet 4.5 |           0.633 |                    0.79125 |                      1.266 |                0.0633 |             3.165 |
+| Haiku 4.5  |           0.211 |                    0.26375 |                      0.422 |                0.0211 |             1.055 |
+
+선택적 이미지는 동일한 모델 입력 요금으로 청구되는 토큰을 추가합니다.
+
 ## Beeble
 
-| 제품 이름               | 구성                             | 크레딧       | 카테고리 |
-| :----------------------- | :---------------------------------------- | :------------ | :------- |
-| SwitchX | model: switchx, output_type: video, resolution: 720p | 30.17 / 30프레임 | 비디오    |
-| SwitchX | model: switchx, output_type: video, resolution: 1080p | 90.52 / 30프레임 | 비디오    |
-| SwitchX | model: switchx, output_type: image, resolution: 720p  | 30.17 / 실행       | 이미지    |
-| SwitchX | model: switchx, output_type: image, resolution: 1080p | 90.52 / 실행       | 이미지    |
+### 비디오: SwitchX 비디오 편집
+
+| 최대 해상도 | 크레딧           |
+| :------------- | :---------------- |
+| 720p           | 30.17 / 30 프레임 |
+| 1080p          | 90.52 / 30 프레임 |
+
+### 이미지: SwitchX 이미지 편집
+
+| 최대 해상도 | 크레딧     |
+| :------------- | :---------- |
+| 720p           | 30.17 / 실행 |
+| 1080p          | 90.52 / 실행 |
 
 ## BFL
 
-| 모델                      | 크레딧                       | 카테고리 |
-| :------------------------- | :---------------------------- | :------- |
-| flux-dev                   | 5.28 / 실행                    | 이미지    |
-| flux-kontext-max           | 16.88 / 실행                   | 이미지    |
-| flux-kontext-pro           | 8.44 / 실행                    | 이미지    |
-| flux-pro-1.0-canny         | 10.55 / 실행                   | 이미지    |
-| flux-pro-1.0-depth         | 10.55 / 실행                   | 이미지    |
-| flux-pro-1.0-expand        | 10.55 / 실행                   | 이미지    |
-| flux-pro-1.0-fill          | 10.55 / 실행                   | 이미지    |
-| flux-tools/erase-v1        | 6.33 / 실행 + 0.84 / 추가 MP | 이미지    |
-| flux-tools/vto-v1          | 7.91 / 실행 + 1.06 / 추가 MP | 이미지    |
-| flux-pro-1.1               | 8.44 / 실행                    | 이미지    |
-| flux-pro-1.1-ultra         | 12.66 / 실행                   | 이미지    |
-| /v1/flux-pro               | 10.55 / 실행                   | 이미지    |
-| flux-2-pro                 | 6.33 / 실행 + 3.17 / 추가 MP | 이미지    |
-| flux-2-max                 | 14.77 / 실행 + 6.33 / 추가 MP | 이미지    |
-
-## 앤트로픽
-
-Anthropic 파트너 노드는 공개 Anthropic API와 동일한 기본 USD 사용량을 청구합니다. **크레딧 = USD × 211** (페이지 헤더 참조). 아래의 토큰 가격은 100만 토큰당입니다. 캐시 가격 승수는 Anthropic의 프롬프트 캐싱 문서와 일치합니다.
-
-### 채팅 (`ClaudeNode`)
-
-모델: 100만 토큰당.
-
-| 모델           | 입력 크레딧 / 1M | 5분 캐시 쓰기 크레딧 / 1M | 1시간 캐시 쓰기 크레딧 / 1M | 캐시 히트 크레딧 / 1M | 출력 크레딧 / 1M |
-| :-------------- | -----------------: | -------------------------: | -------------------------: | ---------------------: | ------------------: |
-| `claude-opus-4-7` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-6` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-5-20251101` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-1-20250805` | 3165 | 3956.25 | 6330 | 316.5 | 15825 |
-| `claude-sonnet-4-6` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-sonnet-4-5-20250929` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-haiku-4-5-20251001` | 211 | 263.75 | 422 | 21.1 | 1055 |
-
-선택적 이미지는 동일한 모델 입력 요율로 청구되는 토큰을 추가합니다.
+| 노드 | 크레딧 |
+| :--- | :---: |
+| Flux 1.1 [pro] 울트라 이미지 | 12.66 / 실행 |
+| Flux.1 Kontext [pro] 이미지 | 8.44 / 실행 |
+| Flux.1 Kontext [max] 이미지 | 16.88 / 실행 |
+| Flux.1 확장 이미지 | 10.55 / 실행 |
+| Flux.1 채우기 이미지 | 10.55 / 실행 |
+| Flux 이미지 지우기 | 6.33 / 실행 + 0.84 / 추가 MP |
+| Flux 가상 피팅 | 7.91 / 실행 + 1.06 / 추가 MP |
+| Flux.2 [pro] | 6.33 / 실행 + 3.17 / 추가 MP |
+| Flux.2 [max] | 14.77 / 실행 + 6.33 / 추가 MP |
 
 ## Bria
 
-| 제품 이름                 | 구성                             | 크레딧     | 카테고리 |
-| :--------------------------- | :---------------------------------------- | :---------- | :------- |
-| Bria 이미지 편집              | endpoint: v2/image/edit, model: fibo      | 8.44 / 실행  | 이미지    |
-| Bria 이미지 배경 제거 | endpoint: v2/image/edit/remove_background | 3.8 / 실행   | 이미지    |
-| Bria 비디오 배경 제거 | endpoint: v2/video/edit/remove_background | 0.89 / 초 | 비디오    |
-| Bria 비디오 그린 스크린     | endpoint: v2/video/edit/green_screen     | 0.89 / 초 | 비디오    |
-| Bria 비디오 배경 교체 | endpoint: v2/video/edit/replace_background | 0.89 / 초 | 비디오    |
-| Bria 투명 비디오 배경 | endpoint: v2/video/edit/remove_background | 0.89 / 초 | 비디오    |
+### 이미지
+
+| 노드 | 크레딧 |
+| :--------------------------- | :--------- |
+| Bria FIBO 이미지 편집 | 8.44 / 실행 |
+| Bria 이미지 배경 제거 | 3.8 / 실행 |
+
+### 비디오
+
+| 노드 | 크레딧 |
+| :----------------------------------------- | :--------- |
+| Bria 비디오 배경 제거 | 0.89 / 초 |
+| Bria 비디오 그린 스크린 | 0.89 / 초 |
+| Bria 비디오 배경 교체 | 0.89 / 초 |
+| Bria 비디오 배경 제거 (투명) | 0.89 / 초 |
 
 ## ByteDance
 
-| 제품 이름                                         | 구성                                                   | 크레딧           | 카테고리 |
-| :--------------------------------------------------- | :-------------------------------------------------------------- | :---------------- | :------- |
-| BytePlus Seed 입력 텍스트 토큰 (100만 토큰당)     | model: seed-2-0-pro-260328                                     | 105.5 / 1M 토큰 | 텍스트     |
-| BytePlus Seed 입력 텍스트 토큰 (100만 토큰당)     | model: seed-2-0-lite-260228                                    | 52.75 / 1M 토큰  | 텍스트     |
-| BytePlus Seed 입력 텍스트 토큰 (100만 토큰당)     | model: seed-2-0-mini-260215                                    | 21.1 / 1M 토큰   | 텍스트     |
-| BytePlus Seed 출력 텍스트 토큰 (100만 토큰당)    | model: seed-2-0-pro-260328                                     | 633 / 1M 토큰    | 텍스트     |
-| BytePlus Seed 출력 텍스트 토큰 (100만 토큰당)    | model: seed-2-0-lite-260228                                    | 422 / 1M 토큰    | 텍스트     |
-| BytePlus Seed 출력 텍스트 토큰 (100만 토큰당)    | model: seed-2-0-mini-260215                                    | 84.4 / 1M 토큰   | 텍스트     |
-| BytePlus Seed 캐시 히트 입력 토큰 (100만 토큰당)| model: seed-2-0-pro-260328                                     | 21.1 / 1M 토큰   | 텍스트     |
-| BytePlus Seed 캐시 히트 입력 토큰 (100만 토큰당)| model: seed-2-0-lite-260228                                    | 10.55 / 1M 토큰  | 텍스트     |
-| BytePlus Seed 캐시 히트 입력 토큰 (100만 토큰당)| model: seed-2-0-mini-260215                                    | 4.22 / 1M 토큰   | 텍스트     |
-| BytePlus 이미지 생성 제품                    | model: seededit-3-0-i2i-250628                                  | 6.33 / 실행        | 이미지    |
-| BytePlus 이미지 생성 제품                    | model: seedream-3-0-t2i-250415                                  | 6.33 / 실행        | 이미지    |
-| BytePlus 이미지 생성 제품                    | model: seedream-4-0-250828                                      | 6.33 / 실행        | 이미지    |
-| BytePlus 이미지 생성 제품                    | model: seedream-4-5-251128                                      | 8.44 / 실행        | 이미지    |
-| BytePlus 이미지 생성 제품                    | model: seedream-5-0-260128                                      | 7.39 / 실행        | 이미지    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-lite-i2v-250428, video_type: image-to-video | 379.8 / 1M 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-lite-t2v-250428, video_type: text-to-video  | 379.8 / 1M 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-pro-250528, video_type: image-to-video      | 527.5 / 1M 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-pro-250528, video_type: text-to-video       | 527.5 / 1M 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-pro-fast-251015, video_type: image-to-video | 211 / 1M 토큰   | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedance-1-0-pro-fast-251015, video_type: text-to-video  | 211 / 1M 토큰   | 비디오    |
-| BytePlus 비디오 생성 제품 (100만 토큰당)    | model: seedream-4-5-251128, video_type: text-to-video           | 211 / 1M 토큰   | 비디오    |
-| BytePlus 오디오 포함 비디오 생성 (100만 토큰당) | generate_audio: false, model: seedance-1-5-pro-251215           | 253.2 / 1M 토큰 | 비디오    |
-| BytePlus 오디오 포함 비디오 생성 (100만 토큰당) | generate_audio: true, model: seedance-1-5-pro-251215            | 506.4 / 1M 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: text-to-video (비디오 입력 없음: 텍스트 또는 이미지)  | 2.112 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: image-to-video (비디오 입력 없음: 텍스트 또는 이미지) | 2.112 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: video-to-video (비디오 입력 있음)              | 1.297 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: text-to-video (비디오 입력 없음: 텍스트 또는 이미지)  | 2.323 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: image-to-video (비디오 입력 없음: 텍스트 또는 이미지) | 2.323 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: video-to-video (비디오 입력 있음)              | 1.418 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: text-to-video (비디오 입력 없음: 텍스트 또는 이미지)     | 1.207 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: image-to-video (비디오 입력 없음: 텍스트 또는 이미지)    | 1.207 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: video-to-video (비디오 입력 있음)                 | 0.724 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: text-to-video (비디오 입력 없음: 텍스트 또는 이미지)  | 1.690 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: image-to-video (비디오 입력 없음: 텍스트 또는 이미지) | 1.690 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: video-to-video (비디오 입력 있음)              | 0.995 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: text-to-video (비디오 입력 없음: 텍스트 또는 이미지)  | 1.056 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: image-to-video (비디오 입력 없음: 텍스트 또는 이미지) | 1.056 / K 토큰 | 비디오    |
-| BytePlus 비디오 생성 제품 (K 토큰당)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: video-to-video (비디오 입력 있음)              | 0.634 / K 토큰 | 비디오    |
+아래 크레딧은 ComfyUI 파트너 노드 가격에 해당합니다(**211 크레딧 = $1 USD**).
 
-> **Seedance 2.0 토큰 계산:** 출력 토큰 = (입력 비디오 지속 시간 + 출력 비디오 지속 시간) × 출력 비디오 길이 × 출력 비디오 너비 × 출력 비디오 프레임 레이트 ÷ 1024. 입력이 텍스트, 이미지 또는 오디오인 경우 입력 지속 시간 = 0. Seedance 2.0은 24fps로 출력합니다. 비디오 기반 비디오 생성 입력에는 최소 토큰 사용 제한이 적용됩니다.
+### LLM: ByteDance Seed
+
+백만 토큰당 가격입니다. 아래 요금은 프롬프트 길이 **[0, 128]K** 기준입니다. 더 긴 프롬프트는 더 높은 등급이 적용됩니다.
+
+| 모델                                  | 입력 크레딧 / 100만 | 캐시 히트 크레딧 / 100만 | 출력 크레딧 / 100만 |
+| :------------------------------------- | -----------------: | ---------------------: | :------------------ |
+| Seed 2.0 Pro (`seed-2-0-pro-260328`)   |              105.5 |                   21.1 | 633                 |
+| Seed 2.0 Lite (`seed-2-0-lite-260228`) |              52.75 |                  10.55 | 422                 |
+| Seed 2.0 Mini (`seed-2-0-mini-260215`) |               21.1 |                   4.22 | 84.4                |
+
+선택적 이미지와 비디오는 입력 가격으로 입력 토큰이 추가됩니다.
+
+### 이미지: ByteDance Seedream 4.5 & 5.0
+
+성공적으로 생성된 이미지당 가격입니다.
+
+| 모델                                     | 크레딧 / 이미지 |
+| :---------------------------------------- | :-------------: |
+| seedream 5.0 lite (`seedream-5-0-260128`) |      7.39       |
+| seedream-4-5-251128                       |      8.44       |
+| seedream-4-0-250828                       |      6.33       |
+
+### 이미지: ByteDance 이미지 (지원 중단됨)
+
+| 모델                   | 크레딧 / 이미지 |
+| :---------------------- | :-------------- |
+| seedream-3-0-t2i-250415 | 6.33            |
+
+### 비디오: Seedance 2.0
+
+480p와 720p는 동일한 요금입니다. Fast 및 Mini는 1080p 또는 4K를 지원하지 않습니다.
+
+예상 토큰 소비량:
+
+`(입력 비디오 지속 시간 + 출력 비디오 지속 시간) × 출력 비디오 너비 × 출력 비디오 높이 × 출력 비디오 프레임 레이트 ÷ 1024`
+
+입력이 텍스트, 이미지 또는 오디오만 있는 경우 입력 비디오 지속 시간 = 0입니다. API의 실제 사용량이 기준입니다.
+
+| 모델             | 해상도 | 비디오 입력 | 크레딧 / 1K 토큰 |
+| :---------------- | :--------- | :---------- | ------------------: |
+| Seedance 2.0      | 480p, 720p | 아니요          | 2.112               |
+| Seedance 2.0      | 480p, 720p | 예         | 1.297               |
+| Seedance 2.0      | 1080p      | 아니요          | 2.323               |
+| Seedance 2.0      | 1080p      | 예         | 1.418               |
+| Seedance 2.0      | 4k         | 아니요          | 1.207               |
+| Seedance 2.0      | 4k         | 예         | 0.724               |
+| Seedance 2.0 Fast | 480p, 720p | 아니요          | 1.690               |
+| Seedance 2.0 Fast | 480p, 720p | 예         | 0.996               |
+| Seedance 2.0 Mini | 480p, 720p | 아니요          | 1.056               |
+| Seedance 2.0 Mini | 480p, 720p | 예         | 0.634               |
+
+**비디오 입력**은 참조 비디오가 연결됨을 의미합니다. 텍스트, 이미지 및 오디오 참조는 비디오 입력 없음으로 간주됩니다.
+
+비디오 기반 비디오 생성 입력의 경우 최소 토큰 사용량이 적용될 수 있습니다. Seedance 2.0은 24fps로 출력합니다.
+
+### 비디오: Seedance 1.x
+
+토큰 기준으로 청구됩니다(Seedance 2.0과 동일한 추정 공식). Seedance 2.0과 달리 **토큰 요금은 해상도에 따라 변하지 않습니다**. 해상도는 공식에서 너비 × 높이를 통해 클립이 사용하는 토큰 수를 변경하므로, 더 높은 해상도는 더 많은 비용이 듭니다.
+
+**토큰 요금**
+
+| 모델                        | 조건               | 크레딧 / 100만 토큰 |
+| :--------------------------- | :---------------------- | :------------------ |
+| seedance-1-5-pro-251215      | `generate_audio: 거짓` | 253.2               |
+| seedance-1-5-pro-251215      | `generate_audio: 참`  | 506.4               |
+| seedance-1-0-pro-250528      | —                       | 527.5               |
+| seedance-1-0-pro-fast-251015 | —                       | 211                 |
+
+**대략적 크레딧 / 10초**(지속 시간 ÷ 10에 따라 크기 조절. 범위는 종횡비에 따라 다름)
+
+| 모델                        | 해상도 | generate_audio | 크레딧 / 10초 |
+| :--------------------------- | :--------- | :------------- | :--------------- |
+| seedance-1-5-pro-251215      | 480p       | 꺼짐            | 25.32            |
+| seedance-1-5-pro-251215      | 480p       | 켜짐             | 50.64            |
+| seedance-1-5-pro-251215      | 720p       | 꺼짐            | 54.86            |
+| seedance-1-5-pro-251215      | 720p       | 켜짐             | 109.72           |
+| seedance-1-5-pro-251215      | 1080p      | 꺼짐            | 122.38 – 124.49  |
+| seedance-1-5-pro-251215      | 1080p      | 켜짐             | 244.76 – 249.0   |
+| seedance-1-0-pro-250528      | 480p       | —              | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p       | —              | 107.61 – 118.16  |
+| seedance-1-0-pro-250528      | 1080p      | —              | 248.98 – 257.42  |
+| seedance-1-0-pro-fast-251015 | 480p       | —              | 18.99 – 21.1     |
+| seedance-1-0-pro-fast-251015 | 720p       | —              | 44.31 – 48.53    |
+| seedance-1-0-pro-fast-251015 | 1080p      | —              | 99.17 – 103.39   |
+| seedance-1-0-lite-i2v-250428 | 480p       | —              | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p       | —              | 78.07 – 86.51    |
+| seedance-1-0-lite-i2v-250428 | 1080p      | —              | 179.35 – 185.68  |
+
+**ByteDance 참조 이미지를 비디오로** (480p 및 720p만 해당):
+
+| 모델                        | 해상도 | 크레딧 / 10초 |
+| :--------------------------- | :--------- | :--------------- |
+| seedance-1-0-pro-250528      | 480p       | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p       | 107.61 – 118.16  |
+| seedance-1-0-lite-i2v-250428 | 480p       | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p       | 78.07 – 86.51    |
 
 ## ElevenLabs
 
-| 제품 이름                           | 구성                                              | 크레딧     | 카테고리 |
-| :------------------------------------- | :--------------------------------------------------------- | :---------- | :------- |
-| 11labs 텍스트 음성 변환                  | endpoint: v1/text-to-dialogue, model: eleven_v3            | 50.64 / 실행 | 오디오    |
-| 11labs 텍스트 음성 변환                  | endpoint: v1/text-to-speech, model: eleven_multilingual_v2 | 50.64 / 실행 | 오디오    |
-| 11labs 텍스트 음성 변환                  | endpoint: v1/text-to-speech, model: eleven_v3              | 50.64 / 실행 | 오디오    |
-| 11labs 음성 텍스트 변환                  | endpoint: v1/speech-to-text, model: scribe_v2              | 92.84 / 실행 | 오디오    |
-| 11labs 음성 텍스트 변환 키워드          | endpoint: v1/speech-to-text, model: scribe_v2              | 18.57 / 실행 | 오디오    |
-| 11labs 음성 텍스트 변환 엔티티 감지 | endpoint: scribe_v2, model: v1/speech-to-text              | 27.85 / 실행 | 오디오    |
-| 11labs 음성 대 음성 분당     | endpoint: v1/speech-to-speech                              | 50.64 / 분 | 오디오    |
-| 11labs 사운드 생성 분당     | endpoint: v1/sound-generation                              | 29.54 / 분 | 오디오    |
-| 11labs 오디오 분리 분당      | endpoint: v1/audio-isolation                               | 50.64 / 분 | 오디오    |
-| 11labs 음성 추가                       | endpoint: v1/voices/add                                    | 31.65 / 실행 | 오디오    |
+| 노드                             | 크레딧          |
+| :------------------------------- | :--------------- |
+| ElevenLabs 텍스트 음성 변환        | 50.64 / 1K chars |
+| ElevenLabs 텍스트 → 대화          | 50.64 / 1K chars |
+| ElevenLabs 음성 → 텍스트          | 1.54 / min       |
+| ElevenLabs 음성 변환              | 50.64 / min      |
+| ElevenLabs 텍스트 → 효과음        | 29.54 / min      |
+| ElevenLabs 음성 분리              | 50.64 / min      |
+| ElevenLabs 즉시 음성 복제          | 31.65 / 실행      |
 
-## Freepik
+## Magnific
 
-| 제품 이름                 | 구성                     | 크레딧     | 카테고리 |
-| :--------------------------- | :-------------------------------- | :---------- | :------- |
-| Freepik 이미지 생성당 | endpoint: magnific-relight        | 23.21 / 실행 | 이미지    |
-| Freepik 이미지 생성당 | endpoint: magnific-style-transfer | 23.21 / 실행 | 이미지    |
-| Freepik 이미지 생성당 | endpoint: skin-enhancer-creative  | 61.19 / 실행 | 이미지    |
-| Freepik 이미지 생성당 | endpoint: skin-enhancer-faithful  | 78.07 / 실행 | 이미지    |
-| Freepik 이미지 생성당 | endpoint: skin-enhancer-flexible  | 94.95 / 실행 | 이미지    |
-| Freepik 이미지 비용           | NA                                | 211 / 실행   | 이미지    |
+### 이미지: 업스케일
+
+**Magnific Image Upscale (Creative)** 와 **Magnific Image Upscale (Precise V2)** 는 동일한 요금 체계를 공유합니다. 업스케일링은 2배 단계로 실행됩니다 (`2x` = 1단계, `4x` = 2단계, `8x` = 3단계, `16x` = 4단계). 각 단계 이후, 픽셀 수가 4배가 됩니다. 각 단계는 해당 단계의 입력 메가픽셀을 기준으로 가격이 책정됩니다.
+
+| 단계별 입력 MP | 크레딧 / 2배 단계 |
+| :--------------- | :----------------- |
+| ≤1.3             | 35.91              |
+| ≤3.0             | 71.82              |
+| ≤6.4             | 107.73             |
+| >6.4             | 430.88             |
+
+**총 크레딧** = 선택한 `scale_factor`에 대한 모든 단계의 합계입니다. 예: **4배**로 1 MP 이미지를 업스케일 → 1 MP에서의 단계 1 (35.91) + 4 MP에서의 단계 2 (107.73) = **143.64 크레딧**.
+
+### 이미지: 편집
+
+| 노드                                  | 크레딧         |
+| :------------------------------------ | :------------- |
+| Magnific 이미지 스타일 전송            | 23.21 / 실행   |
+| Magnific 이미지 리라이트               | 23.21 / 실행   |
+| Magnific 이미지 피부 보정 (creative)   | 61.19 / 실행   |
+| Magnific 이미지 피부 보정 (faithful)   | 78.07 / 실행   |
+| Magnific 이미지 피부 보정 (flexible)   | 94.95 / 실행   |
 
 ## Google
 
-| 제품 이름                                | 구성                                              | 크레딧            | 카테고리 |
-| :------------------------------------------ | :--------------------------------------------------------- | :----------------- | :------- |
-| prod-v1-Veo 2 제품                       | model: veo-2.0-generate-001                                | 105.5 / 실행        | 이미지    |
-| prod-v1-Veo 2 제품                       | model: veo-3.0-generate-preview                            | 158.25 / 실행       | 이미지    |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-2.5-flash-image                              | 63.3 / 1M 토큰   | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-2.5-flash                                    | 63.3 / 1M 토큰   | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-2.5-pro                                      | 263.75 / 1M 토큰 | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M 토큰  | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-3.1-pro-preview                              | 422 / 1M 토큰    | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-3-pro-image-preview                          | 422 / 1M 토큰    | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-3-pro-preview                                | 422 / 1M 토큰    | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-2.5-flash-image                              | 527.5 / 1M 토큰  | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-2.5-flash                                    | 527.5 / 1M 토큰  | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-2.5-pro                                      | 2110 / 1M 토큰   | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-3.1-flash-image-preview                      | 633 / 1M 토큰    | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-3.1-pro-preview                              | 2532 / 1M 토큰   | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-3-pro-image-preview                          | 2532 / 1M 토큰   | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-3-pro-preview                                | 2532 / 1M 토큰   | 텍스트     |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-2.5-flash-image                              | 63.3 / 1M 토큰   | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-2.5-flash                                    | 63.3 / 1M 토큰   | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-2.5-pro                                      | 263.75 / 1M 토큰 | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M 토큰  | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-3.1-pro-preview                              | 422 / 1M 토큰    | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-3-pro-image-preview                          | 422 / 1M 토큰    | 이미지    |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-3-pro-preview                                | 422 / 1M 토큰    | 이미지    |
-| Gemini 출력 이미지 토큰 (100만당) 제품 | model: gemini-2.5-flash-image                              | 6330 / 1M 토큰   | 이미지    |
-| Gemini 출력 이미지 토큰 (100만당) 제품 | model: gemini-3.1-flash-image-preview                      | 12660 / 1M 토큰  | 이미지    |
-| Gemini 출력 이미지 토큰 (100만당) 제품 | model: gemini-3.1-pro-preview                              | 25320 / 1M 토큰  | 이미지    |
-| Gemini 출력 이미지 토큰 (100만당) 제품 | model: gemini-3-pro-image-preview                          | 25320 / 1M 토큰  | 이미지    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 2K      | 21.31 / 실행        | 이미지    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 4K      | 32.49 / 실행        | 이미지    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-2.5-flash-image                              | 63.3 / 1M 토큰   | 비디오    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-2.5-flash                                    | 63.3 / 1M 토큰   | 비디오    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-2.5-pro                                      | 263.75 / 1M 토큰 | 비디오    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-3.1-pro-preview                              | 422 / 1M 토큰    | 비디오    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-3-pro-image-preview                          | 422 / 1M 토큰    | 비디오    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-3-pro-preview                                | 422 / 1M 토큰    | 비디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-2.5-flash-image                              | 211 / 1M 토큰    | 오디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-2.5-flash                                    | 211 / 1M 토큰    | 오디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-2.5-pro                                      | 263.75 / 1M 토큰 | 오디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-3.1-pro-preview                              | 422 / 1M 토큰    | 오디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-3-pro-image-preview                          | 422 / 1M 토큰    | 오디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-3-pro-preview                                | 422 / 1M 토큰    | 오디오    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 거짓, model: veo-3.0-fast-generate-001     | 168.8 / 실행        | 비디오    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 거짓, model: veo-3.0-generate-001          | 337.6 / 실행        | 비디오    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 참, model: veo-3.0-fast-generate-001      | 253.2 / 실행        | 비디오    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 참, model: veo-3.0-generate-001           | 675.2 / 실행        | 비디오    |
-| Google Veo2 Video Generation                | NA                                                         | 105.5 / 실행        | 비디오    |
-| Google Veo3                                 | generateAudio: 거짓, model: veo-3.0-fast-generate-001     | 21.1 / 실행         | 이미지    |
-| Google Veo3                                 | generateAudio: 거짓, model: veo-3.0-generate-001          | 42.2 / 실행         | 이미지    |
-| Google Veo3                                 | generateAudio: 거짓, model: veo-3.1-fast-generate-preview | 21.1 / 실행         | 이미지    |
-| Google Veo3                                 | generateAudio: 거짓, model: veo-3.1-generate-preview      | 42.2 / 실행         | 이미지    |
-| Google Veo3                                 | generateAudio: 참, model: veo-3.0-fast-generate-001      | 31.65 / 실행        | 이미지    |
-| Google Veo3                                 | generateAudio: 참, model: veo-3.0-generate-001           | 84.4 / 실행         | 이미지    |
-| Google Veo3                                 | generateAudio: 참, model: veo-3.1-fast-generate-preview  | 31.65 / 실행        | 이미지    |
-| Google Veo3                                 | generateAudio: 참, model: veo-3.1-generate-preview       | 84.4 / 실행         | 이미지    |
-| Gemini Thoughts Tokens (100만당) 제품     | model: gemini-3.1-flash-image-preview                      | 633 / 1M 토큰    | 텍스트     |
-| Gemini Thoughts Tokens (100만당) 제품     | model: gemini-3.1-pro-preview                              | 2532 / 1M 토큰   | 텍스트     |
-| Gemini Thoughts Tokens (100만당) 제품     | model: gemini-3-pro-image-preview                          | 2532 / 1M 토큰   | 텍스트     |
-| Gemini Thoughts Tokens (100만당) 제품     | model: gemini-3-pro-preview                                | 2532 / 1M 토큰   | 텍스트     |
-| Gemini 입력 텍스트 토큰 (100만당) 제품   | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M 토큰  | 텍스트     |
-| Gemini 출력 텍스트 토큰 (100만당) 제품  | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M 토큰  | 텍스트     |
-| Gemini 입력 이미지 토큰 (100만당) 제품  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M 토큰  | 이미지    |
-| Gemini 입력 비디오 토큰 (100만당) 제품  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M 토큰  | 비디오    |
-| Gemini 입력 오디오 토큰 (100만당) 제품  | model: gemini-3.1-flash-lite-preview                       | 105.5 / 1M 토큰  | 오디오    |
-| Gemini Thoughts Tokens (100만당) 제품     | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M 토큰  | 텍스트     |
+### 채팅: Google Gemini
+
+토큰 기반 과금; thought 토큰은 출력 텍스트 요금이 적용됩니다.
+
+| 모델                                                   | 입력 크레딧 / 1K | 출력 크레딧 / 1K |
+| :------------------------------------------------------ | -----------------: | :------------------ |
+| Gemini 3.1 Pro (`gemini-3.1-pro-preview`)               |              0.422 | 2.532               |
+| Gemini 3.1 Flash-Lite (`gemini-3.1-flash-lite-preview`) |            0.05275 | 0.3165              |
+| Gemini 2.5 Pro (`gemini-2.5-pro`)                       |            0.26375 | 2.11                |
+| Gemini 2.5 Flash (`gemini-2.5-flash`)                   |             0.0633 | 0.5275              |
+
+### 이미지: Nano Banana
+
+토큰 기반 과금.
+
+| 모델                                            | 입력 크레딧 / 1K | 출력(텍스트) 크레딧 / 1K | 출력(이미지) 크레딧 / 1K |
+| :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
+| Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image-preview`)   |              0.422 |                      2.532 | 25.32                       |
+| Nano Banana 2 (`gemini-3.1-flash-image-preview`) |             0.1055 |                      0.633 | 12.66                       |
+
+### 비디오: Google Veo
+
+총 크레딧 = **(크레딧 / 초) × 지속 시간**.
+
+| 모델                                  | 해상도  | generate_audio | 크레딧 / 초 |
+| :------------------------------------- | :---------- | :------------- | :------------ |
+| veo-2.0-generate-001                   | —           | —              | 105.5         |
+| veo-3.1-lite                           | 720p        | 거짓          | 6.33          |
+| veo-3.1-lite                           | 720p        | 참           | 10.55         |
+| veo-3.1-lite                           | 1080p       | 거짓          | 10.55         |
+| veo-3.1-lite                           | 1080p       | 참           | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | 거짓          | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | 참           | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | 거짓          | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | 참           | 25.32         |
+| veo-3.1-fast-generate                  | 4k          | 거짓          | 52.75         |
+| veo-3.1-fast-generate                  | 4k          | 참           | 63.3          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | 거짓          | 42.2          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | 참           | 84.4          |
+| veo-3.1-generate                       | 4k          | 거짓          | 84.4          |
+| veo-3.1-generate                       | 4k          | 참           | 126.6         |
+| veo-3.0-fast-generate-001              | —           | 거짓          | 21.1          |
+| veo-3.0-fast-generate-001              | —           | 참           | 31.65         |
 
 ## HappyHorse
 
-| 제품 이름 | 구성 | 크레딧 | 카테고리 |
-| :--- | :--- | :--- | :--- |
-| HappyHorse 비디오 생성 제품 | 모델: happyhorse1.0, 해상도: 720P | 29.54 / 초 | 비디오 |
-| HappyHorse 비디오 생성 제품 | 모델: happyhorse1.0, 해상도: 1080P | 50.64 / 초 | 비디오 |
-| HappyHorse 비디오 생성 제품 | 모델: happyhorse1.1, 해상도: 720P | 42.24 / 초 | 비디오 |
-| HappyHorse 비디오 생성 제품 | 모델: happyhorse1.1, 해상도: 1080P | 54.31 / 초 | 비디오 |
+총 크레딧 = **(크레딧/초) × `duration`**.
 
-HappyHorse 1.1은 텍스트 기반 비디오 생성, 이미지 기반 비디오 생성, 레퍼런스 기반 비디오 생성을 동일한 가격에 지원합니다.
+| 모델           | 해상도 | 크레딧/초 |
+| :------------- | :----- | :-------- |
+| HappyHorse 1.0 | 720P   | 29.54     |
+| HappyHorse 1.0 | 1080P  | 50.64     |
+| HappyHorse 1.1 | 720P   | 42.24     |
+| HappyHorse 1.1 | 1080P  | 54.31     |
+
+**HappyHorse 비디오 편집**은 **HappyHorse 1.0**만 지원합니다. 동일한 요율로 청구됩니다. 총 크레딧 = **(크레딧/초) × 출력 지속 시간**(3–15초, 입력 비디오와 일치).
 
 ## Hitpaw
 
-### 비디오 향상
+### 비디오: HitPaw 비디오 향상
 
-| 제품 이름                     | 구성                                           | 크레딧       | 카테고리 |
-| :------------------------------- | :------------------------------------------------ | :---------- | :------- |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 720P, fps: &lt;30fps  | 2.11 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 720P, fps: 30-60fps   | 4.22 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 720P, fps: 60-120fps  | 8.44 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 720P, fps: ≥120fps    | 12.66 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 1080P, fps: &lt;30fps | 3.17 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 1080P, fps: 30-60fps  | 6.33 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 1080P, fps: 60-120fps | 12.66 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 1080P, fps: ≥120fps   | 18.99 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 2K, fps: &lt;30fps    | 4.22 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 2K, fps: 30-60fps     | 8.23 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 2K, fps: 60-120fps    | 16.46 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 2K, fps: ≥120fps      | 24.69 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 4K, fps: &lt;30fps    | 5.28 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 4K, fps: 30-60fps     | 10.76 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 4K, fps: 60-120fps    | 21.31 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 4K, fps: ≥120fps      | 32.07 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 8K, fps: &lt;30fps    | 6.96 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 8K, fps: 30-60fps     | 13.93 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 8K, fps: 60-120fps    | 27.85 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Standard, resolution: 8K, fps: ≥120fps      | 41.78 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 720P, fps: &lt;30fps     | 3.17 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 720P, fps: 30-60fps      | 6.54 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 720P, fps: 60-120fps     | 13.08 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 720P, fps: ≥120fps       | 19.41 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 1080P, fps: &lt;30fps    | 4.22 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 1080P, fps: 30-60fps     | 8.44 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 1080P, fps: 60-120fps    | 16.88 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 1080P, fps: ≥120fps      | 25.32 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 2K, fps: &lt;30fps       | 5.49 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 2K, fps: 30-60fps        | 10.97 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 2K, fps: 60-120fps       | 21.94 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 2K, fps: ≥120fps         | 32.92 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 4K, fps: &lt;30fps       | 7.17 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 4K, fps: 30-60fps        | 14.35 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 4K, fps: 60-120fps       | 28.49 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 4K, fps: ≥120fps         | 42.83 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 8K, fps: &lt;30fps       | 9.28 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 8K, fps: 30-60fps        | 18.57 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 8K, fps: 60-120fps       | 37.14 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Ultra, resolution: 8K, fps: ≥120fps         | 55.7 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 720P, fps: &lt;30fps       | 3.17 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 720P, fps: 30-60fps        | 6.33 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 720P, fps: 60-120fps       | 12.66 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 720P, fps: ≥120fps         | 18.99 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 1080P, fps: &lt;30fps      | 5.28 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 1080P, fps: 30-60fps       | 10.55 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 1080P, fps: 60-120fps      | 21.1 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 1080P, fps: ≥120fps        | 31.65 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 2K, fps: &lt;30fps         | 8.02 / 초  | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 2K, fps: 30-60fps          | 15.82 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 2K, fps: 60-120fps         | 31.65 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 2K, fps: ≥120fps           | 47.48 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 4K / 8K, fps: &lt;30fps    | 11.82 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 4K / 8K, fps: 30-60fps     | 23.84 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 4K / 8K, fps: 60-120fps    | 47.48 / 초 | 비디오    |
-| Hitpaw 비디오 향상 제품 | type: Gen, resolution: 4K / 8K, fps: ≥120fps      | 71.32 / 초 | 비디오    |
+총 크레딧 = **(크레딧 / 초) × 비디오 길이**. 요금은 입력 FPS에 따라 다릅니다.
 
-### 사진 향상
+**Portrait Restore / General Restore** (Portrait Restore 1x/2x, General Restore 1x/2x/4x):
 
-| 제품 이름                     | 구성                                         | 크레딧        | 카테고리 |
-| :------------------------------- | :-------------------------------------------- | :----------- | :------- |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: &lt;8MP            | 2.11 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 8-12MP             | 4.22 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 12-24MP            | 6.33 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 24-48MP            | 14.77 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 48-108MP           | 29.54 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 108-216MP          | 50.64 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Standard, megapixels: 216-432MP          | 101.28 / 회 | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative Portrait, megapixels: &lt;8MP | 4.22 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative Portrait, megapixels: 8-12MP  | 6.33 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative Portrait, megapixels: 12-24MP | 8.44 / 회   | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative Portrait, megapixels: 24-34MP | 12.66 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative, megapixels: &lt;8MP          | 10.55 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative, megapixels: 8-12MP           | 12.66 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative, megapixels: 12-24MP          | 16.88 / 회  | 이미지    |
-| Hitpaw 사진 향상 제품 | type: Generative, megapixels: 24-34MP          | 31.65 / 회  | 이미지    |
+| 해상도 | FPS       | 크레딧 / 초 |
+| :----- | :-------- | :---------- |
+| 720P   | &lt;30fps | 2.11        |
+| 720P   | 30–60fps  | 4.22        |
+| 720P   | 60–120fps | 8.44        |
+| 720P   | ≥120fps   | 12.66       |
+| 1080P  | &lt;30fps | 3.17        |
+| 1080P  | 30–60fps  | 6.33        |
+| 1080P  | 60–120fps | 12.66       |
+| 1080P  | ≥120fps   | 18.99       |
+| 2K     | &lt;30fps | 4.22        |
+| 2K     | 30–60fps  | 8.23        |
+| 2K     | 60–120fps | 16.46       |
+| 2K     | ≥120fps   | 24.69       |
+| 4K     | &lt;30fps | 5.28        |
+| 4K     | 30–60fps  | 10.76       |
+| 4K     | 60–120fps | 21.31       |
+| 4K     | ≥120fps   | 32.07       |
+| 8K     | &lt;30fps | 6.96        |
+| 8K     | 30–60fps  | 13.93       |
+| 8K     | 60–120fps | 27.85       |
+| 8K     | ≥120fps   | 41.78       |
+
+**Ultra HD** (Ultra HD 모델 2x):
+
+| 해상도 | FPS       | 크레딧 / 초 |
+| :----- | :-------- | :---------- |
+| 720P   | &lt;30fps | 3.17        |
+| 720P   | 30–60fps  | 6.54        |
+| 720P   | 60–120fps | 13.08       |
+| 720P   | ≥120fps   | 19.41       |
+| 1080P  | &lt;30fps | 4.22        |
+| 1080P  | 30–60fps  | 8.44        |
+| 1080P  | 60–120fps | 16.88       |
+| 1080P  | ≥120fps   | 25.32       |
+| 2K     | &lt;30fps | 5.49        |
+| 2K     | 30–60fps  | 10.97       |
+| 2K     | 60–120fps | 21.94       |
+| 2K     | ≥120fps   | 32.92       |
+| 4K     | &lt;30fps | 7.17        |
+| 4K     | 30–60fps  | 14.35       |
+| 4K     | 60–120fps | 28.49       |
+| 4K     | ≥120fps   | 42.83       |
+| 8K     | &lt;30fps | 9.28        |
+| 8K     | 30–60fps  | 18.57       |
+| 8K     | 60–120fps | 37.14       |
+| 8K     | ≥120fps   | 55.7        |
+
+**Generative** (Generative 모델 1x, 최대 4K):
+
+| 해상도 | FPS       | 크레딧 / 초 |
+| :----- | :-------- | :---------- |
+| 720P   | &lt;30fps | 3.17        |
+| 720P   | 30–60fps  | 6.33        |
+| 720P   | 60–120fps | 12.66       |
+| 720P   | ≥120fps   | 18.99       |
+| 1080P  | &lt;30fps | 5.28        |
+| 1080P  | 30–60fps  | 10.55       |
+| 1080P  | 60–120fps | 21.1        |
+| 1080P  | ≥120fps   | 31.65       |
+| 2K     | &lt;30fps | 8.02        |
+| 2K     | 30–60fps  | 15.82       |
+| 2K     | 60–120fps | 31.65       |
+| 2K     | ≥120fps   | 47.48       |
+| 4K     | &lt;30fps | 11.82       |
+| 4K     | 30–60fps  | 23.84       |
+| 4K     | 60–120fps | 47.48       |
+| 4K     | ≥120fps   | 71.32       |
+
+### 이미지: HitPaw 일반 이미지 향상
+
+**Generative Portrait**:
+
+| 메가픽셀 | 크레딧 / 실행 |
+| :------- | :------------ |
+| &lt;8MP  | 4.22          |
+| 8–12MP   | 6.33          |
+| 12–24MP  | 8.44          |
+| 24–34MP  | 12.66         |
+
+**Generative**:
+
+| 메가픽셀 | 크레딧 / 실행 |
+| :------- | :------------ |
+| &lt;8MP  | 10.55         |
+| 8–12MP   | 12.66         |
+| 12–24MP  | 16.88         |
+| 24–34MP  | 31.65         |
 
 ## Ideogram
 
-| 제품명                                | 구성                                                                    | 크레딧        | 카테고리 |
-| :------------------------------------ | :---------------------------------------------------------------------- | :------------ | :------- |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit-character-ref, rendering_speed: DEFAULT      | 45.26 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit-character-ref, rendering_speed: QUALITY      | 60.35 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit-character-ref, rendering_speed: TURBO        | 30.17 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit, rendering_speed: BALANCED                   | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit, rendering_speed: DEFAULT                    | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit, rendering_speed: QUALITY                    | 27.16 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/edit, rendering_speed: TURBO                      | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate-character-ref, rendering_speed: DEFAULT  | 45.26 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate-character-ref, rendering_speed: QUALITY  | 60.35 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate-character-ref, rendering_speed: TURBO    | 30.17 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate, rendering_speed: BALANCED               | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate, rendering_speed: DEFAULT                | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate, rendering_speed: QUALITY                | 27.16 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/generate, rendering_speed: TURBO                  | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/reframe, rendering_speed: DEFAULT                 | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/reframe, rendering_speed: QUALITY                 | 27.16 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/reframe, rendering_speed: TURBO                   | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/remix, rendering_speed: BALANCED                  | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/remix, rendering_speed: DEFAULT                   | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/remix, rendering_speed: QUALITY                   | 27.16 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/remix, rendering_speed: TURBO                     | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/replace-background, rendering_speed: BALANCED     | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/replace-background, rendering_speed: DEFAULT      | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/replace-background, rendering_speed: QUALITY      | 27.16 / 회    | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: ideogram-v3/replace-background, rendering_speed: TURBO        | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V3 Image Generation  | endpoint: remix, rendering_speed: TURBO                                 | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V4 Image Generation  | endpoint: ideogram-v4/generate, rendering_speed: TURBO                  | 9.05 / 회     | 이미지   |
-| prod-v1-Ideogram V4 Image Generation  | endpoint: ideogram-v4/generate, rendering_speed: DEFAULT                | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram V4 Image Generation  | endpoint: ideogram-v4/generate, rendering_speed: QUALITY                | 30.17 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2                                             | 24.14 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2_turbo                                       | 15.09 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1                                         | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1_turbo                                   | 6.03 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a                                        | 12.07 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a_turbo                                  | 7.54 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2                                         | 24.14 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2_turbo                                   | 15.09 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2                                          | 24.14 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2_turbo                                    | 15.09 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1                                            | 18.1 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1_turbo                                      | 6.03 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a                                           | 12.07 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a_turbo                                     | 7.54 / 회     | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2                                            | 24.14 / 회    | 이미지   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2_turbo                                      | 15.09 / 회    | 이미지   |
+| 노드 | 터보 | 캐릭터 참조 | 렌더링 속도 | 이미지당 크레딧 |
+| :--- | :--- | :---------- | :---------- | :-------------- |
+| Ideogram V1 | 거짓 | — | — | 18.1 |
+| Ideogram V1 | 참 | — | — | 6.03 |
+| Ideogram V2 | 거짓 | — | — | 24.14 |
+| Ideogram V2 | 참 | — | — | 15.09 |
+| Ideogram V3 | — | 아니요 | TURBO | 9.05 |
+| Ideogram V3 | — | 아니요 | DEFAULT | 18.1 |
+| Ideogram V3 | — | 아니요 | QUALITY | 27.16 |
+| Ideogram V3 | — | 예 | TURBO | 30.17 |
+| Ideogram V3 | — | 예 | DEFAULT | 45.26 |
+| Ideogram V3 | — | 예 | QUALITY | 60.35 |
+| Ideogram V4 | — | — | TURBO | 9.05 |
+| Ideogram V4 | — | — | DEFAULT | 18.1 |
+| Ideogram V4 | — | — | QUALITY | 30.17 |
 
 ## Krea
 
-| 제품명 | 구성 | 크레딧 | 카테고리 |
-| :--- | :--- | :--- | :--- |
-| Krea 2 이미지 생성 | 모델: krea-2-medium-turbo | 3.2 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-medium-turbo, 이미지 스타일 참조 포함 | 3.7 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-medium-turbo, 무드보드 포함 | 4.2 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-medium | 6.4 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-medium, 이미지 스타일 참조 포함 | 7.4 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-medium, 무드보드 포함 | 8.5 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-large | 12.7 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-large, 이미지 스타일 참조 포함 | 13.8 /회 | 이미지 |
-| Krea 2 이미지 생성 | 모델: krea-2-large, 무드보드 포함 | 14.8 /회 | 이미지 |
+| 모델               | 스타일 참조 | 무드보드 | 크레딧/회 |
+| :----------------- | :----------- | :------- | :-------- |
+| Krea 2 Medium Turbo | 아니요      | 아니요   | 3.17      |
+| Krea 2 Medium Turbo | 예          | 아니요   | 3.69      |
+| Krea 2 Medium Turbo | -           | 예       | 4.22      |
+| Krea 2 Medium       | 아니요      | 아니요   | 6.33      |
+| Krea 2 Medium       | 예          | 아니요   | 7.39      |
+| Krea 2 Medium       | -           | 예       | 8.44      |
+| Krea 2 Large        | 아니요      | 아니요   | 12.66     |
+| Krea 2 Large        | 예          | 아니요   | 13.72     |
+| Krea 2 Large        | -           | 예       | 14.77     |
 
 ## Kling
 
-| 제품명                                  | 설정                                                    | 크레딧         | 카테고리 |
-| :-------------------------------------- | :------------------------------------------------------ | :------------- | :------- |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v1                              | 103.39 / run   | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v1-5                            | 103.39 / run   | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v1-6                            | 103.39 / run   | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v2-1                            | 103.39 / run   | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v2-1-master                     | 295.4 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v2-5-turbo                      | 73.85 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: pro, model: kling-v2-master                       | 295.4 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v1                              | 29.54 / sec    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v1-5                            | 59.08 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v1-6                            | 59.08 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v2-1                            | 59.08 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v2-1-master                     | 295.4 / run    | 비디오   |
-| prod-v1-Kling 비디오 생성 제품          | mode: std, model: kling-v2-master                       | 295.4 / run    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: pro, model: kling-v2-6, sound: off                | 14.77 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: pro, model: kling-v2-6, sound: on                 | 29.54 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 1080p, model: kling-v3, no_sound: true      | 23.63 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 1080p, model: kling-v3, no_sound: false     | 35.45 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 720p, model: kling-v3, no_sound: true       | 17.72 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 720p, model: kling-v3, no_sound: false      | 26.59 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: pro, model: kling-v3-omni, no_sound: true         | 23.63 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: pro, model: kling-v3-omni, no_sound: false        | 29.54 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: std, model: kling-v3-omni, no_sound: true         | 17.72 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: std, model: kling-v3-omni, no_sound: false        | 23.63 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | mode: pro, model: kling-v3-4k                           | 88.62 / sec    | 비디오   |
-|                                         |                                                         |                |          |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 720p, model: kling-3.0-turbo                | 23.63 / sec    | 비디오   |
-| Kling 사운드 포함 비디오 생성 제품      | resolution: 1080p, model: kling-3.0-turbo               | 29.54 / sec    | 비디오   |
-| Kling 옴니 비디오 제품                  | generate_with_video: false, mode: pro, model: kling-video-o1 | 23.63 / sec | 비디오   |
-| Kling 옴니 비디오 제품                  | generate_with_video: false, mode: std, model: kling-video-o1 | 17.72 / sec | 비디오   |
-| Kling 옴니 비디오 제품                  | generate_with_video: true, mode: pro, model: kling-video-o1  | 35.45 / sec | 비디오   |
-| Kling 옴니 비디오 제품                  | generate_with_video: true, mode: std, model: kling-video-o1  | 26.59 / sec | 비디오   |
-| Kling 비디오 확장 제품                  | NA                                                        | 59.08 / run   | 비디오   |
-| Kling 립 싱크 제품                      | NA                                                        | 14.77 / run   | 이미지   |
-| Kling 모션 컨트롤 제품                  | mode: std, model: kling-v2-6                              | 14.77 / run   | 이미지   |
-| Kling 모션 컨트롤 제품                  | mode: pro, model: kling-v2-6                              | 23.63 / run   | 이미지   |
-| Kling 가상 착용                         | model: kolors-virtual-try-on-v1                           | 14.77 / run   | 이미지   |
-| Kling 가상 착용                         | model: kolors-virtual-try-on-v1-5                         | 14.77 / run   | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v1, operation: text_to_image                 | 0.74 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v1, operation: image_to_image                | 0.74 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v1-5, operation: text_to_image               | 2.95 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v1-5, operation: image_to_image              | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v2, operation: text_to_image                 | 2.95 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v2-new, operation: image_to_image_restyle    | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v2-1, operation: text_to_image               | 2.95 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 1k, operation: text_to_image      | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 2k, operation: text_to_image      | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 1k, operation: image_to_image     | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 2k, operation: image_to_image     | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 1k, operation: image_editing      | 11.82 / run   | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3, specs: 4k, operation: image_editing      | 11.82 / run   | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 1k, operation: text_to_image | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 2k, operation: text_to_image | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 1k, operation: image_to_image| 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 2k, operation: image_to_image| 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 1k, operation: image_editing | 11.82 / run   | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-v3-omni, specs: 4k, operation: image_editing | 11.82 / run   | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-image-o1, operation: text_to_image            | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-image-o1, operation: image_to_image           | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 제품                   | model: kling-image-o1, operation: image_editing            | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 w/ N                   | model: kling-v1, operation: text_to_image                 | 0.74 / run    | 이미지   |
-| Kling 이미지 생성 w/ N                   | model: kling-v1, operation: image_to_image                | 0.74 / run    | 이미지   |
-| Kling 이미지 생성 w/ N                   | model: kling-v1-5, operation: text_to_image               | 2.95 / run    | 이미지   |
-| Kling 이미지 생성 w/ N                   | model: kling-v1-5, operation: image_to_image              | 5.91 / run    | 이미지   |
-| Kling 이미지 생성 w/ N                   | model: kling-v2, operation: text_to_image                 | 2.95 / run    | 이미지   |
-| Kling 크레딧                            | type: image                                               | 0.74 / run    | 이미지   |
-| Kling 크레딧                            | type: video                                               | 29.54 / run   | 이미지   |
-| Kling 카메라 컨트롤 제품                | type: text-to-video                                        | 29.54 / run   | 비디오   |
-| Kling 카메라 컨트롤 제품                | type: image-to-video                                       | 103.39 / run  | 비디오   |
-| Kling 아바타 제품                       | mode: std                                                  | 11.82 / sec   | 비디오   |
-| Kling 아바타 제품                       | mode: pro                                                  | 23.63 / sec   | 비디오   |
-| Kling 2.6 오디오 제품                   | mode: text-to-video, no_sound: true                        | 14.77 / sec   | 비디오   |
-| Kling 2.6 오디오 제품                   | mode: text-to-video, no_sound: false                       | 29.54 / sec   | 비디오   |
-| Kling 2.6 오디오 제품                   | mode: image-to-video, no_sound: true                       | 14.77 / sec   | 비디오   |
-| Kling 2.6 오디오 제품                   | mode: image-to-video, no_sound: false                      | 29.54 / sec   | 비디오   |
+### 비디오: 초당 크레딧
+
+총 크레딧 = **(크레딧 / 초) × `duration`**, 단 **Kling 3.0 Omni Edit Video** 및 **Kling 모션 컨트롤**은 예외입니다 (출력 초당 요금 부과; 편집 시 duration은 입력 비디오를 따름).
+
+#### kling-video-o1
+
+| 작업                     | 해상도 | 초당 크레딧 |
+|:-------------------------|:-------|:------------|
+| 생성                     | 720p   | 17.72       |
+| 생성                     | 1080p  | 23.63       |
+| 비디오 → 비디오, 편집   | 720p   | 26.59       |
+| 비디오 → 비디오, 편집   | 1080p  | 35.45       |
+
+#### kling-v3-omni
+
+| 작업                     | 해상도 | generate_audio | 초당 크레딧 |
+|:-------------------------|:-------|:---------------|:------------|
+| 생성                     | 720p   | 거짓           | 17.72       |
+| 생성                     | 720p   | 참             | 23.63       |
+| 생성                     | 1080p  | 거짓           | 23.63       |
+| 생성                     | 1080p  | 참             | 29.54       |
+| 생성                     | 4k     | 거짓, 참       | 88.62       |
+| 비디오 → 비디오, 편집   | 720p   | —              | 26.59       |
+| 비디오 → 비디오, 편집   | 1080p  | —              | 35.45       |
+
+#### kling-3.0-turbo
+
+항상 오디오를 생성합니다; 오디오 토글은 무시됩니다.
+
+| 해상도 | 초당 크레딧 |
+|:-------|:------------|
+| 720p   | 23.63       |
+| 1080p  | 29.54       |
+
+#### kling-v3
+
+| 작업     | 해상도 | generate_audio | 초당 크레딧 |
+|:---------|:-------|:---------------|:------------|
+| 생성     | 720p   | 거짓           | 17.72       |
+| 생성     | 720p   | 참             | 26.59       |
+| 생성     | 1080p  | 거짓           | 23.63       |
+| 생성     | 1080p  | 참             | 35.45       |
+| 생성     | 4k     | 거짓, 참       | 88.62       |
+
+| 작업                | 모드 | 초당 크레딧 |
+|:--------------------|:-----|:------------|
+| 모션 컨트롤         | std  | 26.59       |
+| 모션 컨트롤         | pro  | 35.45       |
+
+#### kling-v2-6
+
+| 작업                | generate_audio | 모드 | 초당 크레딧 |
+|:--------------------|:---------------|:-----|:------------|
+| 생성                | 거짓           | —    | 14.77       |
+| 생성                | 참             | —    | 29.54       |
+| 모션 컨트롤         | —              | std  | 14.77       |
+| 모션 컨트롤         | —              | pro  | 23.63       |
+
+#### 레거시 (v2-5-turbo, v2-master, v1.x)
+
+| 모델                                              | 모드       | 초당 크레딧 |
+|:--------------------------------------------------|:-----------|:------------|
+| kling-v2-5-turbo                                  | pro        | 14.77       |
+| kling-v2-master, kling-v2-1-master                | std, pro   | 59.08       |
+| kling-v1-5, kling-v1-6, kling-v2-1                | std        | 11.82       |
+| kling-v1                                          | std        | 5.91        |
+| kling-v1, kling-v1-5, kling-v1-6, kling-v2-1      | pro        | 20.68       |
+
+#### Kling 아바타 2.0
+
+| 모드 | 초당 크레딧 |
+|:-----|:------------|
+| std  | 11.82       |
+| pro  | 23.63       |
+
+**Kling 텍스트/이미지 → 비디오 (카메라 컨트롤)**: 고정 **5초**, `kling-v1` std 또는 `kling-v1-5` pro (레거시 표 참조).
+
+### 비디오: 실행당 크레딧
+
+| 모델      | 작업                         | 실행당 크레딧 |
+|:----------|:-----------------------------|:--------------|
+| kling-v1-6| 대부분의 이펙트 장면         | 59.08         |
+| kling-v1-6| `dizzydizzy`, `bloombloom`   | 103.39        |
+| —         | 비디오 확장                  | 59.08         |
+| —         | 립 싱크                      | 21.1          |
+
+### 이미지
+
+| 모델                                               | 해상도 | 이미지 입력 | 크레딧          |
+|:---------------------------------------------------|:-------|:------------|:----------------|
+| kling-image-o1                                     | 1K, 2K | —           | 5.91 / 이미지   |
+| kling-image-o1                                     | 4K     | —           | 11.82 / 이미지  |
+| kling-v3-omni                                      | 1K, 2K | —           | 5.91 / 이미지   |
+| kling-v3-omni                                      | 4K     | —           | 11.82 / 이미지  |
+| kling-v3                                           | —      | 아니오      | 5.91 / 이미지   |
+| kling-v2                                           | —      | 아니오, 예  | 2.95 / 이미지   |
+| kling-v1-5                                         | —      | 아니오      | 2.95 / 이미지   |
+| kling-v1-5                                         | —      | 예          | 5.91 / 이미지   |
+| kolors-virtual-try-on-v1, kolors-virtual-try-on-v1-5 | —    | —           | 147.7 / 실행    |
+
+총 이미지 크레딧 = **(이미지당 크레딧) × `n`** (**Kling 3.0 Image**)에서; **Kling 3.0 Omni Image**에서는 `series_amount`를 곱합니다 (`kling-image-o1`은 항상 ×1).
 
 ## Lightricks
 
-| 제품명                     | 구성                                                            | 크레딧       | 카테고리 |
-| :------------------------- | :--------------------------------------------------------------- | :----------- | :------- |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-fast, 해상도: 1920x1080   | 8.44 / 초    | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-fast, 해상도: 2560x1440   | 16.88 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-fast, 해상도: 3840x2160   | 33.76 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-pro, 해상도: 1920x1080    | 12.66 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-pro, 해상도: 2560x1440    | 25.32 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 이미지-비디오, 모델: ltx-2-pro, 해상도: 3840x2160    | 50.64 / 회   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-fast, 해상도: 1920x1080   | 8.44 / 초    | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-fast, 해상도: 2560x1440   | 16.88 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-fast, 해상도: 3840x2160   | 33.76 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-pro, 해상도: 1920x1080    | 12.66 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-pro, 해상도: 2560x1440    | 25.32 / 초   | 비디오   |
-| Ltx 비디오 생성 제품        | 엔드포인트: 텍스트-비디오, 모델: ltx-2-pro, 해상도: 3840x2160    | 50.64 / 회   | 비디오   |
+### 비디오: 크레딧 / 초
+
+총 크레딧 = **(크레딧 / 초) × `duration`**.
+
+| 모델          | 해상도 | 크레딧      |
+| :------------ | :----- | :---------- |
+| LTX-2 (Pro)   | 1080p  | 12.66 / 초  |
+| LTX-2 (Pro)   | 1440p  | 25.32 / 초  |
+| LTX-2 (Pro)   | 4K     | 50.64 / 초  |
+| LTX-2 (Fast)  | 1080p  | 8.44 / 초   |
+| LTX-2 (Fast)  | 1440p  | 16.88 / 초  |
+| LTX-2 (Fast)  | 4K     | 33.76 / 초  |
+
+해상도는 `1920x1080`, `2560x1440`, `3840x2160`에 해당합니다. 10초를 초과하는 지속 시간은 **LTX-2 (Fast)** 에서 1080p 및 25 FPS로만 사용할 수 있습니다.
 
 ## Luma
 
-| 제품명                                              | 구성                                                                                              | 크레딧        | 카테고리 |
-| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Luma 비디오 생성 제품                        | model: ray-1-6                                                                                     | 0.97 / 초    | 비디오   |
-| prod-v1-Luma 비디오 생성 제품                        | model: ray-2                                                                                       | 1.93 / 초    | 비디오   |
-| prod-v1-Luma 비디오 생성 제품                        | model: ray-flash-2                                                                                 | 0.66 / 초    | 비디오   |
-| Luma 이미지 생성 (백만 픽셀) 제품                    | model: photon-1                                                                                    | 2.2 / 실행   | 이미지   |
-| Luma 이미지 생성 (백만 픽셀) 제품                    | model: photon-flash-1                                                                              | 0.57 / 실행   | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: text-to-image                                                                  | 8.52 / 실행   | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-to-image                                                                 | 9.16 / 실행   | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 1                                       | 9.16 / 실행   | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 2                                       | 9.79 / 실행   | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 3                                       | 10.42 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 4                                       | 11.06 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 5                                       | 11.69 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 6                                       | 12.32 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 7                                       | 12.96 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 8                                       | 13.59 / 실행  | 이미지   |
-| Luma Agents uni-1 이미지 제품                        | model: uni-1, task: image-reference, num_reference_images: 9                                       | 14.22 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: text-to-image                                                              | 21.10 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-to-image                                                             | 21.73 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 1                                   | 21.73 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 2                                   | 22.37 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 3                                   | 23.00 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 4                                   | 23.63 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 5                                   | 24.27 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 6                                   | 24.90 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 7                                   | 25.53 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 8                                   | 26.16 / 실행  | 이미지   |
-| Luma Agents uni-1-max 이미지 제품                    | model: uni-1-max, task: image-reference, num_reference_images: 9                                   | 26.80 / 실행  | 이미지   |
+### 비디오
 
-### Luma Ray 3.2 비디오
+각 `duration` 선택에 대한 고정 **/실행** 가격은 노드 배지와 일치합니다. **편집** 및 **리프레임**은 **(크레딧/초) × 비디오 길이**로 청구됩니다. **ray-1-6**은 항상 **105.50 / 실행**입니다.
 
-| 제품명 | 구성 | 크레딧 | 카테고리 |
-| :----------- | :------------ | :------ | :------- |
-| Luma Ray 3.2 비디오 생성 | 해상도: 360p, 길이: 5초 | 12.66 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 360p, 길이: 10초 | 37.98 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 540p, 길이: 5초 | 31.65 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 540p, 길이: 10초 | 94.95 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 720p, 길이: 5초 | 63.30 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 720p, 길이: 10초 | 189.90 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 1080p, 길이: 5초 | 253.20 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 생성 | 해상도: 1080p, 길이: 10초 | 759.60 / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 편집 | 해상도: 360p | 113.94 (5초) - 227.88 (10초) / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 편집 | 해상도: 540p | 151.92 (5초) - 303.84 (10초) / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 편집 | 해상도: 720p | 227.88 (5초) - 455.76 (10초) / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 편집 | 해상도: 1080p | 455.76 (5초) - 911.52 (10초) / 실행 | 비디오 |
-| Luma Ray 3.2 비디오 리프레임 | 해상도: 360p | 6.33 / 초 | 비디오 |
-| Luma Ray 3.2 비디오 리프레임 | 해상도: 540p | 12.66 / 초 | 비디오 |
-| Luma Ray 3.2 비디오 리프레임 | 해상도: 720p | 25.32 / 초 | 비디오 |
-| Luma Ray 3.2 비디오 리프레임 | 해상도: 1080p | 75.96 / 초 | 비디오 |
+| 모델       | 작업       | 해상도 | 크레딧                                           |
+| :---------- | :--------- | :--------- | :------------------------------------------------ |
+| ray-3.2     | 생성 | 360p       | 12.66 / 실행 (5초), 37.98 / 실행 (10초)               |
+| ray-3.2     | 생성 | 540p       | 31.65 / 실행 (5초), 94.95 / 실행 (10초)               |
+| ray-3.2     | 생성 | 720p       | 63.30 / 실행 (5초), 189.90 / 실행 (10초)              |
+| ray-3.2     | 생성 | 1080p      | 253.20 / 실행 (5초), 759.60 / 실행 (10초)             |
+| ray-3.2     | 편집       | 360p       | 22.79 / 초                                       |
+| ray-3.2     | 편집       | 540p       | 30.38 / 초                                       |
+| ray-3.2     | 편집       | 720p       | 45.58 / 초                                       |
+| ray-3.2     | 편집       | 1080p      | 91.15 / 초                                       |
+| ray-3.2     | 리프레임    | 360p       | 6.33 / 초                                        |
+| ray-3.2     | 리프레임    | 540p       | 12.66 / 초                                       |
+| ray-3.2     | 리프레임    | 720p       | 25.32 / 초                                       |
+| ray-3.2     | 리프레임    | 1080p      | 75.96 / 초                                       |
+| ray-2       | 생성 | 540p       | 120.27 / 실행 (5초), 217.33 / 실행 (9초)              |
+| ray-2       | 생성 | 720p       | 215.22 / 실행 (5초), 386.13 / 실행 (9초)              |
+| ray-2       | 생성 | 1080p      | 478.97 / 실행 (5초), 865.10 / 실행 (9초)              |
+| ray-2       | 생성 | 4K         | 1922.21 / 실행 (5초), 3460.40 / 실행 (9초)            |
+| ray-flash-2 | 생성 | 540p       | 42.20 / 실행 (5초), 75.96 / 실행 (9초)                |
+| ray-flash-2 | 생성 | 720p       | 71.74 / 실행 (5초), 128.71 / 실행 (9초)               |
+| ray-flash-2 | 생성 | 1080p      | 166.69 / 실행 (5초), 299.62 / 실행 (9초)              |
+| ray-flash-2 | 생성 | 4K         | 660.43 / 실행 (5초), 1192.15 / 실행 (9초)             |
+| ray-1-6     | 생성 | —          | 105.50 / 실행                                      |
+
+**Luma Ray 3.2** 이미지 → 비디오 및 비디오 확장은 항상 **5초** 가격으로 청구됩니다. 레거시 이미지 → 비디오는 **ray-2** / **ray-flash-2** 행의 **5초** 또는 **9초** 가격을 사용합니다.
+
+### 이미지
+
+| 모델          | 작업       | 크레딧                              |
+| :------------- | :--------- | :----------------------------------- |
+| photon-flash-1 | —          | 0.57 / 실행                           |
+| photon-1       | —          | 2.19 / 실행                           |
+| uni-1          | 생성 | 8.52 / 실행 + 0.63 / 참조 이미지 (≤ 9)  |
+| uni-1          | 편집       | 9.16 / 실행 + 0.63 / 참조 이미지 (≤ 8)  |
+| uni-1-max      | 생성 | 21.10 / 실행 + 0.63 / 참조 이미지 (≤ 9) |
+| uni-1-max      | 편집       | 21.73 / 실행 + 0.63 / 참조 이미지 (≤ 8) |
+
+참조 이미지 추가 요금은 크레딧으로 변환하기 전에 USD를 소수점 4자리로 반올림하여 사용합니다.
 
 ## Meshy
 
-| 제품명                       | 구성                                                         | 크레딧        | 카테고리 |
-| :--------------------------- | :----------------------------------------------------------- | :------------ | :------- |
-| Meshy Retexture              | NA                                                           | 84.4 / 회     | 3D       |
-| Meshy Rigging                | NA                                                           | 42.2 / 회     | 3D       |
-| Meshy Remesh                 | NA                                                           | 42.2 / 회     | 3D       |
-| Meshy Animation              | NA                                                           | 25.32 / 회    | 3D       |
-| Meshy Multi Image to 3D      | should_texture: false                                        | 42.2 / 회     | 이미지   |
-| Meshy Multi Image to 3D      | should_texture: true                                         | 126.6 / 회    | 이미지   |
-| Meshy Text to 3D             | mode: preview, model: latest                                 | 168.8 / 회    | 3D       |
-| Meshy Text to 3D             | mode: preview, model: meshy-5                                | 42.2 / 회     | 3D       |
-| Meshy Text to 3D             | mode: refine, model: latest                                  | 84.4 / 회     | 3D       |
-| Meshy Image to 3D            | model: latest, model_type: lowpoly, should_texture: false    | 168.8 / 회    | 이미지   |
-| Meshy Image to 3D            | model: latest, model_type: lowpoly, should_texture: true     | 253.2 / 회    | 이미지   |
-| Meshy Image to 3D            | model: latest, model_type: standard, should_texture: false   | 168.8 / 회    | 이미지   |
-| Meshy Image to 3D            | model: latest, model_type: standard, should_texture: true    | 253.2 / 회    | 이미지   |
-| Meshy Image to 3D            | model: meshy-5, model_type: lowpoly, should_texture: false   | 168.8 / 회    | 이미지   |
-| Meshy Image to 3D            | model: meshy-5, model_type: lowpoly, should_texture: true    | 253.2 / 회    | 이미지   |
-| Meshy Image to 3D            | model: meshy-5, model_type: standard, should_texture: false  | 42.2 / 회     | 이미지   |
-| Meshy Image to 3D            | model: meshy-5, model_type: standard, should_texture: true   | 126.6 / 회    | 이미지   |
+| 노드                        | should_texture | 크레딧      |
+| :-------------------------- | :------------- | :---------- |
+| Meshy: 텍스트를 모델로      | —              | 168.8 / 회 |
+| Meshy: 드래프트 모델 정제   | —              | 84.4 / 회  |
+| Meshy: 이미지를 모델로      | No             | 168.8 / 회 |
+| Meshy: 이미지를 모델로      | Yes            | 253.2 / 회 |
+| Meshy: 다중 이미지를 모델로 | No             | 42.2 / 회  |
+| Meshy: 다중 이미지를 모델로 | Yes            | 126.6 / 회 |
+| Meshy: 리그 모델            | —              | 42.2 / 회  |
+| Meshy: 애니메이션 모델      | —              | 25.32 / 회 |
+| Meshy: 텍스처 모델          | —              | 84.4 / 회  |
+
+**Meshy: 텍스트를 모델로**는 드래프트 메시를 생성합니다. 반환된 `meshy_task_id`에 대해 **Meshy: 드래프트 모델 정제**를 실행하여 텍스처를 입힙니다. **Meshy: 이미지를 모델로**와 **Meshy: 다중 이미지를 모델로**는 `should_texture`가 활성화된 경우 한 단계로 텍스처링할 수 있습니다.
 
 ## Minimax
 
-| 제품 이름                                        | 구성                                                       | 크레딧          | 카테고리 |
-| :----------------------------------------------- | :---------------------------------------------------------- | :-------------- | :------- |
-| prod-v1-Minimax 비디오 제품                        | 모델: i2v-01-director                                      | 90.73 / 회      | 비디오   |
-| prod-v1-Minimax 비디오 제품                        | 모델: i2v-01-live                                          | 90.73 / 회      | 비디오   |
-| prod-v1-Minimax 비디오 제품                        | 모델: i2v-01                                               | 90.73 / 회      | 비디오   |
-| prod-v1-Minimax 비디오 제품                        | 모델: s2v-01                                               | 137.15 / 회     | 비디오   |
-| prod-v1-Minimax 비디오 제품                        | 모델: t2v-01-director                                      | 90.73 / 회      | 비디오   |
-| prod-v1-Minimax 비디오 제품                        | 모델: t2v-01                                               | 90.73 / 회      | 비디오   |
-| Minimax 비디오 생성_Hailuo-02 이후 모델             | 지속 시간: 10, 모델: minimax-hailuo-02, 해상도: 768P        | 118.16 / 회     | 비디오   |
-| Minimax 비디오 생성_Hailuo-02 이후 모델             | 지속 시간: 6, 모델: minimax-hailuo-02, 해상도: 1080P        | 103.39 / 회     | 비디오   |
-| Minimax 비디오 생성_Hailuo-02 이후 모델             | 지속 시간: 6, 모델: minimax-hailuo-02, 해상도: 768P         | 59.08 / 회      | 비디오   |
+| 노드                     | 모델                                | 해상도   | 크레딧                              |
+| :----------------------- | :--------------------------------- | :------- | :--------------------------------- |
+| MiniMax 텍스트 투 비디오  | T2V-01, T2V-01-Director            | —        | 90.73 / 회                        |
+| MiniMax 이미지에서 비디오로 | I2V-01, I2V-01-Director, I2V-01-live | —        | 90.73 / 회                        |
+| MiniMax Hailuo 비디오     | MiniMax-Hailuo-02                  | 768P     | 59.08 / 회 (6s), 118.16 / 회 (10s) |
+| MiniMax Hailuo 비디오     | MiniMax-Hailuo-02                  | 1080P    | 103.39 / 회 (6s)                   |
 
-## Moonvalley
-
-<Warning>
-  **서비스 이용 불가**: Moonvalley API 서비스를 더 이상 사용할 수 없습니다. 아래 나열된 노드는 지원 중단되었으며 예상대로 작동하지 않을 수 있습니다.
-</Warning>
-
-| 제품 이름                        | 구성 | 크레딧        | 카테고리 |
-| :------------------------------- | :--- | :------------ | :------- |
-| Moonvalley Image-to-Video 5s     | NA   | 316.5 / run   | 비디오   |
-| Moonvalley Image-to-Video 10s    | NA   | 633 / run     | 비디오   |
-| Moonvalley Text-to-Video 5s      | NA   | 316.5 / run   | 비디오   |
-| Moonvalley Text-to-Video 10s     | NA   | 633 / run     | 비디오   |
-| Moonvalley Video-to-Video 5s     | NA   | 474.75 / run  | 비디오   |
-| Moonvalley Video-to-Video 10s    | NA   | 844 / run     | 비디오   |
+**MiniMax Hailuo 비디오**는 1080P에서 **6초**만 지원합니다.
 
 ## OpenAI
 
-OpenAI 파트너 노드는 공개 API와 동일한 기본 USD 사용량을 청구합니다. **크레딧 = USD × 211** (페이지 헤더 참조). 아래 텍스트 모델 USD 요금은 OpenAI의 **[API 가격](https://developers.openai.com/api/docs/pricing)** **Standard** 등급 (100만 토큰당)과 일치하며, 이미지 토큰 승수는 `comfy_api_nodes/nodes_openai.py`와 일치합니다. DALL·E 및 Sora 고정 수학은 노드의 `price_badge` 표현식과 일치합니다. 최종 요금은 측정된 사용량(토큰, 기간 및 캐시 히트)에 따라 청구됩니다.
+**크레딧 = USD × 211.** DALL·E와 Sora는 이미지당 또는 초당 고정 요금을 사용합니다. **OpenAI GPT 이미지 2** 및 **OpenAI ChatGPT**는 API 토큰 사용량에 따라 청구됩니다.
 
-### DALL·E 2 (`OpenAIDalle2`)
+### 이미지: DALL·E
 
-생성된 이미지당 (여러 개를 요청하는 경우 `n`을 곱함).
+**DALL·E 2**는 **256×256**, **512×512** 또는 **1024×1024**를 지원합니다. 총 크레딧 = **(크레딧 / 이미지) × `n`**. **DALL·E 3**는 **`quality`** (`standard` / `hd`)를 지원하며 **1024×1024** 또는 세로 **1024×1792** / **1792×1024**를 지원합니다.
 
-| 제품명                 | 구성              | 이미지당 크레딧 | 카테고리 |
-| :--------------------- | :---------------- | :-------------- | :------- |
-| OpenAI DALL·E 2 이미지 | 사이즈: 256x256   | 3.38            | 이미지   |
-| OpenAI DALL·E 2 이미지 | 사이즈: 512x512   | 3.80            | 이미지   |
-| OpenAI DALL·E 2 이미지 | 사이즈: 1024x1024 | 4.22            | 이미지   |
+| 노드            | 품질    | 크기                  | 크레딧         |
+| :-------------- | :------ | :-------------------- | :------------- |
+| OpenAI DALL·E 2 | —       | 256x256               | 3.38 / 이미지  |
+|                 | —       | 512x512               | 3.80 / 이미지  |
+|                 | —       | 1024x1024             | 4.22 / 이미지  |
+| OpenAI DALL·E 3 | standard| 1024x1024             | 8.44 / 회차    |
+|                 | standard| 1024x1792, 1792x1024  | 16.88 / 회차   |
+|                 | hd      | 1024x1024             | 16.88 / 회차   |
+|                 | hd      | 1024x1792, 1792x1024  | 25.32 / 회차   |
 
-### DALL·E 3 (`OpenAIDalle3`)
+### 이미지: GPT 이미지
 
-| 제품명                 | 구성                                                   | 실행당 크레딧 | 카테고리 |
-| :--------------------- | :----------------------------------------------------- | :------------ | :------- |
-| OpenAI DALL·E 3 이미지 | quality: standard, size: 1024x1024                     | 8.44          | 이미지   |
-| OpenAI DALL·E 3 이미지 | quality: standard, size: 1024x1792 또는 1792x1024      | 16.88         | 이미지   |
-| OpenAI DALL·E 3 이미지 | quality: hd, size: 1024x1024                           | 16.88         | 이미지   |
-| OpenAI DALL·E 3 이미지 | quality: hd, size: 1024x1792 또는 1792x1024            | 25.32         | 이미지   |
+생성 이후 API 토큰 사용량에 따라 청구됩니다. `quality` (`low` / `medium` / `high`)에 따른 대략적인 배지입니다. 실제 비용은 아래 토큰 수에 따라 결정됩니다.
 
-### GPT Image 1 / 1.5 / 2 (`OpenAIGPTImage1`)
+| 모델          | 토큰 유형       | 크레딧 / 1M |
+| :------------ | :-------------- | :---------- |
+| gpt-image-1   | 입력            | 2110        |
+| gpt-image-1   | 출력 (이미지)   | 8440        |
+| gpt-image-1.5 | 입력            | 1688        |
+| gpt-image-1.5 | 출력 (이미지)   | 6752        |
+| gpt-image-2   | 입력            | 1688        |
+| gpt-image-2   | 출력 (이미지)   | 6330        |
 
-API 사용량 기준 토큰 기반. 크레딧 = USD × 211 (100만 토큰당, 노드의 `calculate_tokens_price_image_1` / `calculate_tokens_price_image_1_5` 도우미의 요율).
+지원 중단된 **OpenAI GPT 이미지 2** 노드(이전 구현)는 동일한 모델과 요금을 사용합니다.
 
-| 제품명                           | 구성                | 100만 토큰당 크레딧 | 카테고리 |
-| :------------------------------- | :------------------ | :------------------ | :------- |
-| OpenAI GPT Image 입력 (텍스트/이미지) | model: gpt-image-1   | 2110 ($10 / 1M)     | 이미지   |
-| OpenAI GPT Image 출력 (이미지)       | model: gpt-image-1   | 8440 ($40 / 1M)     | 이미지   |
-| OpenAI GPT Image 입력 (텍스트/이미지) | model: gpt-image-1.5 | 1688 ($8 / 1M)      | 이미지   |
-| OpenAI GPT Image 출력 (이미지)       | model: gpt-image-1.5 | 6752 ($32 / 1M)     | 이미지   |
-| OpenAI GPT Image 입력 (이미지)       | model: gpt-image-2   | 1688 ($8 / 1M)      | 이미지   |
-| OpenAI GPT Image 캐시 입력 (이미지)  | model: gpt-image-2   | 422 ($2 / 1M)       | 이미지   |
-| OpenAI GPT Image 입력 (텍스트)       | model: gpt-image-2   | 1055 ($5 / 1M)      | 이미지   |
-| OpenAI GPT Image 캐시 입력 (텍스트)  | model: gpt-image-2   | 263.75 ($1.25 / 1M) | 이미지   |
-| OpenAI GPT Image 출력 (이미지)       | model: gpt-image-2   | 6330 ($30 / 1M)     | 이미지   |
+### 채팅
 
-UI는 실행당 품질(`low` / `medium` / `high`)에 따른 **대략적인 USD 범위**를 표시합니다. 실제 비용은 토큰 수에 따라 달라집니다.
+토큰 기반 청구입니다. 배지 요금은 **1K 토큰당**이며, 표는 **1M 토큰당**입니다.
 
-### 채팅 (`OpenAIChatNode`)
+| 모델          | 입력 크레딧 / 1M | 출력 크레딧 / 1M |
+| :------------ | ---------------: | :--------------- |
+| gpt-5.5       |             1055 | 6330             |
+| gpt-5.5-pro   |             6330 | 37980            |
+| gpt-5         |           263.75 | 2110             |
+| gpt-5-mini    |            52.75 | 422              |
+| gpt-5-nano    |            10.55 | 84.4             |
+| gpt-4.1       |              422 | 1688             |
+| gpt-4.1-mini  |             84.4 | 337.6            |
+| gpt-4.1-nano  |             21.1 | 84.4             |
+| o3            |             2110 | 8440             |
+| o4-mini       |            232.1 | 928.4            |
+| o1            |             3165 | 12660            |
+| o1-pro        |            31650 | 126600           |
 
-노드에서 선택 가능한 모델: `gpt-5.5`, `gpt-5.5-pro`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`, `o1`, `o1-pro`. Standard 등급, 100만 토큰당 (캐시 열은 OpenAI의 캐시 입력 요율이 있는 경우 표시). 단기 및 장기 컨텍스트 가격이 모두 있는 모델의 경우, 요청이 단기 컨텍스트 창을 초과하면 장기 컨텍스트 요율이 적용됩니다.
+선택적 이미지와 파일은 동일한 모델 요금으로 입력 토큰을 추가합니다.
 
-| 모델                        | 입력 크레딧 / 1M | 캐시 입력 크레딧 / 1M | 출력 크레딧 / 1M |
-| :-------------------------- | ----------------: | --------------------: | ----------------: |
-| gpt-5.5 (단기 컨텍스트)     | 1055              | 105.5                 | 6330              |
-| gpt-5.5 (장기 컨텍스트)     | 2110              | 211                   | 9495              |
-| gpt-5.5-pro (단기 컨텍스트) | 6330              | —                     | 37980             |
-| gpt-5.5-pro (장기 컨텍스트) | 12660             | —                     | 56970             |
-| gpt-5                       | 263.75            | 26.38                 | 2110              |
-| gpt-5-mini                  | 52.75             | 5.28                  | 422               |
-| gpt-5-nano                  | 10.55             | 1.06                  | 84.4              |
-| gpt-4.1                     | 422               | 105.5                 | 1688              |
-| gpt-4.1-mini                | 84.4              | 21.1                  | 337.6             |
-| gpt-4.1-nano                | 21.1              | 5.28                  | 84.4              |
-| o3                          | 422               | 105.5                 | 1688              |
-| o4-mini                     | 232.1             | 58.03                 | 928.4             |
-| o1                          | 3165              | 1582.5                | 12660             |
-| o1-pro                      | 31650             | —                     | 126600            |
+### 비디오: Sora
 
-선택적 이미지 및 파일은 동일한 모델 입력 요율로 청구되는 토큰을 추가합니다.
+<Warning>
+  **지원 중단됨**: OpenAI는 2026년 9월에 Sora v2 API 제공을 중단할 예정입니다. 이 노드는 그 이후에 작동이 중단될 수 있습니다.
+</Warning>
 
-### Sora 비디오 (`OpenAIVideoSora2`)
+총 크레딧 = **(크레딧 / 초) × `duration`** (`duration`은 4, 8, 12 중 하나입니다).
 
-USD는 **(초당 요율) × (기간(초))** 입니다. 기간은 4, 8 또는 12가 될 수 있습니다. 크레딧 = USD × 211.
+| 모델        | 크기                   | 크레딧        |
+| :---------- | :--------------------- | :------------ |
+| sora-2      | 720x1280, 1280x720     | 21.10 / 초    |
+| sora-2-pro  | 720x1280, 1280x720     | 63.30 / 초    |
+| sora-2-pro  | 1024x1792, 1792x1024   | 105.50 / 초   |
 
-| 제품명                       | 구성                                          | 초당 크레딧 | 카테고리 |
-| :--------------------------- | :-------------------------------------------- | :---------- | :------- |
-| OpenAI Sora 비디오 생성       | model: sora-2, size: 720x1280 또는 1280x720   | 21.10       | 비디오   |
-| OpenAI Sora 비디오 생성       | model: sora-2-pro, size: 720x1280 또는 1280x720 | 63.30      | 비디오   |
-| OpenAI Sora 비디오 생성       | model: sora-2-pro, size: 1024x1792 또는 1792x1024 | 105.50   | 비디오   |
-
-예시: `sora-2`, 1280x720, 8초 → 약 **168.8** 크레딧 ($0.10 × 8 × 211).
+`sora-2`는 720x1280 및 1280x720만 지원합니다.
 
 ## OpenRouter
 
-### OpenRouter LLM (`OpenRouterLLMNode`)
+뱃지 요금은 **1K 토큰당**이며, 표는 **1M 토큰당**입니다. 최종 요금은 API 사용량에 따라 청구됩니다.
 
-백만 토큰 당 크레딧.
-
-| 모델                              | 입력 크레딧 / 1M | 출력 크레딧 / 1M |
-| :----------------------------------- | -----------------: | ------------------: |
-| `anthropic/claude-opus-4.7`          |               1055 |                5275 |
-| `openai/gpt-5.5-pro`                 |               6330 |               37980 |
-| `openai/gpt-5.5`                     |               1055 |                6330 |
-| `google/gemini-3.5-flash`            |              316.5 |                1899 |
-| `x-ai/grok-4.20`                     |             263.75 |               527.5 |
-| `x-ai/grok-4.3`                      |             263.75 |               527.5 |
-| `deepseek/deepseek-v4-pro`           |             91.785 |              183.57 |
-| `deepseek/deepseek-v4-flash`         |             23.632 |              47.264 |
-| `deepseek/deepseek-v3.2`             |             53.172 |              79.758 |
-| `qwen/qwen3.6-max-preview`           |             219.44 |             1316.64 |
-| `qwen/qwen3.6-plus`                  |            68.575 |              411.45 |
-| `qwen/qwen3.6-flash`                 |           39.5625 |             237.375 |
-| `mistralai/mistral-large-2512`       |              105.5 |               316.5 |
-| `mistralai/mistral-medium-3-5`       |              316.5 |              1582.5 |
-| `z-ai/glm-4.6`                       |              90.73 |              367.14 |
-| `z-ai/glm-5`                         |              126.6 |              405.12 |
-| `moonshotai/kimi-k2.6`               |             154.03 |              736.39 |
-| `moonshotai/kimi-k2-thinking`        |              126.6 |               527.5 |
-| `perplexity/sonar-pro`               |                633 |                3165 |
-| `perplexity/sonar-reasoning-pro`     |                422 |                1688 |
-| `perplexity/sonar-deep-research`     |                422 |                1688 |
-
-## Pika
-
-| 제품명                                                | 구성                                                  | 크레딧        | 카테고리 |
-| :---------------------------------------------------- | :---------------------------------------------------- | :------------ | :------- |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/i2v, resolution: 1080p         | 211 / run     | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/i2v, resolution: 720p          | 126.6 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/pikaframes, resolution: 1080p  | 211 / run     | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/pikaframes, resolution: 720p   | 52.75 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/pikascenes, resolution: 1080p  | 316.5 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/pikascenes, resolution: 720p   | 84.4 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/t2v, resolution: 1080p         | 211 / run     | 비디오   |
-| prod-v1-Pika 비디오 생성 제품 (10초)                     | endpoint: generate/2.2/t2v, resolution: 720p          | 126.6 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/i2v, resolution: 1080p         | 94.95 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/i2v, resolution: 720p          | 42.2 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/pikaframes, resolution: 1080p  | 63.3 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/pikaframes, resolution: 720p   | 42.2 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/pikascenes, resolution: 1080p  | 105.5 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/pikascenes, resolution: 720p   | 63.3 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/t2v, resolution: 1080p         | 94.95 / run   | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/2.2/t2v, resolution: 720p          | 42.2 / run    | 비디오   |
-| prod-v1-Pika 비디오 생성 (5초)                           | endpoint: generate/pikaffects, resolution: 720p       | 94.95 / run   | 비디오   |
-| Pika 기본 비디오 제품                                    | endpoint: generate/pikadditions                       | 63.3 / run    | 비디오   |
-| Pika 기본 비디오 제품                                    | endpoint: generate/pikaffects                         | 94.95 / run   | 비디오   |
-| Pika 기본 비디오 제품                                    | endpoint: generate/pikaswaps                          | 63.3 / run    | 비디오   |
+| 모델                                                          | 입력 크레딧 / 1M | 출력 크레딧 / 1M |
+| :------------------------------------------------------------- | :----------------- | :------------------ |
+| anthropic/claude-opus-4.7                                      | 1055               | 5275                |
+| openai/gpt-5.5-pro                                             | 6330               | 37980               |
+| openai/gpt-5.5                                                 | 1055               | 6330                |
+| google/gemini-3.5-flash                                        | 316.5              | 1899                |
+| x-ai/grok-4.20, x-ai/grok-4.3                                  | 263.75             | 527.5               |
+| deepseek/deepseek-v4-pro                                       | 91.785             | 183.57              |
+| deepseek/deepseek-v4-flash                                     | 23.632             | 47.264              |
+| deepseek/deepseek-v3.2                                         | 53.172             | 79.758              |
+| qwen/qwen3.6-max-preview                                       | 219.44             | 1316.64             |
+| qwen/qwen3.6-plus                                              | 68.575             | 411.45              |
+| qwen/qwen3.6-flash                                             | 39.5625            | 237.375             |
+| mistralai/mistral-large-2512                                   | 105.5              | 316.5               |
+| mistralai/mistral-medium-3-5                                   | 316.5              | 1582.5              |
+| z-ai/glm-4.6                                                   | 90.73              | 367.14              |
+| z-ai/glm-5                                                     | 126.6              | 405.12              |
+| moonshotai/kimi-k2.6                                           | 154.03             | 736.39              |
+| moonshotai/kimi-k2-thinking                                    | 126.6              | 527.5               |
+| perplexity/sonar-pro                                           | 633                | 3165                |
+| perplexity/sonar-reasoning-pro, perplexity/sonar-deep-research | 422                | 1688                |
 
 ## Pixverse
 
-| 제품명                           | 구성                                               | 크레딧        | 카테고리 |
-| :------------------------------- | :------------------------------------------------ | :------------ | :------- |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: fast, quality: 360p     | 189.9 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: fast, quality: 540p     | 189.9 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: fast, quality: 720p     | 253.2 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 1080p  | 253.2 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 360p   | 94.95 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 540p   | 94.95 / 회    | 비디오   |
-| Pixverse 5초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 720p   | 126.6 / 회    | 비디오   |
-| Pixverse 8초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 360p   | 189.9 / 회    | 비디오   |
-| Pixverse 8초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 540p   | 189.9 / 회    | 비디오   |
-| Pixverse 8초 비디오 제품          | model: v3.5, motion_mode: normal, quality: 720p   | 253.2 / 회    | 비디오   |
+모델 **v3.5** (API에서 고정됨, 선택 불가).
+
+**1080p**는 **노멀** 모션에서 **5초**로 제한됩니다. **8초** 클립은 **노멀** 모션만 지원합니다 (빠른 모션은 노멀로 강제 변환).
+
+| 모델 | 길이 | 모션 모드 | 화질 | 크레딧 |
+| :---- | :------- | :---------- | :--------- | :---------- |
+| v3.5  | 5s       | 빠름        | 360p, 540p | 189.9 / 회 |
+|       | 5s       | 빠름        | 720p       | 253.2 / 회 |
+|       | 5s       | 노멀        | 360p, 540p | 94.95 / 회 |
+|       | 5s       | 노멀        | 720p       | 126.6 / 회 |
+|       | 5s       | 노멀        | 1080p      | 253.2 / 회 |
+|       | 8s       | 노멀        | 360p, 540p | 189.9 / 회 |
+|       | 8s       | 노멀        | 720p       | 253.2 / 회 |
 
 ## Quiver
 
-| 제품명               | 설정                   | 크레딧          | 카테고리 |
-| :------------------- | :--------------------- | :-------------- | :------- |
-| Quiver 텍스트 → SVG  | 모델: 화살표-1.1       | 60.35 / 회      | 이미지   |
-| Quiver 이미지 → SVG  | 모델: 화살표-1.1       | 45.26 / 회      | 이미지   |
-| Quiver 텍스트 → SVG  | 모델: 화살표-1.1-max   | 75.43 / 회      | 이미지   |
-| Quiver 이미지 → SVG  | 모델: 화살표-1.1-max   | 60.35 / 회      | 이미지   |
+### 이미지
+
+| 모델         | 크레딧     |
+| :------------ | :---------- |
+| arrow-1.1     | 60.35 / 실행 |
+| arrow-1.1-max | 75.43 / 실행 |
+| arrow-preview | 90.52 / 실행 |
 
 ## Recraft
 
-| 제품명                                 | 구성                                          | 크레딧        | 카테고리 |
-| :------------------------------------- | :-------------------------------------------- | :------------ | :------- |
-| Recraft 스타일 생성                     | endpoint: v2/style/create                     | 8.44 / run    | 이미지   |
-| Recraft 이미지 생성 (텍스트 → 이미지)   | endpoint: v2/auto/text-to-image               | 8.44 / run    | 이미지   |
-| Recraft 이미지 생성 (이미지 → 이미지)   | endpoint: v2/auto/image-to-image              | 8.44 / run    | 이미지   |
-| Recraft Inpainting                     | endpoint: v2/auto/inpainting                  | 8.44 / run    | 이미지   |
-| Recraft 벡터 생성 (텍스트 → 벡터)       | endpoint: v2/auto/text-to-vector              | 16.88 / run   | 이미지   |
-| Recraft 벡터 생성 (이미지 → 벡터)       | endpoint: v2/auto/vectorize-image             | 2.11 / run    | 이미지   |
-| Recraft 배경 교체                       | endpoint: v2/image/replace-background         | 8.44 / run    | 이미지   |
-| Recraft 배경 제거                       | endpoint: v2/image/remove-background          | 2.11 / run    | 이미지   |
-| Recraft Crisp Upscale                  | endpoint: v2/image/crisp-upscale              | 0.84 / run    | 이미지   |
-| Recraft Creative Upscale               | endpoint: v2/image/creative-upscale           | 52.75 / run   | 이미지   |
-| Recraft V4 텍스트-이미지                | model: recraftv4                              | 8.44 / run    | 이미지   |
-| Recraft V4 텍스트-이미지                | model: recraftv4_pro                          | 52.75 / run   | 이미지   |
-| Recraft V4 텍스트-벡터                  | model: recraftv4                              | 16.88 / run   | 이미지   |
-| Recraft V4 텍스트-벡터                  | model: recraftv4_pro                          | 63.30 / run   | 이미지   |
+### 이미지
+
+별도로 명시되지 않는 한 실행당 고정 가격입니다. **`n`**이 표시된 노드는 **(크레딧/이미지) × `n`**만큼 청구됩니다. v3 생성 노드는 API 요청에 모델 **recraftv3**를 전송합니다(노드에서 선택 불가).
+
+| 모델          | 노드                                                                     | 크레딧                    |
+| :------------ | :----------------------------------------------------------------------- | :------------------------ |
+| recraftv4_pro | Recraft V4 텍스트-이미지                                                 | 52.75 / 이미지 (× `n`)   |
+| recraftv4_pro | Recraft V4 텍스트-벡터                                                  | 63.30 / 이미지 (× `n`)   |
+| recraftv4     | Recraft V4 텍스트-이미지                                                 | 8.44 / 이미지 (× `n`)    |
+| recraftv4     | Recraft V4 텍스트-벡터                                                  | 16.88 / 이미지 (× `n`)   |
+| recraftv3     | Recraft 이미지 생성 (텍스트 → 이미지), Recraft 이미지 생성 (이미지 → 이미지), Recraft 이미지 인페인팅 | 8.44 / 이미지 (× `n`)    |
+| recraftv3     | Recraft 벡터 생성 (텍스트 → 벡터)                                       | 16.88 / 이미지 (× `n`)   |
+| —             | Recraft 스타일 생성                                                     | 8.44 / 실행              |
+| —             | Recraft 배경 교체                                                       | 8.44 / 실행              |
+| —             | Recraft 벡터 생성 (이미지 → 벡터), Recraft 배경 제거                    | 2.11 / 실행              |
+| —             | Recraft 선명 업스케일 이미지                                            | 0.84 / 실행              |
+| —             | Recraft 크리에이티브 업스케일 이미지                                    | 52.75 / 실행             |
 
 ## Reve
 
-> 표시된 가격은 기본 가격입니다(test\_time\_scaling=1, 후처리 없음). 업스케일링 또는 배경 제거를 활성화하면 실제 비용이 더 높아질 수 있습니다.
+### 이미지
 
-| 제품명                    | 구성                           | 크레딧         | 카테고리 |
-| :---------------------- | :----------------------------- | :------------- | :------- |
-| Reve 이미지 생성         | 모델: reve-create@20250915     | 7.24 / 회      | 이미지   |
-| Reve 이미지 편집         | 모델: reve-edit@20250915       | 12.07 / 회     | 이미지   |
-| Reve 이미지 편집         | 모델: reve-edit-fast@20251030  | 2.11 / 회      | 이미지   |
-| Reve 이미지 리믹스       | 모델: reve-remix@20250915      | 12.07 / 회     | 이미지   |
-| Reve 이미지 리믹스       | 모델: reve-remix-fast@20251030 | 2.11 / 회      | 이미지   |
+아래 크레딧은 `test_time_scaling=1`, 업스케일 끔 기준의 대략적인 **기본** 요금입니다. **`test_time_scaling` > 1**, **업스케일**, **배경 제거**를 적용하면 API의 실제 요금이 증가할 수 있습니다.
 
-## Rodin
+| 모델                                   | 노드                              | 업스케일 | 크레딧        |
+| :-------------------------------------- | :-------------------------------- | :------ | :---------- |
+| reve-create@20250915                    | Reve 이미지 생성                  | 끔      | 7.24 / 회  |
+|                                         |                                   | 2x      | 9.64 / 회  |
+|                                         |                                   | 3x      | 12.47 / 회 |
+|                                         |                                   | 4x      | 16.08 / 회 |
+| reve-edit@20250915, reve-remix@20250915 | Reve 이미지 편집, Reve 이미지 리믹스 | 끔      | 12.07 / 회 |
+|                                         |                                   | 2x      | 14.47 / 회 |
+|                                         |                                   | 3x      | 17.28 / 회 |
+|                                         |                                   | 4x      | 20.91 / 회 |
+| reve-edit-fast@20251030                 | Reve 이미지 편집                  | —       | 2.11 / 회  |
+| reve-remix-fast@20251030                | Reve 이미지 리믹스                 | —       | 2.11 / 회  |
 
-### Hyper3D Rodin (Gen-2)
+빠른 편집/리믹스 모델은 고정 기본 요금을 사용하므로 업스케일을 적용해도 표시된 예상 요금은 변하지 않습니다.
 
-| 제품명                            | 구성   | 크레딧          | 카테고리 |
-| :-------------------------------- | :----- | :-------------- | :------- |
-| Rodin 3D 생성 (애드온 없음)       | NA     | 84.4 /회        | 3D       |
-| Rodin 3D 생성 (애드온 포함)       | NA     | 253.2 /회       | 3D       |
+## Rodin 3D
 
-### Hyper3D Rodin Gen-2.5 (`Rodin3D_Gen25_Image` / `Rodin3D_Gen25_Text`)
+| 버전 | 노드 | 모드 | addon_highpack | 크레딧 |
+| :--------- | :------------------------------------------------------------------------------------------------------ | :------------ | :------------- | :----------- |
+| Gen-2.5    | Rodin 3D Gen-2.5 - 이미지 → 3D, Rodin 3D Gen-2.5 - 텍스트 → 3D                                           | Regular, Fast | off            | 158.25 / 실행 |
+| Gen-2.5    |                                                                                                         | Extreme-High  | off            | 316.5 / 실행  |
+| Gen-2.5    |                                                                                                         | any           | on             | +168.8 / 실행 |
+| Gen-2      | Rodin 3D 생성 - 일반 생성, 세부 생성, 부드럽게 생성, 스케치 생성, Gen-2 생성 | —             | —              | 84.4 / 실행   |
 
-| 제품명                           | 구성                                         | 크레딧          | 카테고리 |
-| :------------------------------- | :-------------------------------------------- | :-------------- | :------- |
-| Rodin Gen-2.5 (일반/빠름)        | 모드: 일반 또는 빠름                          | 158.25 /회      | 3D       |
-| Rodin Gen-2.5 (극고)             | 모드: 극고                                    | 316.5 /회       | 3D       |
-| Rodin Gen-2.5 HighPack 애드온    | addon_highpack: 참                            | +168.8 /회      | 3D       |
+**HighPack** (`addon_highpack`)은 해당 모드의 Gen-2.5 기본 요금에 **168.8** 크레딧을 추가합니다.
 
 ## Runway
 
-| 제품명                                   | 구성               | 크레딧       | 카테고리 |
-| :--------------------------------------- | :----------------- | :---------- | :------- |
-| prod-v1-Runway Video Generation Product  | 모델: gen3a_turbo  | 15.09 / 초  | 비디오   |
-| prod-v1-Runway Video Generation Product  | 모델: gen4_turbo   | 10.55 / 초  | 비디오   |
-| prod-v1-Runway Video Generation Product  | 모델: aleph2       | 84.48 / 초  | 비디오   |
-| RunwayML Image Generation Product        | 모델: gen4_image   | 24.14 / 실행 | 이미지   |
-| Runway First & Last Frame Generation Product | 모델: gen4_turbo  | 15.09 / 초  | 비디오   |
+### 비디오
+
+Gen3a Turbo, Gen4 Turbo, First-Last-Frame: **5초** 또는 **10초**. 총 크레딧 = **(초당 크레딧) × `duration`**.
+
+| 모델          | 크레딧       |
+| :------------ | :----------- |
+| gen3a_turbo   | 15.09 / 초   |
+| gen4_turbo    | 15.09 / 초   |
+| aleph2        | 84.48 / 초   |
+
+**Runway Aleph2 Keyframe**과 **Runway Aleph2 Prompt Image**는 별도 요금이 없는 헬퍼 노드이며, 요금은 **Runway Aleph2 Video to Video**에 부과됩니다.
+
+### 이미지
+
+| 모델        | 크레딧        |
+| :---------- | :------------ |
+| gen4_image  | 23.21 / 회    |
 
 ## Sonilo
 
-| 제품명                | 구성                           | 크레딧    | 카테고리 |
-| :-------------------- | :----------------------------- | :--------- | :------- |
-| Sonilo Music Generate | 모델: sonilo, 유형: 비디오-음악 | 1.9 / sec  | 오디오    |
-| Sonilo Music Generate | 모델: sonilo, 유형: 텍스트-음악  | 1.055 / sec | 오디오    |
+Sonilo 텍스트로 음악 생성: 총 크레딧 = (크레딧/초) × `duration` (1–360초).
+
+| 노드                  | 크레딧          |
+| :-------------------- | :-------------- |
+| Sonilo 비디오로 음악 생성 | 1.9 /초         |
+| Sonilo 텍스트로 음악 생성 | 0.5275 /초      |
 
 ## Stability AI
 
-| 제품 이름                                   | 구성                                                                       | 크레딧       | 카테고리 |
-| :------------------------------------------ | :------------------------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Stability Image Generation Product  | endpoint: v2beta/stable-image/generate/core                                | 6.33 / 실행  | 이미지   |
-| prod-v1-Stability Image Generation Product  | endpoint: v2beta/stable-image/generate/ultra                               | 16.88 / 실행 | 이미지   |
-| prod-v1-Stability Image Generation Product  | endpoint: v2beta/stable-image/upscale/conservative                         | 84.4 / 실행  | 이미지   |
-| prod-v1-Stability Image Generation Product  | endpoint: v2beta/stable-image/upscale/creative                             | 126.6 / 실행 | 이미지   |
-| prod-v1-Stability Image Generation Product  | endpoint: v2beta/stable-image/upscale/fast                                 | 4.22 / 실행  | 이미지   |
-| Stability AI SD3 Image Products             | 모델: sd3.5-large                                                          | 13.71 / 실행 | 이미지   |
-| Stability AI SD3 Image Products             | 모델: sd3.5-large-turbo                                                    | 8.44 / 실행  | 이미지   |
-| Stability AI SD3 Image Products             | 모델: sd3.5-medium                                                         | 7.39 / 실행  | 이미지   |
-| Stability Audio Generation Product          | endpoint: v2beta/audio/stable-audio-2/audio-to-audio, 모델: stable-audio-2.5 | 42.2 / 실행  | 오디오   |
-| Stability Audio Generation Product          | endpoint: v2beta/audio/stable-audio-2/inpaint, 모델: stable-audio-2.5        | 42.2 / 실행  | 오디오   |
-| Stability Audio Generation Product          | endpoint: v2beta/audio/stable-audio-2/text-to-audio, 모델: stable-audio-2.5  | 42.2 / 실행  | 오디오   |
+### 이미지
+
+| 노드                                      | 모델        | 크레딧      |
+| :---------------------------------------- | :----------- | :----------- |
+| Stability AI Stable Image Ultra           |              | 16.88 / 실행  |
+| Stability AI Stable Diffusion 3.5 Image   | sd3.5-large  | 13.715 / 실행 |
+|                                           | sd3.5-medium | 7.385 / 실행  |
+| Stability AI 업스케일 보수적               |              | 84.4 / 실행   |
+| Stability AI 업스케일 크리에이티브         |              | 126.6 / 실행  |
+| Stability AI 초고속 업스케일               |              | 4.22 / 실행   |
+
+### 오디오
+
+| 모델             | 크레딧    |
+| :---------------- | :--------- |
+| stable-audio-2.5  | 42.2 / 실행 |
 
 ## Tencent
 
-| 제품명                       | 설정                                                 | 크레딧       | 카테고리 |
-| :--------------------------- | :--------------------------------------------------- | :----------- | :------- |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Geometry    | 63.3 / run   | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: LowPoly     | 126.6 / run  | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Normal      | 105.5 / run  | 3D       |
-| Tencent 3D Generate Type     | endpoint: hunyuan/3d-pro, generate_type: Sketch      | 105.5 / run  | 3D       |
-| Tencent 3D Face Count        | custom_face_count: 참, endpoint: hunyuan/3d-pro       | 42.2 / run   | 3D       |
-| Tencent 3D PBR               | enable_pbr: 참, endpoint: hunyuan/3d-pro             | 42.2 / run   | 3D       |
-| Tencent 3D Multiview Images  | endpoint: hunyuan/3d-pro, multi_view: 참             | 42.2 / run   | 이미지   |
-| Tencent 3D                   | endpoint: hunyuan/3d-part                            | 126.6 / run  | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-texture-edit                    | 126.6 / run  | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-uv                              | 42.2 / run   | 3D       |
-| Tencent 3D                   | endpoint: hunyuan/3d-smart-topology                  | 211 / run    | 3D       |
+**`3.1`**은(는) **`3.0`**과(와) 동일한 요금을 사용하지만 LowPoly를 지원하지 않습니다.
+
+### 3D: 생성
+
+| 모델  | 생성 유형   | 크레딧       |
+| :---- | :---------- | :----------- |
+| 3.0   | 지오메트리  | 63.3 / 실행  |
+|       | 노멀(normal) | 105.5 / 실행 |
+|       | LowPoly     | 126.6 / 실행 |
+
+추가 옵션은 기본 요금에 누적됩니다:
+
+| 모델 | 옵션                            | 크레딧       |
+| :--- | :------------------------------ | :----------- |
+| 3.0  | PBR (`pbr` on)                  | +42.2 / 실행 |
+|      | Custom `face_count` (≠ 500000)  | +42.2 / 실행 |
+|      | Multiview 이미지 연결됨         | +42.2 / 실행 |
+
+Multiview는 `image_left`, `image_right` 또는 `image_back`이 연결된 경우에만 **Hunyuan3D: Image(s) to Model**에 적용됩니다.
+
+### 3D: 후처리
+
+| 노드                          | 크레딧       |
+| :---------------------------- | :----------- |
+| Hunyuan3D: Model to UV        | 42.2 / 실행  |
+| Hunyuan3D: Smart Topology     | 211 / 실행   |
+
+**Hunyuan3D: 3D Texture Edit** 및 **Hunyuan3D: 3D Part**는 각각 **126.6 / 실행**입니다.
 
 ## Topaz
 
-### 이미지 향상
+### 이미지
 
-| 제품명                          | 구성                               | 크레딧        | 카테고리 |
-| :------------------------------ | :---------------------------------- | :------------ | :------- |
-| Topaz 이미지 향상 (Reimagine) | 입력 해상도: 720p (1280x720)        | 13.93 / 회    | 이미지    |
-| Topaz 이미지 향상 (Reimagine) | 입력 해상도: 1080p (1920x1080)      | 27.85 / 회    | 이미지    |
-| Topaz 이미지 향상 (Reimagine) | 입력 해상도: 1440p (2560x1440)      | 27.85 / 회    | 이미지    |
-| Topaz 이미지 향상 (Reimagine) | 입력 해상도: 4K (3840x2160)         | 69.63 / 회    | 이미지    |
+요율은 Topaz API가 폴링 시점에 반환합니다(**API 크레딧 × 0.08** USD). 입력 해상도별 일반적인 요금:
 
-### 비디오 향상
+| 모델       | 입력 해상도                 | 크레딧        |
+| :--------- | :-------------------------- | :------------ |
+| Reimagine  | 720p (1280×720)             | 13.93 / 실행  |
+|            | 1080p (1920×1080)           | 27.85 / 실행  |
+|            | 1440p (2560×1440)           | 27.85 / 실행  |
+|            | 4K (3840×2160)              | 69.63 / 실행  |
 
-| 제품명               | 구성                                                                  | 크레딧          | 카테고리 |
-| :------------------- | :--------------------------------------------------------------------- | :-------------- | :------- |
-| Topaz 비디오 향상 | 모델: Starlight Precise 2.5 (slp-2.5), 업스케일러 해상도: FullHD (1080p)    | 12.99 / 초      | 비디오    |
-| Topaz 비디오 향상 | 모델: Starlight Precise 2.5 (slp-2.5), 업스케일러 해상도: 4K (2160p)        | 28.08 / 초      | 비디오    |
-| Topaz 비디오 향상 | 모델: Starlight (Astra) Fast (slf-1), 업스케일러 해상도: FullHD (1080p)     | 6.50 / 초       | 비디오    |
-| Topaz 비디오 향상 | 모델: Starlight (Astra) Fast (slf-1), 업스케일러 해상도: 4K (2160p)         | 14.16 / 초      | 비디오    |
-| Topaz 비디오 향상 | 모델: Starlight (Astra) Creative (slc-1), 업스케일러 해상도: FullHD (1080p) | 43.62 / 초      | 비디오    |
-| Topaz 비디오 향상 | 모델: Starlight (Astra) Creative (slc-1), 업스케일러 해상도: 4K (2160p)     | 77.99 / 초      | 비디오    |
-| Topaz 비디오 향상 | 보간 모델: apo-8, 입력 해상도: 720p                             | 2.55 / 초       | 비디오    |
-| Topaz 비디오 향상 | 보간 모델: apo-8, 입력 해상도: 1080p                            | 5.57 / 초       | 비디오    |
-| Topaz 비디오 향상 | 보간 모델: apo-8, 입력 해상도: 4K                               | 21.59 / 초       | 비디오    |
-| Topaz 비디오 향상 | 모델: Astra 2 (ast-2), 해상도: 1080p                                       | 1.688 / 프레임  | 비디오    |
-| Topaz 비디오 향상 | 모델: Astra 2 (ast-2), 해상도: 4K                                           | 2.813 / 프레임  | 비디오    |
+### 비디오
+
+노드에 표시된 대략적인 요율은 **소스 프레임당**(초당이 아님)입니다. 총 크레딧 ≈ **(크레딧 / 소스 프레임) × 입력 프레임 수**. **apo-8** 보간이 활성화되면 업스케일 요율에 소스 프레임당 **~0.14**(1080p) 또는 **~0.28**(4K)을 추가합니다.
+
+| 업스케일러 모델               | 업스케일러 해상도 | 크레딧 / 소스 프레임 |
+| :---------------------------- | :---------------- | :------------------- |
+| Starlight (Astra) Fast        | FullHD (1080p)    | ~0.43                |
+|                               | 4K (2160p)        | ~0.85                |
+| Starlight Precise 2.5         | FullHD (1080p)    | ~0.70                |
+|                               | 4K (2160p)        | ~1.54                |
+| Astra 2                       | FullHD (1080p)    | ~1.72                |
+|                               | 4K (2160p)        | ~2.85                |
+| Starlight (Astra) Creative    | FullHD (1080p)    | ~2.25                |
+|                               | 4K (2160p)        | ~3.99                |
+
+업스케일러 **비활성화**와 **apo-8** 보간만: UI에는 **보간만** 표시됨; 요금은 폴링 시점의 API 예상 요금에서 부과됩니다.
+
+**Topaz Video Enhance (레거시)**는 지원 중단됨. 고정된 실행 전 예상 요금이 없으며, 요금은 폴링 시점의 API 예상 요금에서 부과됩니다.
 
 ## Tripo
 
-| 제품명 | 구성 | 크레딧 | 카테고리 |
-| :--- | :--- | :--- | :--- |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: detailed, type: image_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: detailed, type: multiview_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: detailed, type: text_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: standard, type: image_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: standard, type: multiview_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.0-20240919, texture_quality: standard, type: text_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: detailed, type: image_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: detailed, type: multiview_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: detailed, type: text_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: standard, type: image_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: standard, type: multiview_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v2.5-20250123, texture_quality: standard, type: text_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: detailed, type: image_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: detailed, type: multiview_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: detailed, type: text_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: standard, type: image_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: standard, type: multiview_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.0-20250812, texture_quality: standard, type: text_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: detailed, type: image_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: detailed, type: multiview_to_model | 84.4 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: detailed, type: text_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: standard, type: image_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: standard, type: multiview_to_model | 63.3 / run | 3D |
-| Tripo 생성 (텍스처 포함) 제품 | model: v3.1, texture_quality: standard, type: text_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.0-20240919, type: image_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.0-20240919, type: multiview_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.0-20240919, type: text_to_model | 21.1 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.5-20250123, type: image_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.5-20250123, type: multiview_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v2.5-20250123, type: text_to_model | 21.1 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.0-20250812, type: image_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.0-20250812, type: multiview_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.0-20250812, type: text_to_model | 21.1 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.1, type: image_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.1, type: multiview_to_model | 42.2 / run | 3D |
-| Tripo 생성 (텍스처 없음) 제품 | model: v3.1, type: text_to_model | 21.1 / run | 3D |
-| Tripo 스타일 제품 | NA | 10.55 / run | 3D |
-| Tripo 사각형 제품 | NA | 10.55 / run | 3D |
-| Tripo 텍스처 추가 제품 | texture_quality: detailed | 42.2 / run | 3D |
-| Tripo 텍스처 추가 제품 | texture_quality: standard | 21.1 / run | 3D |
-| Tripo 후처리 제품 | type: animate_retarget | 21.1 / run | 3D |
-| Tripo 후처리 제품 | type: animate_rig | 52.75 / run | 3D |
-| Tripo 후처리 제품 | type: stylize_model | 42.2 / run | 3D |
-| Tripo 변환 제품 | convert_format: advanced | 21.1 / run | 3D |
-| Tripo 변환 제품 | convert_format: basic | 10.55 / run | 3D |
-| Tripo V1-4 생성 제품 | type: image_to_model | 63.3 / run | 3D |
-| Tripo V1-4 생성 제품 | type: refine_model | 63.3 / run | 3D |
-| Tripo V1-4 생성 제품 | type: text_to_model | 42.2 / run | 3D |
-| Tripo 지오메트리 품질 제품 | geometry_quality: detailed | 42.2 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: text_to_model, output_mode: Geometry only | 63.3 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: standard | 84.4 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: detailed | 105.5 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: image_to_model, output_mode: Geometry only | 84.4 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: standard | 105.5 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: multiview_to_model, output_mode: Geometry only | 84.4 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: standard | 105.5 / run | 3D |
-| Tripo P1 생성 제품 | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / run | 3D |
+레거시 생성 가격은 근사치입니다. 이 노드는 내부 Tripo 크레딧을 **크레딧 × 0.01** 비율로 USD로 변환합니다.
 
-| Tripo 3D 가져오기 제품 | NA | 무료 | 3D |
+### 생성: v1.4
+
+| 모델 버전       | 노드                                               | 크레딧      |
+| :-------------- | :------------------------------------------------- | :---------- |
+| v1.4-20240625   | Tripo: 텍스트를 모델로                              | 42.2 / 실행 |
+|                 | Tripo: 이미지를 모델로, Tripo: 멀티뷰를 모델로      | 63.3 / 실행 |
+
+v1.4 가격은 고정입니다. `texture`, `quad`, 품질 설정은 예상 가격을 변경하지 않습니다.
+
+**Tripo: 드래프트 모델 정제**(v1.4 드래프트만 해당): **63.3 / 실행**.
+
+### 생성: v2.0 / v2.5
+
+`model_version` **v2.0-20240919** 또는 **v2.5-20250123**. `texture` 또는 `pbr`은 텍스처 있음으로 간주됩니다. v2.0 및 v2.5에서 **`geometry_quality: detailed`는 가격을 변경하지 않습니다**.
+
+**Tripo: 텍스트를 모델로**
+
+| 텍스처 | 텍스처 품질 | 크레딧      |
+| :----- | :---------- | :---------- |
+| off    | 표준        | 21.1 / 실행 |
+| on     | 표준        | 42.2 / 실행 |
+| on     | 상세        | 63.3 / 실행 |
+
+**Tripo: 이미지를 모델로** 및 **Tripo: 멀티뷰를 모델로**
+
+| 텍스처 | 텍스처 품질 | 크레딧      |
+| :----- | :---------- | :---------- |
+| off    | 표준        | 42.2 / 실행 |
+| on     | 표준        | 63.3 / 실행 |
+| on     | 상세        | 84.4 / 실행 |
+
+| 옵션   | 크레딧       |
+| :----- | :----------- |
+| `quad` | +10.55 / 실행 |
+
+`quad`는 **Tripo: 텍스트를 모델로** 및 **Tripo: 이미지를 모델로**에만 적용됩니다.
+
+### 생성: v3.0 / v3.1
+
+동일한 노드에 `model_version` **v3.0-20250812** 또는 **v3.1-20260211**. **`geometry_quality: detailed`**는 아래 텍스처 행의 가격에 **+42.2 / 실행**을 추가합니다.
+
+**Tripo: 텍스트를 모델로**
+
+| 텍스처 | 텍스처 품질 | 지오메트리 품질 | 크레딧      |
+| :----- | :---------- | :-------------- | :---------- |
+| off    | 표준        | 표준            | 21.1 / 실행 |
+| off    | 표준        | 상세            | 63.3 / 실행 |
+| on     | 표준        | 표준            | 42.2 / 실행 |
+| on     | 상세        | 표준            | 63.3 / 실행 |
+| on     | 표준        | 상세            | 84.4 / 실행 |
+| on     | 상세        | 상세            | 105.5 / 실행 |
+
+**Tripo: 이미지를 모델로** 및 **Tripo: 멀티뷰를 모델로**
+
+| 텍스처 | 텍스처 품질 | 지오메트리 품질 | 크레딧      |
+| :----- | :---------- | :-------------- | :---------- |
+| off    | 표준        | 표준            | 42.2 / 실행 |
+| off    | 표준        | 상세            | 84.4 / 실행 |
+| on     | 표준        | 표준            | 63.3 / 실행 |
+| on     | 상세        | 표준            | 84.4 / 실행 |
+| on     | 표준        | 상세            | 105.5 / 실행 |
+| on     | 상세        | 상세            | 126.6 / 실행 |
+
+`quad` 추가(+10.55 / 실행)는 **Tripo: 텍스트를 모델로** 및 **Tripo: 이미지를 모델로**에만 적용됩니다.
+
+### 생성: P1
+
+| 모델          | 출력 모드     | 텍스처 품질 | 크레딧(텍스트) | 크레딧(이미지/멀티뷰) |
+| :------------ | :------------ | :---------- | :-------------- | :-------------------- |
+| P1-20260311   | 지오메트리만  | —           | 63.3 / 실행     | 84.4 / 실행           |
+|               | 텍스처 있음   | 표준        | 84.4 / 실행     | 105.5 / 실행          |
+|               | 텍스처 있음   | 상세        | 105.5 / 실행    | 126.6 / 실행          |
+
+### 후처리
+
+| 노드                               | 크레딧      |
+| :--------------------------------- | :---------- |
+| Tripo: 텍스처 모델                 | 21.1 / 실행(표준), 42.2 / 실행(상세) |
+| Tripo: 리그 모델                   | 52.75 / 실행 |
+| Tripo: 리그 모델 리타겟            | 21.1 / 실행 |
+| Tripo: 모델 변환                   | 10.55 / 실행(기본), 21.1 / 실행(고급 옵션) |
+| Tripo: 모델 가져오기               | 무료        |
+
+**Tripo: 모델 변환**은 `quad`가 켜져 있거나, `face_limit`이 설정되었거나, `texture_size` ≠ 4096이거나, `texture_format` ≠ JPEG이거나, `flatten_bottom` 또는 `pivot_to_center_bottom`이 켜져 있거나, `flatten_bottom_threshold` ≠ 0이거나, `scale_factor` ≠ 1일 경우 **21.1 / 실행**을 부과합니다. 그 외에는 **10.55 / 실행**입니다.
 
 ## Vidu
 
-### 비디오 생성 — Q3
+### 비디오: Q3
 
-| 제품명                             | 구성                                      | 크레딧             | 카테고리 |
-| :------------------------------- | :-------------------------------------- | :-------------- | :---- |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-pro, resolution: 1080P   | 33.76 / sec | 비디오  |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-pro, resolution: 720P    | 31.65 / sec | 비디오  |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-pro, resolution: 540P    | 14.77 / sec | 비디오  |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-turbo, resolution: 1080P | 16.88 / sec | 비디오  |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-turbo, resolution: 720P  | 12.66 / sec | 비디오  |
-| Vidu Q3 비디오 생성 제품 | model: vidu-q3-turbo, resolution: 540P  | 8.44 / sec  | 비디오  |
+총 크레딧 = **(크레딧/초) × `duration`**.
 
-### 비디오 생성 — Q2
+| 모델          | 해상도 | 크레딧/초 |
+| :------------ | :----- | :-------- |
+| viduq3-turbo  | 720p   | 12.66     |
+|               | 1080p  | 16.88     |
+| viduq3-pro    | 720p   | 31.65     |
+|               | 1080p  | 33.76     |
+|               | 2K     | 42.2      |
 
-> 비수기 가격은 일반 가격의 절반입니다. 소수점은 올림 처리됩니다.
+**2K**는 **viduq3-pro**를 사용하는 **Vidu Q3 이미지-비디오 생성**에서만 지원됩니다.
 
-| 제품명                             | 구성                                                                       | 크레딧                                  | 카테고리 |
-| :------------------------------- | :----------------------------------------------------------------------- | :----------------------------------- | :---- |
-| Vidu Q2 비디오 생성 제품 | model: q2-turbo, type: img2video / start-end2video, resolution: 540P     | Starts at 6.33, +2.11/sec           | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-turbo, type: img2video / start-end2video, resolution: 720P     | Starts at 8.44, +10.55/sec after 2s | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-turbo, type: img2video / start-end2video, resolution: 1080P    | Starts at 36.92, +10.55/sec         | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: img2video / start-end2video, resolution: 540P       | Starts at 8.44, +5.28/sec after 2s  | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: img2video / start-end2video, resolution: 720P       | Starts at 15.82, +10.55/sec         | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: img2video / start-end2video, resolution: 1080P      | Starts at 58.03, +15.82/sec         | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro-fast, type: img2video / start-end2video, resolution: 720P  | Starts at 8.44, +2.11/sec           | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro-fast, type: img2video / start-end2video, resolution: 1080P | Starts at 16.88, +4.22/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: text2video, resolution: 540P                            | Starts at 10.55, +2.11/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: text2video, resolution: 720P                            | Starts at 15.82, +5.28/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: text2video, resolution: 1080P                           | Starts at 21.1, +10.55/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: reference2video, resolution: 540P                       | Starts at 15.82, +5.28/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: reference2video, resolution: 720P                       | Starts at 26.38, +5.28/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2, type: reference2video, resolution: 1080P                      | Starts at 79.12, +10.55/sec         | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: reference2video, resolution: 540P                   | Starts at 21.1, +5.28/sec           | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: reference2video, resolution: 720P                   | Starts at 31.65, +5.28/sec          | 비디오  |
-| Vidu Q2 비디오 생성 제품 | model: q2-pro, type: reference2video, resolution: 1080P                  | Starts at 89.67, +10.55/sec         | 비디오  |
+### 비디오: Q2
 
-### 비디오 생성 — Q1
+**직선 노드**(멀티-프레임 제외): **기본 + (크레딧/초) × (`duration` − 1)**.
 
-| 제품명                             | 구성                                                                                  | 크레딧         | 카테고리 |
-| :------------------------------- | :---------------------------------------------------------------------------------- | :---------- | :---- |
-| Vidu Q1 비디오 생성 제품 | model: vidu-q1, type: reference2video, style: general, duration: 5s, resolution: 1080P | 84.4 / run | 비디오  |
-| Vidu Q1 비디오 생성 제품 | model: vidu-q1, type: img2video, style: general, duration: 5s, resolution: 1080P       | 84.4 / run | 비디오  |
-| Vidu Q1 비디오 생성 제품 | model: vidu-q1, type: start-end2video, style: general, duration: 5s, resolution: 1080P | 84.4 / run | 비디오  |
-| Vidu Q1 비디오 생성 제품 | model: vidu-q1, type: text2video, style: general, duration: 5s, resolution: 1080P      | 84.4 / run | 비디오  |
-| Vidu Q1 비디오 생성 제품 | model: vidu-q1, type: text2video, style: anime, duration: 5s, resolution: 1080P        | 84.4 / run | 비디오  |
+**멀티-프레임:** **`frames` × 기본 + (크레딧/초) × 세그먼트 지속 시간의 합** (확장 / 멀티-프레임 기본 열 사용).
 
-### 비디오 생성 — Vidu 2.0
+**레퍼런스** (`viduq2`): `audio`가 켜져 있을 때 **+15.825 / 회** 추가.
 
-| 제품명                          | 구성                                                                     | 크레딧          | 카테고리 |
-| :---------------------------- | :---------------------------------------------------------------------- | :----------- | :---- |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: img2video, duration: 4S, resolution: 360P        | 21.1 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: img2video, duration: 4S, resolution: 720P        | 42.2 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: img2video, duration: 4S, resolution: 1080P       | 105.5 / run | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: img2video, duration: 8S, resolution: 720P        | 105.5 / run | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 360P  | 84.4 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 720P  | 84.4 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 360P  | 21.1 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 720P  | 42.2 / run  | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 1080P | 105.5 / run | 비디오  |
-| Vidu 2.0 비디오 생성 제품 | model: vidu-2.0, type: start-end2video, duration: 8S, resolution: 720P  | 105.5 / run | 비디오  |
+| 모델              | 해상도 | 1초 이후 크레딧/초 | 기본 (1초) 직선 노드 | 기본 (1초) 확장 / 멀티-프레임 |
+| :---------------- | :----- | :----------------- | :------------------- | :---------------------------- |
+| viduq2            | 720p   | 5.275              | 15.825               | —                             |
+|                   | 1080p  | 10.55              | 21.1                 | —                             |
+| viduq2-pro-fast   | 720p   | 2.11               | 8.44                 | —                             |
+|                   | 1080p  | 4.22               | 16.88                | —                             |
+| viduq2-pro        | 720p   | 10.55              | 15.825               | 31.65                         |
+|                   | 1080p  | 15.825             | 58.025               | 63.3                          |
+| viduq2-turbo      | 1080p  | 10.55              | 36.925               | 42.2                          |
+|                   | 720p   | 5.275 (확장/MF); 10.55 (I2V/시작-종료, 2초 이후) | — | 15.825            |
 
-### 이미지 생성
+위 viduq2 직선 기본값은 **텍스트 기반 비디오 생성** 기준입니다. **레퍼런스 기반 비디오 생성**은 초당 동일한 요율을 사용하지만 기본값은 **26.375** (720p) 또는 **79.125** (1080p)입니다.
 
-| 제품명                      | 구성                                                                             | 크레딧          | 카테고리 |
-| :------------------------ | :------------------------------------------------------------------------------ | :----------- | :---- |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Text to Image, resolution: 1080P                       | 6.33 / run  | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Text to Image, resolution: 2K                          | 8.44 / run  | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Text to Image, resolution: 4K                          | 10.55 / run | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 1080P | 8.44 / run  | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 2K    | 12.66 / run | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 4K    | 21.1 / run  | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 1080P | 10.55 / run | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 2K    | 16.88 / run | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 4K    | 31.65 / run | 이미지  |
-| Vidu 이미지 생성 제품 | model: viduq1, type: Reference to Image, ref images: 1–7, resolution: 1080P | 21.1 / run  | 이미지  |
+**viduq2-pro-fast**, **viduq2-pro**, **viduq2-turbo**의 직선 기본값은 **이미지 기반 비디오 생성** 및 **시작/종료 프레임 기반 비디오 생성** 기준입니다. **viduq2-turbo**를 **720p**에서 해당 노드에 사용할 때: 1초에서 **8.44** (I2V), 2초에서 **10.55** (I2V에서는 고정, 시작/종료 최소 지속 시간은 2초), 그 후 2초 이후 **+10.55 / 초**입니다. **5.275 / 초** 요율은 I2V나 시작/종료가 아닌 확장 및 멀티-프레임에만 적용됩니다.
 
-### 비디오 확장
+### 비디오: Q1
 
-| 제품명                 | 구성                                   | 크레딧                          | 카테고리 |
-| :------------------- | :----------------------------------- | :--------------------------- | :---- |
-| Vidu 비디오 확장 제품 | model: q2-turbo, resolution: 540P  | Starts at 10.55, +2.11/sec  | 비디오  |
-| Vidu 비디오 확장 제품 | model: q2-turbo, resolution: 720P  | Starts at 15.82, +5.28/sec  | 비디오  |
-| Vidu 비디오 확장 제품 | model: q2-turbo, resolution: 1080P | Starts at 42.2, +10.55/sec  | 비디오  |
-| Vidu 비디오 확장 제품 | model: q2-pro, resolution: 540P    | Starts at 15.82, +5.28/sec  | 비디오  |
-| Vidu 비디오 확장 제품 | model: q2-pro, resolution: 720P    | Starts at 31.65, +10.55/sec | 비디오  |
-| Vidu 비디오 확장 제품 | model: q2-pro, resolution: 1080P   | Starts at 63.3, +15.82/sec  | 비디오  |
+**1080p**에서 고정 **5초**.
 
-### 기타 기능
+| 모델   | 크레딧      |
+| :----- | :---------- |
+| viduq1 | 84.4 / 회   |
 
-| 제품명                | 구성 | 크레딧         | 카테고리 |
-| :------------------ | :-: | :---------- | :---- |
-| Vidu 립 싱크 제품   | —   | 21.1 / 5s   | 비디오  |
-| Vidu 모션 싱크 제품 | —   | 10.55 / sec | 비디오  |
+## Wan
 
-## WAN
+| 모델 | 해상도 | 크레딧 |
+| :--- | :--- | :--- |
+| wan2.5-t2i-preview, wan2.5-i2i-preview | — | 6.33 / 회 |
+| wan2.7-t2v, wan2.7-i2v | 720P | 21.1 / 초 |
+| | 1080P | 31.65 / 초 |
+| wan2.7-i2v (계속) | 720P | 21.1 / 초 (범위) |
+| | 1080P | 31.65 / 초 (범위) |
+| wan2.7-videoedit | 720P | 21.1 / 초 (입력 + 출력) |
+| | 1080P | 31.65 / 초 (입력 + 출력) |
+| wan2.7-r2v | 720P | 21.1 / 초 (범위) |
+| | 1080P | 31.65 / 초 (범위) |
+| wan2.5-t2v-preview, wan2.5-i2v-preview | 480p | 10.55 / 초 |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 720p | 21.1 / 초 |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 1080p | 31.65 / 초 |
+| wan2.6-r2v | 720p | 21.1 / 초 (범위) |
+| | 1080p | 31.65 / 초 (범위) |
 
-| 제품 이름                    | 구성                                           | 크레딧        | 카테고리 |
-| :--------------------------- | :--------------------------------------------- | :------------ | :------- |
-| Wan 이미지 생성 제품         | model: wan2.5-i2i-preview                      | 6.33 / run    | 이미지   |
-| Wan 이미지 생성 제품         | model: wan2.5-t2i-preview                      | 6.33 / run    | 이미지   |
-| Wan 이미지 생성 제품         | model: wan2.6-t2i                              | 6.33 / run    | 이미지   |
-| Wan 비디오 생성 제품         | model: wan2.5-i2v-preview, resolution: 1080P   | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.5-i2v-preview, resolution: 480P    | 10.55 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.5-i2v-preview, resolution: 720P    | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.5-t2v-preview, resolution: 1080P   | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.5-t2v-preview, resolution: 480P    | 10.55 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.5-t2v-preview, resolution: 720P    | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-i2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-i2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-r2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-r2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-t2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.6-t2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-i2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-i2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-r2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-r2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-t2v, resolution: 1080P           | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-t2v, resolution: 720P            | 21.1 / sec    | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-videoedit, resolution: 1080P     | 31.65 / sec   | 비디오   |
-| Wan 비디오 생성 제품         | model: wan2.7-videoedit, resolution: 720P      | 21.1 / sec    | 비디오   |
+## WaveSpeed
 
-## Wavespeed
-
-| 제품명                | 구성                            | 크레딧          | 카테고리 |
-| :-------------------- | :------------------------------ | :-------------- | :------- |
-| Wavespeed Flashvsr    | 해상도: 1080p                   | 18.99 / 실행    | 이미지   |
-| Wavespeed Flashvsr    | 해상도: 2k                      | 25.32 / 실행    | 이미지   |
-| Wavespeed Flashvsr    | 해상도: 4k                      | 33.76 / 실행    | 이미지   |
-| Wavespeed Flashvsr    | 해상도: 720p                    | 12.66 / 실행    | 이미지   |
-| Wavespeed Image       | 엔드포인트: seedvr2             | 2.11 / 실행     | 이미지   |
-| Wavespeed Image       | 엔드포인트: ultimate-image-upscaler | 12.66 / 실행 | 이미지   |
+| 모델       | 해상도    | 크레딧          |
+| :--------- | :-------- | :-------------- |
+| flashvsr   | 720p      | 2.532 / 초  |
+|            | 1080p     | 3.798 / 초  |
+|            | 2K        | 5.064 / 초  |
+|            | 4K        | 6.752 / 초  |
+| SeedVR2    | —         | 2.11 / 실행   |
+| Ultimate   | —         | 12.66 / 실행  |
 
 ## xAI
 
 <Note>
-비디오 엔드포인트는 검토된 콘텐츠에 대해 요금이 부과됩니다.
+비디오 엔드포인트는 조정된 콘텐츠에 대해 요금을 청구합니다.
 </Note>
 
-| 제품명 | 구성 | 크레딧 | 카테고리 |
-| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------ | :-------------- | :------- |
-| xAI 이미지 생성 | endpoint: v1/images/generations, model: grok-imagine-image-beta, resolution: 1k | 6.96 / 회 | 이미지 |
-| xAI 이미지 생성 | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 1k | 10.55 / 회 | 이미지 |
-| xAI 이미지 생성 | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 2k | 14.77 / 회 | 이미지 |
-| xAI 이미지 편집 출력 | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k | 6.96 / 회 | 이미지 |
-| xAI 이미지 편집 출력 | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 1k | 10.55 / 회 | 이미지 |
-| xAI 이미지 편집 출력 | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 2k | 14.77 / 회 | 이미지 |
-| xAI 이미지 편집 입력 | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k | 0.42 / 회 | 이미지 |
-| xAI 이미지 편집 입력 | endpoint: v1/images/edits, model: grok-imagine-image-quality | 2.11 / 회 | 이미지 |
-| xAI 비디오 생성 출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p | 38.19 / 초 | 비디오 |
-| xAI 비디오 생성 출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p | 38.19 / 초 | 비디오 |
-| xAI 비디오 생성 출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 480p | 24.14 / 초 | 비디오 |
-| xAI 비디오 생성 출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 720p | 42.24 / 초 | 비디오 |
-| xAI 비디오 생성 출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 1080p | 75.43 / 초 | 비디오 |
-| xAI 비디오 생성 입력 이미지 | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, type: image-to-video | 3.02 / 초 | 비디오 |
-| xAI 비디오 생성 입력 이미지 | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p, type: image-to-video | 0.42 / 초 | 비디오 |
-| xAI 비디오 생성 입력 이미지 | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p, type: image-to-video | 0.42 / 초 | 비디오 |
-| xAI 비디오 편집 입력+출력 비디오 (초당) | endpoint: v1/videos/edits, model: grok-imagine-video-beta, resolution: 480p | 40.3 / 초 | 비디오 |
-| xAI 이미지 편집 입력 | endpoint: v1/images/edits, model: v1/images/edits, resolution: 1k | 0.42 / 회 | 이미지 |
-| xAI 비디오 편집 입력+출력 비디오 (초당) | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p | 40.3 / 초 | 비디오 |
-| xAI 크레딧 | NA | 2.11 / 회 | 이미지 |
+### 이미지
 
-## 기타 (클라우드)
+| 모델                      | 해상도 | 작업   | 크레딧                                            |
+| :------------------------ | :----- | :----- | :----------------------------------------------- |
+| grok-imagine-image-quality | 1K    | 생성   | 10.55 / 출력 이미지                              |
+|                           | 2K    | 생성   | 14.77 / 출력 이미지                              |
+| grok-imagine-image-pro    | —      | 생성   | 14.77 / 출력 이미지                              |
+| grok-imagine-image        | —      | 생성   | 4.22 / 출력 이미지                               |
+| grok-imagine-image-quality | 1K    | 편집   | 2.11 입력 + 10.55 / 출력 이미지                  |
+|                           | 2K    | 편집   | 2.11 입력 + 14.77 / 출력 이미지                  |
+| grok-imagine-image-pro    | —      | 편집   | 0.422 입력 + 14.77 / 출력 이미지                 |
+| grok-imagine-image        | —      | 편집   | 0.422–1.266 입력 + 4.22 / 출력 이미지            |
 
-| 제품명              | 구성                    | 크레딧      | 카테고리 |
-| :---------------- | :--------------------- | :--------- | :------- |
-| GPU 시간 제품       | gpu_type: rtx_pro_6000 | 0.27 / 초  | 이미지   |
+### 비디오
+
+| 모델                          | 해상도 | 크레딧                                                            |
+| :---------------------------- | :----- | :--------------------------------------------------------------- |
+| grok-imagine-video            | 480p   | 10.55 / 초 출력 (+0.422 입력 이미지)                            |
+|                               | 720p   | 14.77 / 초 출력 (+0.422 입력 이미지)                            |
+| grok-imagine-video-1.5        | 480p   | 24.14 / 초 출력 (+3.02 입력 이미지)                             |
+|                               | 720p   | 42.24 / 초 출력 (+3.02 입력 이미지)                             |
+|                               | 1080p  | 75.43 / 초 출력 (+3.02 입력 이미지)                             |
+| grok-imagine-video (편집)     | —      | 12.66 / 초 (입력 + 출력 비디오)                                 |
+| grok-imagine-video (참조)     | 480p   | 15.09 / 초 출력 + 0.603 / 참조 이미지                           |
+|                               | 720p   | 21.12 / 초 출력 + 0.603 / 참조 이미지                           |
+| grok-imagine-video (확장)     | —      | 6.03–45.26 입력 + 15.09 × 확장 초 출력 / 회                  |
+
+## 클라우드 GPU
+
+| GPU 유형       | 크레딧       |
+| :------------- | :----------- |
+| rtx_pro_6000   | 0.27 / 초    |

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -27,14 +27,14 @@ Optional images add tokens billed at the same model input rates.
 
 ## Beeble
 
-### Video — SwitchX Video Edit
+### Video: SwitchX Video Edit
 
 | max_resolution | Credits           |
 | :------------- | :---------------- |
 | 720p           | 30.17 / 30 frames |
 | 1080p          | 90.52 / 30 frames |
 
-### Image — SwitchX Image Edit
+### Image: SwitchX Image Edit
 
 | max_resolution | Credits     |
 | :------------- | :---------- |
@@ -75,7 +75,7 @@ Optional images add tokens billed at the same model input rates.
 
 ## ByteDance
 
-### LLM — ByteDance Seed
+### LLM: ByteDance Seed
 
 Per 1K tokens, matching the `ByteDanceSeedNode` price display. Final cost scales with actual token usage.
 
@@ -85,7 +85,7 @@ Per 1K tokens, matching the `ByteDanceSeedNode` price display. Final cost scales
 | Seed 2.0 Lite | 0.0633 | 0.01055 | 0.422 |
 | Seed 2.0 Mini | 0.05275 | 0.00422 | 0.1899 |
 
-### Image — ByteDance Seedream 4.5 & 5.0
+### Image: ByteDance Seedream 4.5 & 5.0
 
 Per image generated (approximate).
 
@@ -95,13 +95,13 @@ Per image generated (approximate).
 | seedream-4-5-251128 | 8.44 |
 | seedream-4-0-250828 | 6.33 |
 
-### Image — ByteDance Image (deprecated)
+### Image: ByteDance Image (deprecated)
 
 | model | Credits / run |
 | :---- | :------------ |
 | seedream-3-0-t2i-250415 | 6.33 |
 
-### Video — Seedance 1.x
+### Video: Seedance 1.x
 
 Used by **ByteDance Text to Video**, **Image to Video**, and **First-Last-Frame to Video**. **ByteDance Reference Images to Video** supports Seedance 1.0 Pro and Lite at 480p and 720p only.
 
@@ -125,7 +125,7 @@ Approximate credits for **10 seconds** of video; scale linearly with `duration`.
 | seedance-1-0-lite-i2v-250428 | 720p | — | 78.07 – 86.51 |
 | seedance-1-0-lite-i2v-250428 | 1080p | — | 179.35 – 185.68 |
 
-### Video — Seedance 2.0
+### Video: Seedance 2.0
 
 Used by **ByteDance Seedance 2.0 Text to Video**, **First-Last-Frame to Video**, and **Reference to Video**. Billed from output token usage at the rates below. 480p uses the same per-K rate as 720p.
 
@@ -947,7 +947,7 @@ Per 1M tokens.
 | Tripo Import 3D Product | NA | Free | 3D |
 ## Vidu
 
-### Video Generation — Q3
+### Video Generation: Q3
 
 | Product Name                     | Configuration                           | Credits     | Category |
 | :------------------------------- | :-------------------------------------- | :---------- | :------- |
@@ -958,7 +958,7 @@ Per 1M tokens.
 | Vidu Q3 Video Generation Product | model: vidu-q3-turbo, resolution: 720P  | 12.66 / sec | Video    |
 | Vidu Q3 Video Generation Product | model: vidu-q3-turbo, resolution: 540P  | 8.44 / sec  | Video    |
 
-### Video Generation — Q2
+### Video Generation: Q2
 
 > Off-peak price is half the normal price. Decimals round up.
 
@@ -982,7 +982,7 @@ Per 1M tokens.
 | Vidu Q2 Video Generation Product | model: q2-pro, type: reference2video, resolution: 720P                   | Starts at 31.65, +5.28/sec          | Video    |
 | Vidu Q2 Video Generation Product | model: q2-pro, type: reference2video, resolution: 1080P                  | Starts at 89.67, +10.55/sec         | Video    |
 
-### Video Generation — Q1
+### Video Generation: Q1
 
 | Product Name                     | Configuration                                                                          | Credits    | Category |
 | :------------------------------- | :------------------------------------------------------------------------------------- | :--------- | :------- |
@@ -992,7 +992,7 @@ Per 1M tokens.
 | Vidu Q1 Video Generation Product | model: vidu-q1, type: text2video, style: general, duration: 5s, resolution: 1080P      | 84.4 / run | Video    |
 | Vidu Q1 Video Generation Product | model: vidu-q1, type: text2video, style: anime, duration: 5s, resolution: 1080P        | 84.4 / run | Video    |
 
-### Video Generation — Vidu 2.0
+### Video Generation: Vidu 2.0
 
 | Product Name                      | Configuration                                                           | Credits     | Category |
 | :-------------------------------- | :---------------------------------------------------------------------- | :---------- | :------- |

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -77,13 +77,13 @@ Optional images add tokens billed at the same model input rates.
 
 ### LLM: ByteDance Seed
 
-Per 1K tokens, matching the `ByteDanceSeedNode` price display. Final cost scales with actual token usage.
+Per 1K tokens from `_SEED_PRICES_PER_MILLION` billing rates (USD per 1M ÷ 1000 × 211). Final cost scales with actual token usage.
 
-| Model | Input credits / 1K | Cache hit credits / 1K | Output credits / 1K |
-| :---- | -----------------: | ---------------------: | ------------------: |
-| Seed 2.0 Pro | 0.1055 | 0.0211 | 0.633 |
-| Seed 2.0 Lite | 0.0633 | 0.01055 | 0.422 |
-| Seed 2.0 Mini | 0.05275 | 0.00422 | 0.1899 |
+| Model         | Input credits / 1K | Cache hit credits / 1K | Output credits / 1K |
+| :------------ | -----------------: | ---------------------: | :------------------ |
+| Seed 2.0 Pro  |             0.1055 |                 0.0211 | 0.633               |
+| Seed 2.0 Lite |            0.05275 |                0.01055 | 0.422               |
+| Seed 2.0 Mini |             0.0211 |                0.00422 | 0.0844              |
 
 ### Image: ByteDance Seedream 4.5 & 5.0
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -15,13 +15,13 @@ Anthropic partner nodes bill the same underlying USD usage as the public Anthrop
 
 ### Chat (`ClaudeNode`)
 
-| Model | Input credits / 1K | 5m Cache Write credits / 1K | 1h Cache Write credits / 1K | Cache Hit credits / 1K | Output credits / 1K |
-| :---- | -----------------: | --------------------------: | --------------------------: | ---------------------: | ------------------: |
-| Opus 4.7 | 1.055 | 1.31875 | 2.11 | 0.1055 | 5.275 |
-| Opus 4.6 | 1.055 | 1.31875 | 2.11 | 0.1055 | 5.275 |
-| Sonnet 4.6 | 0.633 | 0.79125 | 1.266 | 0.0633 | 3.165 |
-| Sonnet 4.5 | 0.633 | 0.79125 | 1.266 | 0.0633 | 3.165 |
-| Haiku 4.5 | 0.211 | 0.26375 | 0.422 | 0.0211 | 1.055 |
+| Model      | Input credits / 1K | 5m Cache Write credits / 1K | 1h Cache Write credits / 1K | Cache Hit credits / 1K | Output credits / 1K |
+| :--------- | -----------------: | --------------------------: | --------------------------: | ---------------------: | :------------------ |
+| Opus 4.7   |              1.055 |                     1.31875 |                        2.11 |                 0.1055 | 5.275               |
+| Opus 4.6   |              1.055 |                     1.31875 |                        2.11 |                 0.1055 | 5.275               |
+| Sonnet 4.6 |              0.633 |                     0.79125 |                       1.266 |                 0.0633 | 3.165               |
+| Sonnet 4.5 |              0.633 |                     0.79125 |                       1.266 |                 0.0633 | 3.165               |
+| Haiku 4.5  |              0.211 |                     0.26375 |                       0.422 |                 0.0211 | 1.055               |
 
 Optional images add tokens billed at the same model input rates.
 
@@ -57,14 +57,21 @@ Optional images add tokens billed at the same model input rates.
 
 ## Bria
 
-| Product Name                 | Configuration                             | Credits     | Category |
-| :--------------------------- | :---------------------------------------- | :---------- | :------- |
-| Bria Image Edit              | endpoint: v2/image/edit, model: fibo      | 8.44 / run  | Image    |
-| Bria Image Remove Background | endpoint: v2/image/edit/remove_background | 3.8 / run   | Image    |
-| Bria Video Remove Background | endpoint: v2/video/edit/remove_background | 0.89 / sec | Video    |
-| Bria Video Green Screen     | endpoint: v2/video/edit/green_screen     | 0.89 / sec | Video    |
-| Bria Video Replace Background | endpoint: v2/video/edit/replace_background | 0.89 / sec | Video    |
-| Bria Transparent Video Background | endpoint: v2/video/edit/remove_background | 0.89 / sec | Video    |
+### Image
+
+| Node | Credits |
+| :--- | :------ |
+| Bria FIBO Image Edit | 8.44 / run |
+| Bria Remove Image Background | 3.8 / run |
+
+### Video
+
+| Node | Credits |
+| :--- | :------ |
+| Bria Remove Video Background | 0.89 / sec |
+| Bria Video Green Screen | 0.89 / sec |
+| Bria Video Replace Background | 0.89 / sec |
+| Bria Remove Video Background (Transparent) | 0.89 / sec |
 
 ## ByteDance
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -27,22 +27,17 @@ The following table lists the pricing of the current Partner Nodes. All prices a
 
 ## BFL
 
-| Model                      | Credits                       | Category |
-| :------------------------- | :---------------------------- | :------- |
-| flux-dev                   | 5.28 / run                    | Image    |
-| flux-kontext-max           | 16.88 / run                   | Image    |
-| flux-kontext-pro           | 8.44 / run                    | Image    |
-| flux-pro-1.0-canny         | 10.55 / run                   | Image    |
-| flux-pro-1.0-depth         | 10.55 / run                   | Image    |
-| flux-pro-1.0-expand        | 10.55 / run                   | Image    |
-| flux-pro-1.0-fill          | 10.55 / run                   | Image    |
-| flux-tools/erase-v1        | 6.33 / run + 0.84 / extra MP | Image    |
-| flux-tools/vto-v1          | 7.91 / run + 1.06 / extra MP | Image    |
-| flux-pro-1.1               | 8.44 / run                    | Image    |
-| flux-pro-1.1-ultra         | 12.66 / run                   | Image    |
-| /v1/flux-pro               | 10.55 / run                   | Image    |
-| flux-2-pro                 | 6.33 / run + 3.17 / extra MP | Image    |
-| flux-2-max                 | 14.77 / run + 6.33 / extra MP | Image    |
+| Node | Credits |
+| :--- | :------ |
+| Flux 1.1 [pro] Ultra Image | 12.66 / run |
+| Flux.1 Kontext [pro] Image | 8.44 / run |
+| Flux.1 Kontext [max] Image | 16.88 / run |
+| Flux.1 Expand Image | 10.55 / run |
+| Flux.1 Fill Image | 10.55 / run |
+| Flux Erase Image | 6.33 / run + 0.84 / extra MP |
+| Flux Virtual Try-On | 7.91 / run + 1.06 / extra MP |
+| Flux.2 [pro] | 6.33 / run + 3.17 / extra MP |
+| Flux.2 [max] | 14.77 / run + 6.33 / extra MP |
 
 ## Anthropic
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -2,7 +2,7 @@
 title: "Pricing"
 description: "This article lists the pricing of the current Partner Nodes. All prices are in credits (211 credits = 1 USD)."
 sidebarTitle: "Pricing"
-mode: wide
+mode: "wide"
 ---
 
 The following table lists the pricing of the current Partner Nodes. All prices are in credits.
@@ -75,1041 +75,1009 @@ Optional images add tokens billed at the same model input rates.
 
 ## ByteDance
 
+Credits below match ComfyUI partner node pricing (**211 credits = $1 USD**).
+
 ### LLM: ByteDance Seed
 
-Per 1K tokens from `_SEED_PRICES_PER_MILLION` billing rates (USD per 1M ÷ 1000 × 211). Final cost scales with actual token usage.
+Per million tokens. Rates below are for prompt length **[0, 128]K**; longer prompts use higher tiers.
 
-| Model         | Input credits / 1K | Cache hit credits / 1K | Output credits / 1K |
-| :------------ | -----------------: | ---------------------: | :------------------ |
-| Seed 2.0 Pro  |             0.1055 |                 0.0211 | 0.633               |
-| Seed 2.0 Lite |            0.05275 |                0.01055 | 0.422               |
-| Seed 2.0 Mini |             0.0211 |                0.00422 | 0.0844              |
+| Model                                  | Input credits / 1M | Cache hit credits / 1M | Output credits / 1M |
+| :------------------------------------- | -----------------: | ---------------------: | :------------------ |
+| Seed 2.0 Pro (`seed-2-0-pro-260328`)   |              105.5 |                   21.1 | 633                 |
+| Seed 2.0 Lite (`seed-2-0-lite-260228`) |              52.75 |                  10.55 | 422                 |
+| Seed 2.0 Mini (`seed-2-0-mini-260215`) |               21.1 |                   4.22 | 84.4                |
+
+Optional images and videos add input tokens at the input rate.
 
 ### Image: ByteDance Seedream 4.5 & 5.0
 
-Per image generated (approximate).
+Per successfully generated image.
 
-| model | Credits / image |
-| :---- | :-------------- |
-| seedream 5.0 lite | 7.39 |
-| seedream-4-5-251128 | 8.44 |
-| seedream-4-0-250828 | 6.33 |
+| model                                     | Credits / image |
+| :---------------------------------------- | :-------------: |
+| seedream 5.0 lite (`seedream-5-0-260128`) |      7.39       |
+| seedream-4-5-251128                       |      8.44       |
+| seedream-4-0-250828                       |      6.33       |
 
 ### Image: ByteDance Image (deprecated)
 
-| model | Credits / run |
-| :---- | :------------ |
-| seedream-3-0-t2i-250415 | 6.33 |
-
-### Video: Seedance 1.x
-
-Used by **ByteDance Text to Video**, **Image to Video**, and **First-Last-Frame to Video**. **ByteDance Reference Images to Video** supports Seedance 1.0 Pro and Lite at 480p and 720p only.
-
-Approximate credits for **10 seconds** of video; scale linearly with `duration`. For **Seedance 1.5 Pro**, enable `generate_audio` to double the cost.
-
-| model | resolution | generate_audio | Credits / 10 sec (approx) |
-| :---- | :--------- | :------------- | :------------------------ |
-| seedance-1-5-pro-251215 | 480p | off | 25.32 |
-| seedance-1-5-pro-251215 | 480p | on | 50.64 |
-| seedance-1-5-pro-251215 | 720p | off | 54.86 |
-| seedance-1-5-pro-251215 | 720p | on | 109.72 |
-| seedance-1-5-pro-251215 | 1080p | off | 122.38 |
-| seedance-1-5-pro-251215 | 1080p | on | 244.76 |
-| seedance-1-0-pro-250528 | 480p | — | 48.53 – 50.64 |
-| seedance-1-0-pro-250528 | 720p | — | 107.61 – 118.16 |
-| seedance-1-0-pro-250528 | 1080p | — | 248.98 – 257.42 |
-| seedance-1-0-pro-fast-251015 | 480p | — | 18.99 – 21.1 |
-| seedance-1-0-pro-fast-251015 | 720p | — | 44.31 – 48.53 |
-| seedance-1-0-pro-fast-251015 | 1080p | — | 99.17 – 103.39 |
-| seedance-1-0-lite-i2v-250428 | 480p | — | 35.87 – 37.98 |
-| seedance-1-0-lite-i2v-250428 | 720p | — | 78.07 – 86.51 |
-| seedance-1-0-lite-i2v-250428 | 1080p | — | 179.35 – 185.68 |
+| model                   | Credits / image |
+| :---------------------- | :-------------- |
+| seedream-3-0-t2i-250415 | 6.33            |
 
 ### Video: Seedance 2.0
 
-Used by **ByteDance Seedance 2.0 Text to Video**, **First-Last-Frame to Video**, and **Reference to Video**. Billed from output token usage at the rates below. 480p uses the same per-K rate as 720p.
+480p and 720p share the same rate. Fast and Mini do not support 1080p or 4K.
 
-| model | resolution | Video input | Credits / K tokens |
-| :---- | :--------- | :---------- | -----------------: |
-| Seedance 2.0 | 720p | no | 2.112 |
-| Seedance 2.0 | 720p | yes | 1.297 |
-| Seedance 2.0 | 1080p | no | 2.323 |
-| Seedance 2.0 | 1080p | yes | 1.418 |
-| Seedance 2.0 | 4k | no | 1.207 |
-| Seedance 2.0 | 4k | yes | 0.724 |
-| Seedance 2.0 Fast | 720p | no | 1.690 |
-| Seedance 2.0 Fast | 720p | yes | 0.995 |
-| Seedance 2.0 Mini | 720p | no | 1.056 |
-| Seedance 2.0 Mini | 720p | yes | 0.634 |
+Estimated token consumption:
 
-**Video input** means reference video is connected (Reference to Video node). Text, image, and audio references count as no video input.
+`(Input video duration + Output video duration) × Output video width × Output video height × Output video frame rate ÷ 1024`
 
-> **Seedance 2.0 token calculation:** Output tokens = (Input video duration + Output video duration) × Output video length × Output video width × Output video frame rate ÷ 1024. When input is text, image, or audio, input duration = 0. Seedance 2.0 outputs at 24fps. For video-to-video inputs, a minimum token usage limit applies.
+When input is text, image, or audio only, input video duration = 0. Actual usage from the API is authoritative.
+
+| Model             | Resolution | Video input | Credits / 1K tokens |
+| :---------------- | :--------- | :---------- | ------------------: |
+| Seedance 2.0      | 480p, 720p | no          | 2.112               |
+| Seedance 2.0      | 480p, 720p | yes         | 1.297               |
+| Seedance 2.0      | 1080p      | no          | 2.323               |
+| Seedance 2.0      | 1080p      | yes         | 1.418               |
+| Seedance 2.0      | 4k         | no          | 1.207               |
+| Seedance 2.0      | 4k         | yes         | 0.724               |
+| Seedance 2.0 Fast | 480p, 720p | no          | 1.690               |
+| Seedance 2.0 Fast | 480p, 720p | yes         | 0.996               |
+| Seedance 2.0 Mini | 480p, 720p | no          | 1.056               |
+| Seedance 2.0 Mini | 480p, 720p | yes         | 0.634               |
+
+**Video input** means reference video is connected. Text, image, and audio references count as no video input.
+
+For video-to-video inputs, a minimum token usage may apply. Seedance 2.0 outputs at 24fps.
+
+### Video: Seedance 1.x
+
+Billed by tokens (same estimation formula as Seedance 2.0). Unlike Seedance 2.0, the **token rate does not change by resolution**; resolution changes how many tokens a clip uses (via width × height in the formula), so higher resolutions cost more.
+
+**Token rate**
+
+| Model                        | Condition               | Credits / 1M tokens |
+| :--------------------------- | :---------------------- | :------------------ |
+| seedance-1-5-pro-251215      | `generate_audio: false` | 253.2               |
+| seedance-1-5-pro-251215      | `generate_audio: true`  | 506.4               |
+| seedance-1-0-pro-250528      | —                       | 527.5               |
+| seedance-1-0-pro-fast-251015 | —                       | 211                 |
+
+**Approximate credits / 10 sec** (scale with `duration ÷ 10`. Ranges reflect aspect ratio.)
+
+| model                        | resolution | generate_audio | Credits / 10 sec |
+| :--------------------------- | :--------- | :------------- | :--------------- |
+| seedance-1-5-pro-251215      | 480p       | off            | 25.32            |
+| seedance-1-5-pro-251215      | 480p       | on             | 50.64            |
+| seedance-1-5-pro-251215      | 720p       | off            | 54.86            |
+| seedance-1-5-pro-251215      | 720p       | on             | 109.72           |
+| seedance-1-5-pro-251215      | 1080p      | off            | 122.38 – 124.49  |
+| seedance-1-5-pro-251215      | 1080p      | on             | 244.76 – 249.0   |
+| seedance-1-0-pro-250528      | 480p       | —              | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p       | —              | 107.61 – 118.16  |
+| seedance-1-0-pro-250528      | 1080p      | —              | 248.98 – 257.42  |
+| seedance-1-0-pro-fast-251015 | 480p       | —              | 18.99 – 21.1     |
+| seedance-1-0-pro-fast-251015 | 720p       | —              | 44.31 – 48.53    |
+| seedance-1-0-pro-fast-251015 | 1080p      | —              | 99.17 – 103.39   |
+| seedance-1-0-lite-i2v-250428 | 480p       | —              | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p       | —              | 78.07 – 86.51    |
+| seedance-1-0-lite-i2v-250428 | 1080p      | —              | 179.35 – 185.68  |
+
+**ByteDance Reference Images to Video** (480p and 720p only):
+
+| model                        | resolution | Credits / 10 sec |
+| :--------------------------- | :--------- | :--------------- |
+| seedance-1-0-pro-250528      | 480p       | 48.53 – 50.64    |
+| seedance-1-0-pro-250528      | 720p       | 107.61 – 118.16  |
+| seedance-1-0-lite-i2v-250428 | 480p       | 35.87 – 37.98    |
+| seedance-1-0-lite-i2v-250428 | 720p       | 78.07 – 86.51    |
 
 ## ElevenLabs
 
-| Product Name                           | Configuration                                              | Credits     | Category |
-| :------------------------------------- | :--------------------------------------------------------- | :---------- | :------- |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-dialogue, model: eleven_v3            | 50.64 / run | Audio    |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-speech, model: eleven_multilingual_v2 | 50.64 / run | Audio    |
-| 11labs Text-to-Speech                  | endpoint: v1/text-to-speech, model: eleven_v3              | 50.64 / run | Audio    |
-| 11labs Speech-to-Text                  | endpoint: v1/speech-to-text, model: scribe_v2              | 92.84 / run | Audio    |
-| 11labs Speech-to-Text Keyterm          | endpoint: v1/speech-to-text, model: scribe_v2              | 18.57 / run | Audio    |
-| 11labs Speech-to-Text Entity Detection | endpoint: scribe_v2, model: v1/speech-to-text              | 27.85 / run | Audio    |
-| 11labs Speech-to-Speech Per Minute     | endpoint: v1/speech-to-speech                              | 50.64 / min | Audio    |
-| 11labs Sound Generation Per Minute     | endpoint: v1/sound-generation                              | 29.54 / min | Audio    |
-| 11labs Audio Isolation Per Minute      | endpoint: v1/audio-isolation                               | 50.64 / min | Audio    |
-| 11labs Add Voice                       | endpoint: v1/voices/add                                    | 31.65 / run | Audio    |
+| Node                             | Credits          |
+| :------------------------------- | :--------------- |
+| ElevenLabs Text to Speech        | 50.64 / 1K chars |
+| ElevenLabs Text to Dialogue      | 50.64 / 1K chars |
+| ElevenLabs Speech to Text        | 1.54 / min       |
+| ElevenLabs Speech to Speech      | 50.64 / min      |
+| ElevenLabs Text to Sound Effects | 29.54 / min      |
+| ElevenLabs Voice Isolation       | 50.64 / min      |
+| ElevenLabs Instant Voice Clone   | 31.65 / run      |
 
-## Freepik
+## Magnific
 
-| Product Name                 | Configuration                     | Credits     | Category |
-| :--------------------------- | :-------------------------------- | :---------- | :------- |
-| Freepik Image Per Generation | endpoint: magnific-relight        | 23.21 / run | Image    |
-| Freepik Image Per Generation | endpoint: magnific-style-transfer | 23.21 / run | Image    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-creative  | 61.19 / run | Image    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-faithful  | 78.07 / run | Image    |
-| Freepik Image Per Generation | endpoint: skin-enhancer-flexible  | 94.95 / run | Image    |
-| Freepik Image Cost           | NA                                | 211 / run   | Image    |
+### Image: Upscale
+
+**Magnific Image Upscale (Creative)** and **Magnific Image Upscale (Precise V2)** share the same billing. Upscaling runs in 2x steps (`2x` = 1 step, `4x` = 2, `8x` = 3, `16x` = 4). After each step, pixel count ×4; each step is priced by the input megapixels at that step.
+
+| Input MP at step | Credits / 2x step |
+| :--------------- | :---------------- |
+| ≤1.3             | 35.91             |
+| ≤3.0             | 71.82             |
+| ≤6.4             | 107.73            |
+| >6.4             | 430.88            |
+
+**Total credits** = sum of all steps for your `scale_factor`. Example: **4x** on a 1 MP image → step 1 at 1 MP (35.91) + step 2 at 4 MP (107.73) = **143.64 credits**.
+
+### Image: Edit
+
+| Node                                    | Credits     |
+| :-------------------------------------- | :---------- |
+| Magnific Image Style Transfer           | 23.21 / run |
+| Magnific Image Relight                  | 23.21 / run |
+| Magnific Image Skin Enhancer (creative) | 61.19 / run |
+| Magnific Image Skin Enhancer (faithful) | 78.07 / run |
+| Magnific Image Skin Enhancer (flexible) | 94.95 / run |
 
 ## Google
 
-| Product Name                                | Configuration                                              | Credits            | Category |
-| :------------------------------------------ | :--------------------------------------------------------- | :----------------- | :------- |
-| prod-v1-Veo 2 Product                       | model: veo-2.0-generate-001                                | 105.5 / run        | Image    |
-| prod-v1-Veo 2 Product                       | model: veo-3.0-generate-preview                            | 158.25 / run       | Image    |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M tokens  | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-preview                                | 422 / 1M tokens    | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 527.5 / 1M tokens  | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 527.5 / 1M tokens  | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 2110 / 1M tokens   | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 633 / 1M tokens    | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 2532 / 1M tokens   | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 2532 / 1M tokens   | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 2532 / 1M tokens   | Text     |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M tokens  | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | Image    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | Image    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-2.5-flash-image                              | 6330 / 1M tokens   | Image    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-flash-image-preview                      | 12660 / 1M tokens  | Image    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-pro-preview                              | 25320 / 1M tokens  | Image    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3-pro-image-preview                          | 25320 / 1M tokens  | Image    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 2K      | 21.31 / run        | Image    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 4K      | 32.49 / run        | Image    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | Video    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | Video    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | Video    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | Video    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | Video    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | Video    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 211 / 1M tokens    | Audio    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 211 / 1M tokens    | Audio    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | Audio    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | Audio    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | Audio    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | Audio    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: false, model: veo-3.0-fast-generate-001     | 168.8 / run        | Video    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: false, model: veo-3.0-generate-001          | 337.6 / run        | Video    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: true, model: veo-3.0-fast-generate-001      | 253.2 / run        | Video    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: true, model: veo-3.0-generate-001           | 675.2 / run        | Video    |
-| Google Veo2 Video Generation                | NA                                                         | 105.5 / run        | Video    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.0-fast-generate-001     | 21.1 / run         | Image    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.0-generate-001          | 42.2 / run         | Image    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.1-fast-generate-preview | 21.1 / run         | Image    |
-| Google Veo3                                 | generateAudio: false, model: veo-3.1-generate-preview      | 42.2 / run         | Image    |
-| Google Veo3                                 | generateAudio: true, model: veo-3.0-fast-generate-001      | 31.65 / run        | Image    |
-| Google Veo3                                 | generateAudio: true, model: veo-3.0-generate-001           | 84.4 / run         | Image    |
-| Google Veo3                                 | generateAudio: true, model: veo-3.1-fast-generate-preview  | 31.65 / run        | Image    |
-| Google Veo3                                 | generateAudio: true, model: veo-3.1-generate-preview       | 84.4 / run         | Image    |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-flash-image-preview                      | 633 / 1M tokens    | Text     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-pro-preview                              | 2532 / 1M tokens   | Text     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3-pro-image-preview                          | 2532 / 1M tokens   | Text     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3-pro-preview                                | 2532 / 1M tokens   | Text     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | Text     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M tokens  | Text     |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | Image    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | Video    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 105.5 / 1M tokens  | Audio    |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M tokens  | Text     |
+### Chat: Google Gemini
+
+Token-based billing; thought tokens use the output text rate.
+
+| Model                                                   | Input credits / 1K | Output credits / 1K |
+| :------------------------------------------------------ | -----------------: | :------------------ |
+| Gemini 3.1 Pro (`gemini-3.1-pro-preview`)               |              0.422 | 2.532               |
+| Gemini 3.1 Flash-Lite (`gemini-3.1-flash-lite-preview`) |            0.05275 | 0.3165              |
+| Gemini 2.5 Pro (`gemini-2.5-pro`)                       |            0.26375 | 2.11                |
+| Gemini 2.5 Flash (`gemini-2.5-flash`)                   |             0.0633 | 0.5275              |
+
+### Image: Nano Banana
+
+Token-based billing.
+
+| Model                                            | Input credits / 1K | Output (text) credits / 1K | Output (image) credits / 1K |
+| :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
+| Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image-preview`)   |              0.422 |                      2.532 | 25.32                       |
+| Nano Banana 2 (`gemini-3.1-flash-image-preview`) |             0.1055 |                      0.633 | 12.66                       |
+
+### Video: Google Veo
+
+Total credits = **(credits / sec) × duration**.
+
+| Model                                  | Resolution  | generate_audio | Credits / sec |
+| :------------------------------------- | :---------- | :------------- | :------------ |
+| veo-2.0-generate-001                   | —           | —              | 105.5         |
+| veo-3.1-lite                           | 720p        | false          | 6.33          |
+| veo-3.1-lite                           | 720p        | true           | 10.55         |
+| veo-3.1-lite                           | 1080p       | false          | 10.55         |
+| veo-3.1-lite                           | 1080p       | true           | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | false          | 16.88         |
+| veo-3.1-fast-generate                  | 720p        | true           | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | false          | 21.1          |
+| veo-3.1-fast-generate                  | 1080p       | true           | 25.32         |
+| veo-3.1-fast-generate                  | 4k          | false          | 52.75         |
+| veo-3.1-fast-generate                  | 4k          | true           | 63.3          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | false          | 42.2          |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | true           | 84.4          |
+| veo-3.1-generate                       | 4k          | false          | 84.4          |
+| veo-3.1-generate                       | 4k          | true           | 126.6         |
+| veo-3.0-fast-generate-001              | —           | false          | 21.1          |
+| veo-3.0-fast-generate-001              | —           | true           | 31.65         |
 
 ## HappyHorse
 
-| Product Name                        | Configuration                       | Credits     | Category |
-| :---------------------------------- | :---------------------------------- | :---------- | :------- |
-| HappyHorse Video Generation Product | model: happyhorse1.0, resolution: 720P  | 29.54 / sec | Video    |
-| HappyHorse Video Generation Product | model: happyhorse1.0, resolution: 1080P | 50.64 / sec | Video    |
-| HappyHorse Video Generation Product | model: happyhorse1.1, resolution: 720P  | 42.24 / sec | Video    |
-| HappyHorse Video Generation Product | model: happyhorse1.1, resolution: 1080P | 54.31 / sec | Video    |
+Total credits = **(credits / sec) × `duration`**.
 
-HappyHorse 1.1 supports text-to-video, image-to-video, and reference-to-video at the same price.
+| Model          | Resolution | Credits / sec |
+| :------------- | :--------- | :------------ |
+| HappyHorse 1.0 | 720P       | 29.54         |
+| HappyHorse 1.0 | 1080P      | 50.64         |
+| HappyHorse 1.1 | 720P       | 42.24         |
+| HappyHorse 1.1 | 1080P      | 54.31         |
+
+**HappyHorse Video Edit** supports **HappyHorse 1.0** only. Billed at the same rates; total credits = **(credits / sec) × output duration** (3–15 sec, matches the input video).
 
 ## Hitpaw
 
-### Video Enhancement
+### Video: HitPaw Video Enhance
 
-| Product Name                     | Configuration                                     | Credits     | Category |
-| :------------------------------- | :------------------------------------------------ | :---------- | :------- |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: &lt;30fps  | 2.11 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: 30-60fps   | 4.22 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: 60-120fps  | 8.44 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 720P, fps: ≥120fps    | 12.66 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: &lt;30fps | 3.17 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: 30-60fps  | 6.33 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: 60-120fps | 12.66 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 1080P, fps: ≥120fps   | 18.99 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: &lt;30fps    | 4.22 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: 30-60fps     | 8.23 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: 60-120fps    | 16.46 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 2K, fps: ≥120fps      | 24.69 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: &lt;30fps    | 5.28 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: 30-60fps     | 10.76 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: 60-120fps    | 21.31 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 4K, fps: ≥120fps      | 32.07 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: &lt;30fps    | 6.96 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: 30-60fps     | 13.93 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: 60-120fps    | 27.85 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Standard, resolution: 8K, fps: ≥120fps      | 41.78 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: &lt;30fps     | 3.17 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: 30-60fps      | 6.54 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: 60-120fps     | 13.08 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 720P, fps: ≥120fps       | 19.41 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: &lt;30fps    | 4.22 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: 30-60fps     | 8.44 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: 60-120fps    | 16.88 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 1080P, fps: ≥120fps      | 25.32 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: &lt;30fps       | 5.49 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: 30-60fps        | 10.97 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: 60-120fps       | 21.94 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 2K, fps: ≥120fps         | 32.92 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: &lt;30fps       | 7.17 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: 30-60fps        | 14.35 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: 60-120fps       | 28.49 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 4K, fps: ≥120fps         | 42.83 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: &lt;30fps       | 9.28 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: 30-60fps        | 18.57 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: 60-120fps       | 37.14 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Ultra, resolution: 8K, fps: ≥120fps         | 55.7 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: &lt;30fps       | 3.17 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: 30-60fps        | 6.33 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: 60-120fps       | 12.66 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 720P, fps: ≥120fps         | 18.99 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: &lt;30fps      | 5.28 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: 30-60fps       | 10.55 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: 60-120fps      | 21.1 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 1080P, fps: ≥120fps        | 31.65 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: &lt;30fps         | 8.02 / sec  | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: 30-60fps          | 15.82 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: 60-120fps         | 31.65 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 2K, fps: ≥120fps           | 47.48 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: &lt;30fps    | 11.82 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: 30-60fps     | 23.84 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: 60-120fps    | 47.48 / sec | Video    |
-| Hitpaw Video Enhancement Product | type: Gen, resolution: 4K / 8K, fps: ≥120fps      | 71.32 / sec | Video    |
+Total credits = **(credits / sec) × video duration**. Rates depend on input FPS.
 
-### Photo Enhancement
+**Portrait Restore / General Restore** (Portrait Restore 1x/2x, General Restore 1x/2x/4x):
 
-| Product Name                     | Configuration                                  | Credits      | Category |
-| :------------------------------- | :--------------------------------------------- | :----------- | :------- |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: &lt;8MP            | 2.11 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 8-12MP             | 4.22 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 12-24MP            | 6.33 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 24-48MP            | 14.77 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 48-108MP           | 29.54 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 108-216MP          | 50.64 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Standard, megapixels: 216-432MP          | 101.28 / run | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: &lt;8MP | 4.22 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 8-12MP  | 6.33 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 12-24MP | 8.44 / run   | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative Portrait, megapixels: 24-34MP | 12.66 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: &lt;8MP          | 10.55 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 8-12MP           | 12.66 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 12-24MP          | 16.88 / run  | Image    |
-| Hitpaw Photo Enhancement Product | type: Generative, megapixels: 24-34MP          | 31.65 / run  | Image    |
+| Resolution | FPS       | Credits / sec |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 2.11          |
+| 720P       | 30–60fps  | 4.22          |
+| 720P       | 60–120fps | 8.44          |
+| 720P       | ≥120fps   | 12.66         |
+| 1080P      | &lt;30fps | 3.17          |
+| 1080P      | 30–60fps  | 6.33          |
+| 1080P      | 60–120fps | 12.66         |
+| 1080P      | ≥120fps   | 18.99         |
+| 2K         | &lt;30fps | 4.22          |
+| 2K         | 30–60fps  | 8.23          |
+| 2K         | 60–120fps | 16.46         |
+| 2K         | ≥120fps   | 24.69         |
+| 4K         | &lt;30fps | 5.28          |
+| 4K         | 30–60fps  | 10.76         |
+| 4K         | 60–120fps | 21.31         |
+| 4K         | ≥120fps   | 32.07         |
+| 8K         | &lt;30fps | 6.96          |
+| 8K         | 30–60fps  | 13.93         |
+| 8K         | 60–120fps | 27.85         |
+| 8K         | ≥120fps   | 41.78         |
+
+**Ultra HD** (Ultra HD Model 2x):
+
+| Resolution | FPS       | Credits / sec |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 3.17          |
+| 720P       | 30–60fps  | 6.54          |
+| 720P       | 60–120fps | 13.08         |
+| 720P       | ≥120fps   | 19.41         |
+| 1080P      | &lt;30fps | 4.22          |
+| 1080P      | 30–60fps  | 8.44          |
+| 1080P      | 60–120fps | 16.88         |
+| 1080P      | ≥120fps   | 25.32         |
+| 2K         | &lt;30fps | 5.49          |
+| 2K         | 30–60fps  | 10.97         |
+| 2K         | 60–120fps | 21.94         |
+| 2K         | ≥120fps   | 32.92         |
+| 4K         | &lt;30fps | 7.17          |
+| 4K         | 30–60fps  | 14.35         |
+| 4K         | 60–120fps | 28.49         |
+| 4K         | ≥120fps   | 42.83         |
+| 8K         | &lt;30fps | 9.28          |
+| 8K         | 30–60fps  | 18.57         |
+| 8K         | 60–120fps | 37.14         |
+| 8K         | ≥120fps   | 55.7          |
+
+**Generative** (Generative Model 1x; up to 4K):
+
+| Resolution | FPS       | Credits / sec |
+| :--------- | :-------- | :------------ |
+| 720P       | &lt;30fps | 3.17          |
+| 720P       | 30–60fps  | 6.33          |
+| 720P       | 60–120fps | 12.66         |
+| 720P       | ≥120fps   | 18.99         |
+| 1080P      | &lt;30fps | 5.28          |
+| 1080P      | 30–60fps  | 10.55         |
+| 1080P      | 60–120fps | 21.1          |
+| 1080P      | ≥120fps   | 31.65         |
+| 2K         | &lt;30fps | 8.02          |
+| 2K         | 30–60fps  | 15.82         |
+| 2K         | 60–120fps | 31.65         |
+| 2K         | ≥120fps   | 47.48         |
+| 4K         | &lt;30fps | 11.82         |
+| 4K         | 30–60fps  | 23.84         |
+| 4K         | 60–120fps | 47.48         |
+| 4K         | ≥120fps   | 71.32         |
+
+### Image: HitPaw General Image Enhance
+
+**Generative Portrait**:
+
+| Megapixels | Credits / run |
+| :--------- | :------------ |
+| &lt;8MP    | 4.22          |
+| 8–12MP     | 6.33          |
+| 12–24MP    | 8.44          |
+| 24–34MP    | 12.66         |
+
+**Generative**:
+
+| Megapixels | Credits / run |
+| :--------- | :------------ |
+| &lt;8MP    | 10.55         |
+| 8–12MP     | 12.66         |
+| 12–24MP    | 16.88         |
+| 24–34MP    | 31.65         |
 
 ## Ideogram
 
-| Product Name                              | Configuration                                                          | Credits     | Category |
-| :---------------------------------------- | :--------------------------------------------------------------------- | :---------- | :------- |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: DEFAULT     | 45.26 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: QUALITY     | 60.35 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: TURBO       | 30.17 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: BALANCED                  | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: DEFAULT                   | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: QUALITY                   | 27.16 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: TURBO                     | 9.05 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: DEFAULT | 45.26 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: QUALITY | 60.35 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: TURBO   | 30.17 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: BALANCED              | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: DEFAULT               | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: QUALITY               | 27.16 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: TURBO                 | 9.05 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: DEFAULT                | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: QUALITY                | 27.16 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: TURBO                  | 9.05 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: BALANCED                 | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: DEFAULT                  | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: QUALITY                  | 27.16 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: TURBO                    | 9.05 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: BALANCED    | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: DEFAULT     | 18.1 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: QUALITY     | 27.16 / run | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: TURBO       | 9.05 / run  | Image    |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: remix, rendering_speed: TURBO                                | 9.05 / run  | Image    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: TURBO                 | 9.05 / run  | Image    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: DEFAULT               | 18.1 / run  | Image    |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: QUALITY               | 30.17 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2                                             | 24.14 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2_turbo                                       | 15.09 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1                                         | 18.1 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1_turbo                                   | 6.03 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a                                        | 12.07 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a_turbo                                  | 7.54 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2                                         | 24.14 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2_turbo                                   | 15.09 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2                                          | 24.14 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2_turbo                                    | 15.09 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1                                            | 18.1 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1_turbo                                      | 6.03 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a                                           | 12.07 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a_turbo                                     | 7.54 / run  | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2                                            | 24.14 / run | Image    |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2_turbo                                      | 15.09 / run | Image    |
+| Node        | turbo | Character reference | rendering_speed | Credits / image |
+| :---------- | :---- | :------------------ | :-------------- | :-------------- |
+| Ideogram V1 | false | —                   | —               | 18.1            |
+| Ideogram V1 | true  | —                   | —               | 6.03            |
+| Ideogram V2 | false | —                   | —               | 24.14           |
+| Ideogram V2 | true  | —                   | —               | 15.09           |
+| Ideogram V3 | —     | No                  | TURBO           | 9.05            |
+| Ideogram V3 | —     | No                  | DEFAULT         | 18.1            |
+| Ideogram V3 | —     | No                  | QUALITY         | 27.16           |
+| Ideogram V3 | —     | Yes                 | TURBO           | 30.17           |
+| Ideogram V3 | —     | Yes                 | DEFAULT         | 45.26           |
+| Ideogram V3 | —     | Yes                 | QUALITY         | 60.35           |
+| Ideogram V4 | —     | —                   | TURBO           | 9.05            |
+| Ideogram V4 | —     | —                   | DEFAULT         | 18.1            |
+| Ideogram V4 | —     | —                   | QUALITY         | 30.17           |
 
 ## Krea
 
-| Product Name | Configuration | Credits | Category |
-| :----------- | :------------ | :------ | :------- |
-| Krea 2 Image Generation | model: krea-2-medium-turbo | 3.2 / run | Image |
-| Krea 2 Image Generation | model: krea-2-medium-turbo, with image style reference | 3.7 / run | Image |
-| Krea 2 Image Generation | model: krea-2-medium-turbo, with moodboard | 4.2 / run | Image |
-| Krea 2 Image Generation | model: krea-2-medium | 6.4 / run | Image |
-| Krea 2 Image Generation | model: krea-2-medium, with image style reference | 7.4 / run | Image |
-| Krea 2 Image Generation | model: krea-2-medium, with moodboard | 8.5 / run | Image |
-| Krea 2 Image Generation | model: krea-2-large | 12.7 / run | Image |
-| Krea 2 Image Generation | model: krea-2-large, with image style reference | 13.8 / run | Image |
-| Krea 2 Image Generation | model: krea-2-large, with moodboard | 14.8 / run | Image |
+| Model               | Style reference | Moodboard | Credits / run |
+| :------------------ | :-------------- | :-------- | :------------ |
+| Krea 2 Medium Turbo | No              | No        | 3.17          |
+| Krea 2 Medium Turbo | Yes             | No        | 3.69          |
+| Krea 2 Medium Turbo | —               | Yes       | 4.22          |
+| Krea 2 Medium       | No              | No        | 6.33          |
+| Krea 2 Medium       | Yes             | No        | 7.39          |
+| Krea 2 Medium       | —               | Yes       | 8.44          |
+| Krea 2 Large        | No              | No        | 12.66         |
+| Krea 2 Large        | Yes             | No        | 13.72         |
+| Krea 2 Large        | —               | Yes       | 14.77         |
 
 ## Kling
 
-| Product Name                              | Configuration                                                | Credits      | Category |
-| :---------------------------------------- | :----------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v1                                   | 103.39 / run | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v1-5                                 | 103.39 / run | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v1-6                                 | 103.39 / run | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v2-1                                 | 103.39 / run | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v2-1-master                          | 295.4 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v2-5-turbo                           | 73.85 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: pro, model: kling-v2-master                            | 295.4 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v1                                   | 29.54 / sec  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v1-5                                 | 59.08 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v1-6                                 | 59.08 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v2-1                                 | 59.08 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v2-1-master                          | 295.4 / run  | Video    |
-| prod-v1-Kling Video Generation Product    | mode: std, model: kling-v2-master                            | 295.4 / run  | Video    |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v2-6, sound: off                     | 14.77 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v2-6, sound: on                      | 29.54 / sec  | Video    |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-v3, no_sound: true           | 23.63 / sec  | Video    |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-v3, no_sound: false          | 35.45 / sec  | Video    |
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-v3, no_sound: true            | 17.72 / sec  | Video    |
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-v3, no_sound: false           | 26.59 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-omni, no_sound: true              | 23.63 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-omni, no_sound: false             | 29.54 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: std, model: kling-v3-omni, no_sound: true              | 17.72 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: std, model: kling-v3-omni, no_sound: false             | 23.63 / sec  | Video    |
-| Kling Video Generation with Sound Product | mode: pro, model: kling-v3-4k                                | 88.62 / sec  | Video    |
-|
-| Kling Video Generation with Sound Product | resolution: 720p, model: kling-3.0-turbo | 23.63 / sec | Video |
-| Kling Video Generation with Sound Product | resolution: 1080p, model: kling-3.0-turbo | 29.54 / sec | Video |
-| Kling Omni Video Product                  | generate_with_video: false, mode: pro, model: kling-video-o1 | 23.63 / sec  | Video    |
-| Kling Omni Video Product                  | generate_with_video: false, mode: std, model: kling-video-o1 | 17.72 / sec  | Video    |
-| Kling Omni Video Product                  | generate_with_video: true, mode: pro, model: kling-video-o1  | 35.45 / sec  | Video    |
-| Kling Omni Video Product                  | generate_with_video: true, mode: std, model: kling-video-o1  | 26.59 / sec  | Video    |
-| Kling Video Extension Product             | NA                                                           | 59.08 / run  | Video    |
-| Kling Lip Sync Product                    | NA                                                           | 14.77 / run  | Image    |
-| Kling Motion Control Product              | mode: std, model: kling-v2-6                                 | 14.77 / run  | Image    |
-| Kling Motion Control Product              | mode: pro, model: kling-v2-6                                 | 23.63 / run  | Image    |
-| Kling Virtual Try On                      | model: kolors-virtual-try-on-v1                              | 14.77 / run  | Image    |
-| Kling Virtual Try On                      | model: kolors-virtual-try-on-v1-5                            | 14.77 / run  | Image    |
-| Kling Image Generation Product            | model: kling-v1, operation: text_to_image                    | 0.74 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v1, operation: image_to_image                   | 0.74 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v1-5, operation: text_to_image                  | 2.95 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v1-5, operation: image_to_image                 | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v2, operation: text_to_image                    | 2.95 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v2-new, operation: image_to_image_restyle       | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v2-1, operation: text_to_image                  | 2.95 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: text_to_image         | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 2k, operation: text_to_image         | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: image_to_image        | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 2k, operation: image_to_image        | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 1k, operation: image_editing         | 11.82 / run  | Image    |
-| Kling Image Generation Product            | model: kling-v3, specs: 4k, operation: image_editing         | 11.82 / run  | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: text_to_image    | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 2k, operation: text_to_image    | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: image_to_image   | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 2k, operation: image_to_image   | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 1k, operation: image_editing    | 11.82 / run  | Image    |
-| Kling Image Generation Product            | model: kling-v3-omni, specs: 4k, operation: image_editing    | 11.82 / run  | Image    |
-| Kling Image Generation Product            | model: kling-image-o1, operation: text_to_image               | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-image-o1, operation: image_to_image              | 5.91 / run   | Image    |
-| Kling Image Generation Product            | model: kling-image-o1, operation: image_editing               | 5.91 / run   | Image    |
-| Kling Image Generation w/ N               | model: kling-v1, operation: text_to_image                    | 0.74 / run   | Image    |
-| Kling Image Generation w/ N               | model: kling-v1, operation: image_to_image                   | 0.74 / run   | Image    |
-| Kling Image Generation w/ N               | model: kling-v1-5, operation: text_to_image                  | 2.95 / run   | Image    |
-| Kling Image Generation w/ N               | model: kling-v1-5, operation: image_to_image                 | 5.91 / run   | Image    |
-| Kling Image Generation w/ N               | model: kling-v2, operation: text_to_image                    | 2.95 / run   | Image    |
-| Kling Credits                             | type: image                                                  | 0.74 / run   | Image    |
-| Kling Credits                             | type: video                                                  | 29.54 / run  | Image    |
-| Kling Camera Control Product              | type: text-to-video                                           | 29.54 / run  | Video    |
-| Kling Camera Control Product              | type: image-to-video                                          | 103.39 / run | Video    |
-| Kling Avatar Product                      | mode: std                                                     | 11.82 / sec  | Video    |
-| Kling Avatar Product                      | mode: pro                                                     | 23.63 / sec  | Video    |
-| Kling 2.6 Audio Product                   | mode: text-to-video, no_sound: true                           | 14.77 / sec  | Video    |
-| Kling 2.6 Audio Product                   | mode: text-to-video, no_sound: false                          | 29.54 / sec  | Video    |
-| Kling 2.6 Audio Product                   | mode: image-to-video, no_sound: true                          | 14.77 / sec  | Video    |
-| Kling 2.6 Audio Product                   | mode: image-to-video, no_sound: false                         | 29.54 / sec  | Video    |
+### Video: Credits / sec
+
+Total credits = **(credits / sec) × `duration`**, except **Kling 3.0 Omni Edit Video** and **Kling Motion Control** (billed per second of output; duration follows input video on Edit).
+
+#### kling-video-o1
+
+| task                 | resolution | Credits / sec |
+| :------------------- | :--------- | :------------ |
+| generation           | 720p       | 17.72         |
+| generation           | 1080p      | 23.63         |
+| video to video, edit | 720p       | 26.59         |
+| video to video, edit | 1080p      | 35.45         |
+
+#### kling-v3-omni
+
+| task                 | resolution | generate_audio | Credits / sec |
+| :------------------- | :--------- | :------------- | :------------ |
+| generation           | 720p       | false          | 17.72         |
+| generation           | 720p       | true           | 23.63         |
+| generation           | 1080p      | false          | 23.63         |
+| generation           | 1080p      | true           | 29.54         |
+| generation           | 4k         | false, true    | 88.62         |
+| video to video, edit | 720p       | —              | 26.59         |
+| video to video, edit | 1080p      | —              | 35.45         |
+
+#### kling-3.0-turbo
+
+Always generates audio; the audio toggle is ignored.
+
+| resolution | Credits / sec |
+| :--------- | :------------ |
+| 720p       | 23.63         |
+| 1080p      | 29.54         |
+
+#### kling-v3
+
+| task       | resolution | generate_audio | Credits / sec |
+| :--------- | :--------- | :------------- | :------------ |
+| generation | 720p       | false          | 17.72         |
+| generation | 720p       | true           | 26.59         |
+| generation | 1080p      | false          | 23.63         |
+| generation | 1080p      | true           | 35.45         |
+| generation | 4k         | false, true    | 88.62         |
+
+| task           | mode | Credits / sec |
+| :------------- | :--- | :------------ |
+| motion control | std  | 26.59         |
+| motion control | pro  | 35.45         |
+
+#### kling-v2-6
+
+| task           | generate_audio | mode | Credits / sec |
+| :------------- | :------------- | :--- | :------------ |
+| generation     | false          | —    | 14.77         |
+| generation     | true           | —    | 29.54         |
+| motion control | —              | std  | 14.77         |
+| motion control | —              | pro  | 23.63         |
+
+#### Legacy (v2-5-turbo, v2-master, v1.x)
+
+| Model                                        | mode     | Credits / sec |
+| :------------------------------------------- | :------- | :------------ |
+| kling-v2-5-turbo                             | pro      | 14.77         |
+| kling-v2-master, kling-v2-1-master           | std, pro | 59.08         |
+| kling-v1-5, kling-v1-6, kling-v2-1           | std      | 11.82         |
+| kling-v1                                     | std      | 5.91          |
+| kling-v1, kling-v1-5, kling-v1-6, kling-v2-1 | pro      | 20.68         |
+
+#### Kling Avatar 2.0
+
+| mode | Credits / sec |
+| :--- | :------------ |
+| std  | 11.82         |
+| pro  | 23.63         |
+
+**Kling Text/Image to Video (Camera Control)**: fixed **5s** at `kling-v1` std or `kling-v1-5` pro (Legacy table).
+
+### Video: Credits / run
+
+| Model      | task                       | Credits / run |
+| :--------- | :------------------------- | :------------ |
+| kling-v1-6 | Most effect scenes         | 59.08         |
+| kling-v1-6 | `dizzydizzy`, `bloombloom` | 103.39        |
+| —          | Video Extend               | 59.08         |
+| —          | Lip Sync                   | 21.1          |
+
+### Image
+
+| Model                                                | resolution | Image input | Credits       |
+| :--------------------------------------------------- | :--------- | :---------- | :------------ |
+| kling-image-o1                                       | 1K, 2K     | —           | 5.91 / image  |
+| kling-image-o1                                       | 4K         | —           | 11.82 / image |
+| kling-v3-omni                                        | 1K, 2K     | —           | 5.91 / image  |
+| kling-v3-omni                                        | 4K         | —           | 11.82 / image |
+| kling-v3                                             | —          | No          | 5.91 / image  |
+| kling-v2                                             | —          | No, Yes     | 2.95 / image  |
+| kling-v1-5                                           | —          | No          | 2.95 / image  |
+| kling-v1-5                                           | —          | Yes         | 5.91 / image  |
+| kolors-virtual-try-on-v1, kolors-virtual-try-on-v1-5 | —          | —           | 147.7 / run   |
+
+Total image credits = **(credits / image) × `n`** on **Kling 3.0 Image**; multiply by `series_amount` on **Kling 3.0 Omni Image** (`kling-image-o1` always ×1).
 
 ## Lightricks
 
-| Product Name                 | Configuration                                                      | Credits     | Category |
-| :--------------------------- | :----------------------------------------------------------------- | :---------- | :------- |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-fast, resolution: 1920x1080 | 8.44 / sec  | Video    |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-fast, resolution: 2560x1440 | 16.88 / sec | Video    |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-fast, resolution: 3840x2160 | 33.76 / sec | Video    |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-pro, resolution: 1920x1080  | 12.66 / sec | Video    |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-pro, resolution: 2560x1440  | 25.32 / sec | Video    |
-| Ltx Video generation product | endpoint: image-to-video, model: ltx-2-pro, resolution: 3840x2160  | 50.64 / run | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-fast, resolution: 1920x1080  | 8.44 / sec  | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-fast, resolution: 2560x1440  | 16.88 / sec | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-fast, resolution: 3840x2160  | 33.76 / sec | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-pro, resolution: 1920x1080   | 12.66 / sec | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-pro, resolution: 2560x1440   | 25.32 / sec | Video    |
-| Ltx Video generation product | endpoint: text-to-video, model: ltx-2-pro, resolution: 3840x2160   | 50.64 / run | Video    |
+### Video: Credits / sec
+
+Total credits = **(credits / sec) × `duration`**.
+
+| Model        | resolution | Credits      |
+| :----------- | :--------- | :----------- |
+| LTX-2 (Pro)  | 1080p      | 12.66 / sec  |
+| LTX-2 (Pro)  | 1440p      | 25.32 / sec  |
+| LTX-2 (Pro)  | 4K         | 50.64 / sec  |
+| LTX-2 (Fast) | 1080p      | 8.44 / sec   |
+| LTX-2 (Fast) | 1440p      | 16.88 / sec  |
+| LTX-2 (Fast) | 4K         | 33.76 / sec  |
+
+Resolution maps to `1920x1080`, `2560x1440`, and `3840x2160`. Durations over 10s are only available on **LTX-2 (Fast)** at 1080p and 25 FPS.
 
 ## Luma
 
-| Product Name                                        | Configuration                                                                                          | Credits      | Category |
-| :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Luma Video Generation Product               | model: ray-1-6                                                                                         | 0.97 / sec   | Video    |
-| prod-v1-Luma Video Generation Product               | model: ray-2                                                                                           | 1.93 / sec   | Video    |
-| prod-v1-Luma Video Generation Product               | model: ray-flash-2                                                                                     | 0.66 / sec   | Video    |
-| Luma Image Generations (millions of pixels) Product | model: photon-1                                                                                        | 2.2 / run    | Image    |
-| Luma Image Generations (millions of pixels) Product | model: photon-flash-1                                                                                  | 0.57 / run   | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: text-to-image                                                                      | 8.52 / run   | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-to-image                                                                     | 9.16 / run   | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 1                                           | 9.16 / run   | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 2                                           | 9.79 / run   | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 3                                           | 10.42 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 4                                           | 11.06 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 5                                           | 11.69 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 6                                           | 12.32 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 7                                           | 12.96 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 8                                           | 13.59 / run  | Image    |
-| Luma Agents uni-1 Image Product                     | model: uni-1, task: image-reference, num_reference_images: 9                                           | 14.22 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: text-to-image                                                                  | 21.10 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-to-image                                                                 | 21.73 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 1                                       | 21.73 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 2                                       | 22.37 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 3                                       | 23.00 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 4                                       | 23.63 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 5                                       | 24.27 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 6                                       | 24.90 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 7                                       | 25.53 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 8                                       | 26.16 / run  | Image    |
-| Luma Agents uni-1-max Image Product                 | model: uni-1-max, task: image-reference, num_reference_images: 9                                       | 26.80 / run  | Image    |
+### Video
 
+Flat **/run** prices match the node badge for each `duration` choice. **Edit** and **reframe** bill **(credits / sec) × video length**. **ray-1-6** is always **105.50 / run**.
 
+| Model       | task       | resolution | Credits                                           |
+| :---------- | :--------- | :--------- | :------------------------------------------------ |
+| ray-3.2     | generation | 360p       | 12.66 / run (5s), 37.98 / run (10s)               |
+| ray-3.2     | generation | 540p       | 31.65 / run (5s), 94.95 / run (10s)               |
+| ray-3.2     | generation | 720p       | 63.30 / run (5s), 189.90 / run (10s)              |
+| ray-3.2     | generation | 1080p      | 253.20 / run (5s), 759.60 / run (10s)             |
+| ray-3.2     | edit       | 360p       | 22.79 / sec                                       |
+| ray-3.2     | edit       | 540p       | 30.38 / sec                                       |
+| ray-3.2     | edit       | 720p       | 45.58 / sec                                       |
+| ray-3.2     | edit       | 1080p      | 91.15 / sec                                       |
+| ray-3.2     | reframe    | 360p       | 6.33 / sec                                        |
+| ray-3.2     | reframe    | 540p       | 12.66 / sec                                       |
+| ray-3.2     | reframe    | 720p       | 25.32 / sec                                       |
+| ray-3.2     | reframe    | 1080p      | 75.96 / sec                                       |
+| ray-2       | generation | 540p       | 120.27 / run (5s), 217.33 / run (9s)              |
+| ray-2       | generation | 720p       | 215.22 / run (5s), 386.13 / run (9s)              |
+| ray-2       | generation | 1080p      | 478.97 / run (5s), 865.10 / run (9s)              |
+| ray-2       | generation | 4K         | 1922.21 / run (5s), 3460.40 / run (9s)            |
+| ray-flash-2 | generation | 540p       | 42.20 / run (5s), 75.96 / run (9s)                |
+| ray-flash-2 | generation | 720p       | 71.74 / run (5s), 128.71 / run (9s)               |
+| ray-flash-2 | generation | 1080p      | 166.69 / run (5s), 299.62 / run (9s)              |
+| ray-flash-2 | generation | 4K         | 660.43 / run (5s), 1192.15 / run (9s)             |
+| ray-1-6     | generation | —          | 105.50 / run                                      |
 
-### Luma Ray 3.2 Video
+**Luma Ray 3.2** Image to Video and Extend Video always bill the **5s** price. Legacy Image to Video uses **5s** or **9s** from **ray-2** / **ray-flash-2** rows.
 
-| Product Name | Configuration | Credits | Category |
-| :----------- | :------------ | :------ | :------- |
-| Luma Ray 3.2 Video Generation | resolution: 360p, duration: 5s | 12.66 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 360p, duration: 10s | 37.98 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 540p, duration: 5s | 31.65 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 540p, duration: 10s | 94.95 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 720p, duration: 5s | 63.30 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 720p, duration: 10s | 189.90 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 1080p, duration: 5s | 253.20 / run | Video |
-| Luma Ray 3.2 Video Generation | resolution: 1080p, duration: 10s | 759.60 / run | Video |
-| Luma Ray 3.2 Video Edit | resolution: 360p | 113.94 (5s) - 227.88 (10s) / run | Video |
-| Luma Ray 3.2 Video Edit | resolution: 540p | 151.92 (5s) - 303.84 (10s) / run | Video |
-| Luma Ray 3.2 Video Edit | resolution: 720p | 227.88 (5s) - 455.76 (10s) / run | Video |
-| Luma Ray 3.2 Video Edit | resolution: 1080p | 455.76 (5s) - 911.52 (10s) / run | Video |
-| Luma Ray 3.2 Video Reframe | resolution: 360p | 6.33 / second | Video |
-| Luma Ray 3.2 Video Reframe | resolution: 540p | 12.66 / second | Video |
-| Luma Ray 3.2 Video Reframe | resolution: 720p | 25.32 / second | Video |
-| Luma Ray 3.2 Video Reframe | resolution: 1080p | 75.96 / second | Video |
+### Image
+
+| Model          | task       | Credits                              |
+| :------------- | :--------- | :----------------------------------- |
+| photon-flash-1 | —          | 0.57 / run                           |
+| photon-1       | —          | 2.19 / run                           |
+| uni-1          | generation | 8.52 / run + 0.63 / ref image (≤ 9)  |
+| uni-1          | edit       | 9.16 / run + 0.63 / ref image (≤ 8)  |
+| uni-1-max      | generation | 21.10 / run + 0.63 / ref image (≤ 9) |
+| uni-1-max      | edit       | 21.73 / run + 0.63 / ref image (≤ 8) |
+
+Reference-image surcharge uses USD rounded to 4 decimals before converting to credits.
 
 ## Meshy
 
-| Product Name            | Configuration                                               | Credits     | Category |
-| :---------------------- | :---------------------------------------------------------- | :---------- | :------- |
-| Meshy Retexture         | NA                                                          | 84.4 / run  | 3D       |
-| Meshy Rigging           | NA                                                          | 42.2 / run  | 3D       |
-| Meshy Remesh            | NA                                                          | 42.2 / run  | 3D       |
-| Meshy Animation         | NA                                                          | 25.32 / run | 3D       |
-| Meshy Multi Image to 3D | should_texture: false                                       | 42.2 / run  | Image    |
-| Meshy Multi Image to 3D | should_texture: true                                        | 126.6 / run | Image    |
-| Meshy Text to 3D        | mode: preview, model: latest                                | 168.8 / run | 3D       |
-| Meshy Text to 3D        | mode: preview, model: meshy-5                               | 42.2 / run  | 3D       |
-| Meshy Text to 3D        | mode: refine, model: latest                                 | 84.4 / run  | 3D       |
-| Meshy Image to 3D       | model: latest, model_type: lowpoly, should_texture: false   | 168.8 / run | Image    |
-| Meshy Image to 3D       | model: latest, model_type: lowpoly, should_texture: true    | 253.2 / run | Image    |
-| Meshy Image to 3D       | model: latest, model_type: standard, should_texture: false  | 168.8 / run | Image    |
-| Meshy Image to 3D       | model: latest, model_type: standard, should_texture: true   | 253.2 / run | Image    |
-| Meshy Image to 3D       | model: meshy-5, model_type: lowpoly, should_texture: false  | 168.8 / run | Image    |
-| Meshy Image to 3D       | model: meshy-5, model_type: lowpoly, should_texture: true   | 253.2 / run | Image    |
-| Meshy Image to 3D       | model: meshy-5, model_type: standard, should_texture: false | 42.2 / run  | Image    |
-| Meshy Image to 3D       | model: meshy-5, model_type: standard, should_texture: true  | 126.6 / run | Image    |
+| Node                        | should_texture | Credits     |
+| :-------------------------- | :------------- | :---------- |
+| Meshy: Text to Model        | —              | 168.8 / run |
+| Meshy: Refine Draft Model   | —              | 84.4 / run  |
+| Meshy: Image to Model       | No             | 168.8 / run |
+| Meshy: Image to Model       | Yes            | 253.2 / run |
+| Meshy: Multi-Image to Model | No             | 42.2 / run  |
+| Meshy: Multi-Image to Model | Yes            | 126.6 / run |
+| Meshy: Rig Model            | —              | 42.2 / run  |
+| Meshy: Animate Model        | —              | 25.32 / run |
+| Meshy: Texture Model        | —              | 84.4 / run  |
+
+**Meshy: Text to Model** creates a draft mesh; run **Meshy: Refine Draft Model** on the returned `meshy_task_id` to texture it. **Meshy: Image to Model** and **Meshy: Multi-Image to Model** can texture in one step when `should_texture` is enabled.
 
 ## Minimax
 
-| Product Name                                    | Configuration                                            | Credits      | Category |
-| :---------------------------------------------- | :------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Minimax Video Product                   | model: i2v-01-director                                   | 90.73 / run  | Video    |
-| prod-v1-Minimax Video Product                   | model: i2v-01-live                                       | 90.73 / run  | Video    |
-| prod-v1-Minimax Video Product                   | model: i2v-01                                            | 90.73 / run  | Video    |
-| prod-v1-Minimax Video Product                   | model: s2v-01                                            | 137.15 / run | Video    |
-| prod-v1-Minimax Video Product                   | model: t2v-01-director                                   | 90.73 / run  | Video    |
-| prod-v1-Minimax Video Product                   | model: t2v-01                                            | 90.73 / run  | Video    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 10, model: minimax-hailuo-02, resolution: 768P | 118.16 / run | Video    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 6, model: minimax-hailuo-02, resolution: 1080P | 103.39 / run | Video    |
-| Minimax Video Generation_models after Hailuo-02 | duration: 6, model: minimax-hailuo-02, resolution: 768P  | 59.08 / run  | Video    |
+| Node                   | model                                | resolution | Credits                              |
+| :--------------------- | :----------------------------------- | :--------- | :----------------------------------- |
+| MiniMax Text to Video  | T2V-01, T2V-01-Director              | —          | 90.73 / run                          |
+| MiniMax Image to Video | I2V-01, I2V-01-Director, I2V-01-live | —          | 90.73 / run                          |
+| MiniMax Hailuo Video   | MiniMax-Hailuo-02                    | 768P       | 59.08 / run (6s), 118.16 / run (10s) |
+| MiniMax Hailuo Video   | MiniMax-Hailuo-02                    | 1080P      | 103.39 / run (6s)                    |
 
-## Moonvalley
-
-<Warning>
-  **Service unavailable**: The Moonvalley API service is no longer available. The nodes listed below have been deprecated and may not function as expected.
-</Warning>
-
-| Product Name                  | Configuration | Credits      | Category |
-| :---------------------------- | :------------ | :----------- | :------- |
-| Moonvalley Image-to-Video 5s  | NA            | 316.5 / run  | Video    |
-| Moonvalley Image-to-Video 10s | NA            | 633 / run    | Video    |
-| Moonvalley Text-to-Video 5s   | NA            | 316.5 / run  | Video    |
-| Moonvalley Text-to-Video 10s  | NA            | 633 / run    | Video    |
-| Moonvalley Video-to-Video 5s  | NA            | 474.75 / run | Video    |
-| Moonvalley Video-to-Video 10s | NA            | 844 / run    | Video    |
+**MiniMax Hailuo Video** only supports **6s** at 1080P.
 
 ## OpenAI
 
-OpenAI partner nodes bill the same underlying USD usage as the public API. **Credits = USD × 211** (see page header). Text-model USD rates below match OpenAI’s **[API pricing](https://developers.openai.com/api/docs/pricing)** **Standard** tier (per 1M tokens) as published on that page; image-token multipliers match `comfy_api_nodes/nodes_openai.py`. DALL·E and Sora fixed math matches the nodes’ `price_badge` expressions. Final charges follow metered usage (tokens, duration, and any cache hits).
+**Credits = USD × 211.** DALL·E and Sora use fixed per-image or per-second rates. **OpenAI GPT Image 2** and **OpenAI ChatGPT** bill from API token usage.
 
-### DALL·E 2 (`OpenAIDalle2`)
+### Image: DALL·E
 
-Per generated image (multiply by `n` when you request more than one).
+**DALL·E 2** supports **256×256**, **512×512**, or **1024×1024**; total credits = **(credits / image) × `n`**. **DALL·E 3** adds **`quality`** (`standard` / `hd`) and supports **1024×1024** or portrait **1024×1792** / **1792×1024**.
 
-| Product Name          | Configuration   | Credits / image | Category |
-| :-------------------- | :-------------- | :-------------- | :------- |
-| OpenAI DALL·E 2 image | size: 256x256   | 3.38            | Image    |
-| OpenAI DALL·E 2 image | size: 512x512   | 3.80            | Image    |
-| OpenAI DALL·E 2 image | size: 1024x1024 | 4.22            | Image    |
+| Node            | quality  | size                 | Credits      |
+| :-------------- | :------- | :------------------- | :----------- |
+| OpenAI DALL·E 2 | —        | 256x256              | 3.38 / image |
+|                 | —        | 512x512              | 3.80 / image |
+|                 | —        | 1024x1024            | 4.22 / image |
+| OpenAI DALL·E 3 | standard | 1024x1024            | 8.44 / run   |
+|                 | standard | 1024x1792, 1792x1024 | 16.88 / run  |
+|                 | hd       | 1024x1024            | 16.88 / run  |
+|                 | hd       | 1024x1792, 1792x1024 | 25.32 / run  |
 
-### DALL·E 3 (`OpenAIDalle3`)
+### Image: GPT Image
 
-| Product Name          | Configuration                                      | Credits / run | Category |
-| :-------------------- | :------------------------------------------------- | :------------ | :------- |
-| OpenAI DALL·E 3 image | quality: standard, size: 1024x1024                 | 8.44          | Image    |
-| OpenAI DALL·E 3 image | quality: standard, size: 1024x1792 or 1792x1024      | 16.88         | Image    |
-| OpenAI DALL·E 3 image | quality: hd, size: 1024x1024                       | 16.88         | Image    |
-| OpenAI DALL·E 3 image | quality: hd, size: 1024x1792 or 1792x1024          | 25.32         | Image    |
+Billed from API token usage after generation. Approximate badge by `quality` (`low` / `medium` / `high`); actual cost follows token counts below.
 
-### GPT Image 1 / 1.5 / 2 (`OpenAIGPTImage1`)
+| model         | token type     | Credits / 1M |
+| :------------ | :------------- | :----------- |
+| gpt-image-1   | input          | 2110         |
+| gpt-image-1   | output (image) | 8440         |
+| gpt-image-1.5 | input          | 1688         |
+| gpt-image-1.5 | output (image) | 6752         |
+| gpt-image-2   | input          | 1688         |
+| gpt-image-2   | output (image) | 6330         |
 
-Token-based from API usage. Credits = USD × 211 per 1M tokens (rates from the node's `calculate_tokens_price_image_1` / `calculate_tokens_price_image_1_5` helpers).
+The deprecated **OpenAI GPT Image 2** node (older implementation) uses the same models and rates.
 
-| Product Name                         | Configuration    | Credits / 1M tokens | Category |
-| :----------------------------------- | :--------------- | :------------------ | :------- |
-| OpenAI GPT Image input (text/image)  | model: gpt-image-1   | 2110 ($10 / 1M)     | Image    |
-| OpenAI GPT Image output (image)      | model: gpt-image-1   | 8440 ($40 / 1M)     | Image    |
-| OpenAI GPT Image input (text/image)  | model: gpt-image-1.5 | 1688 ($8 / 1M)      | Image    |
-| OpenAI GPT Image output (image)      | model: gpt-image-1.5 | 6752 ($32 / 1M)     | Image    |
-| OpenAI GPT Image input (image)       | model: gpt-image-2   | 1688 ($8 / 1M)      | Image    |
-| OpenAI GPT Image cached input (image)| model: gpt-image-2   | 422 ($2 / 1M)       | Image    |
-| OpenAI GPT Image input (text)        | model: gpt-image-2   | 1055 ($5 / 1M)      | Image    |
-| OpenAI GPT Image cached input (text) | model: gpt-image-2   | 263.75 ($1.25 / 1M) | Image    |
-| OpenAI GPT Image output (image)      | model: gpt-image-2   | 6330 ($30 / 1M)     | Image    |
+### Chat
 
-The UI shows approximate **USD ranges** per run by quality (`low` / `medium` / `high`); actual cost depends on token counts.
+Token-based billing. Badge rates are **per 1K tokens**; table is **per 1M tokens**.
 
-### Chat (`OpenAIChatNode`)
+| Model        | Input credits / 1M | Output credits / 1M |
+| :----------- | -----------------: | :------------------ |
+| gpt-5.5      |               1055 | 6330                |
+| gpt-5.5-pro  |               6330 | 37980               |
+| gpt-5        |             263.75 | 2110                |
+| gpt-5-mini   |              52.75 | 422                 |
+| gpt-5-nano   |              10.55 | 84.4                |
+| gpt-4.1      |                422 | 1688                |
+| gpt-4.1-mini |               84.4 | 337.6               |
+| gpt-4.1-nano |               21.1 | 84.4                |
+| o3           |               2110 | 8440                |
+| o4-mini      |              232.1 | 928.4               |
+| o1           |               3165 | 12660               |
+| o1-pro       |              31650 | 126600              |
 
-Models selectable in the node: `gpt-5.5`, `gpt-5.5-pro`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`, `o1`, `o1-pro`. Standard tier, per 1M tokens (cached column is OpenAI’s cached-input rate where listed). For models with both short- and long-context pricing, the long-context rate applies once the request exceeds the short-context window.
+Optional images and files add input tokens at the same model rates.
 
-| Model                       | Input credits / 1M | Cached input credits / 1M | Output credits / 1M |
-| :-------------------------- | -------------------: | ------------------------: | ------------------: |
-| gpt-5.5 (short context)     | 1055                 | 105.5                     | 6330                |
-| gpt-5.5 (long context)      | 2110                 | 211                       | 9495                |
-| gpt-5.5-pro (short context) | 6330                 | —                         | 37980               |
-| gpt-5.5-pro (long context)  | 12660                | —                         | 56970               |
-| gpt-5                       | 263.75               | 26.38                     | 2110                |
-| gpt-5-mini                  | 52.75                | 5.28                      | 422                 |
-| gpt-5-nano                  | 10.55                | 1.06                      | 84.4                |
-| gpt-4.1                     | 422                  | 105.5                     | 1688                |
-| gpt-4.1-mini                | 84.4                 | 21.1                      | 337.6               |
-| gpt-4.1-nano                | 21.1                 | 5.28                      | 84.4                |
-| o3                          | 422                  | 105.5                     | 1688                |
-| o4-mini                     | 232.1                | 58.03                     | 928.4               |
-| o1                          | 3165                 | 1582.5                    | 12660               |
-| o1-pro                      | 31650                | —                         | 126600              |
+### Video: Sora
 
-Optional images and files add tokens billed at the same model input rates.
+<Warning>
+  **Deprecated**: OpenAI plans to stop serving the Sora v2 API in September 2026. This node may stop working after that date.
+</Warning>
 
-### Sora video (`OpenAIVideoSora2`)
+Total credits = **(credits / sec) × `duration`** (`duration` is 4, 8, or 12).
 
-USD is **(per-second rate) × (duration in seconds)**; duration can be 4, 8, or 12. Credits = USD × 211.
+| model      | size                 | Credits      |
+| :--------- | :------------------- | :----------- |
+| sora-2     | 720x1280, 1280x720   | 21.10 / sec  |
+| sora-2-pro | 720x1280, 1280x720   | 63.30 / sec  |
+| sora-2-pro | 1024x1792, 1792x1024 | 105.50 / sec |
 
-| Product Name                 | Configuration                               | Credits / sec | Category |
-| :--------------------------- | :------------------------------------------ | :------------ | :------- |
-| OpenAI Sora video generation | model: sora-2, size: 720x1280 or 1280x720   | 21.10         | Video    |
-| OpenAI Sora video generation | model: sora-2-pro, size: 720x1280 or 1280x720 | 63.30       | Video    |
-| OpenAI Sora video generation | model: sora-2-pro, size: 1024x1792 or 1792x1024 | 105.50    | Video    |
-
-Example: `sora-2`, 1280x720, 8 seconds → about **168.8** credits ($0.10 × 8 × 211).
+`sora-2` only supports 720x1280 and 1280x720.
 
 ## OpenRouter
 
-### OpenRouter LLM (`OpenRouterLLMNode`)
+Badge rates are **per 1K tokens**; table is **per 1M tokens**. Final charges follow API usage.
 
-Per 1M tokens.
-
-| Model                              | Input credits / 1M | Output credits / 1M |
-| :----------------------------------- | -----------------: | ------------------: |
-| `anthropic/claude-opus-4.7`          |               1055 |                5275 |
-| `openai/gpt-5.5-pro`                 |               6330 |               37980 |
-| `openai/gpt-5.5`                     |               1055 |                6330 |
-| `google/gemini-3.5-flash`            |              316.5 |                1899 |
-| `x-ai/grok-4.20`                     |             263.75 |               527.5 |
-| `x-ai/grok-4.3`                      |             263.75 |               527.5 |
-| `deepseek/deepseek-v4-pro`           |             91.785 |              183.57 |
-| `deepseek/deepseek-v4-flash`         |             23.632 |              47.264 |
-| `deepseek/deepseek-v3.2`             |             53.172 |              79.758 |
-| `qwen/qwen3.6-max-preview`           |             219.44 |             1316.64 |
-| `qwen/qwen3.6-plus`                  |            68.575 |              411.45 |
-| `qwen/qwen3.6-flash`                 |           39.5625 |             237.375 |
-| `mistralai/mistral-large-2512`       |              105.5 |               316.5 |
-| `mistralai/mistral-medium-3-5`       |              316.5 |              1582.5 |
-| `z-ai/glm-4.6`                       |              90.73 |              367.14 |
-| `z-ai/glm-5`                         |              126.6 |              405.12 |
-| `moonshotai/kimi-k2.6`               |             154.03 |              736.39 |
-| `moonshotai/kimi-k2-thinking`        |              126.6 |               527.5 |
-| `perplexity/sonar-pro`               |                633 |                3165 |
-| `perplexity/sonar-reasoning-pro`     |                422 |                1688 |
-| `perplexity/sonar-deep-research`     |                422 |                1688 |
-
-## Pika
-
-| Product Name                                       | Configuration                                        | Credits     | Category |
-| :------------------------------------------------- | :--------------------------------------------------- | :---------- | :------- |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/i2v, resolution: 1080p        | 211 / run   | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/i2v, resolution: 720p         | 126.6 / run | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikaframes, resolution: 1080p | 211 / run   | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikaframes, resolution: 720p  | 52.75 / run | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikascenes, resolution: 1080p | 316.5 / run | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/pikascenes, resolution: 720p  | 84.4 / run  | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/t2v, resolution: 1080p        | 211 / run   | Video    |
-| prod-v1-Pika Video Generation Product (10 seconds) | endpoint: generate/2.2/t2v, resolution: 720p         | 126.6 / run | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/i2v, resolution: 1080p        | 94.95 / run | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/i2v, resolution: 720p         | 42.2 / run  | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikaframes, resolution: 1080p | 63.3 / run  | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikaframes, resolution: 720p  | 42.2 / run  | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikascenes, resolution: 1080p | 105.5 / run | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/pikascenes, resolution: 720p  | 63.3 / run  | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/t2v, resolution: 1080p        | 94.95 / run | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/2.2/t2v, resolution: 720p         | 42.2 / run  | Video    |
-| prod-v1-Pika Video Generation (5 seconds)          | endpoint: generate/pikaffects, resolution: 720p      | 94.95 / run | Video    |
-| Pika Basic Video Product                           | endpoint: generate/pikadditions                      | 63.3 / run  | Video    |
-| Pika Basic Video Product                           | endpoint: generate/pikaffects                        | 94.95 / run | Video    |
-| Pika Basic Video Product                           | endpoint: generate/pikaswaps                         | 63.3 / run  | Video    |
+| Model                                                          | Input credits / 1M | Output credits / 1M |
+| :------------------------------------------------------------- | :----------------- | :------------------ |
+| anthropic/claude-opus-4.7                                      | 1055               | 5275                |
+| openai/gpt-5.5-pro                                             | 6330               | 37980               |
+| openai/gpt-5.5                                                 | 1055               | 6330                |
+| google/gemini-3.5-flash                                        | 316.5              | 1899                |
+| x-ai/grok-4.20, x-ai/grok-4.3                                  | 263.75             | 527.5               |
+| deepseek/deepseek-v4-pro                                       | 91.785             | 183.57              |
+| deepseek/deepseek-v4-flash                                     | 23.632             | 47.264              |
+| deepseek/deepseek-v3.2                                         | 53.172             | 79.758              |
+| qwen/qwen3.6-max-preview                                       | 219.44             | 1316.64             |
+| qwen/qwen3.6-plus                                              | 68.575             | 411.45              |
+| qwen/qwen3.6-flash                                             | 39.5625            | 237.375             |
+| mistralai/mistral-large-2512                                   | 105.5              | 316.5               |
+| mistralai/mistral-medium-3-5                                   | 316.5              | 1582.5              |
+| z-ai/glm-4.6                                                   | 90.73              | 367.14              |
+| z-ai/glm-5                                                     | 126.6              | 405.12              |
+| moonshotai/kimi-k2.6                                           | 154.03             | 736.39              |
+| moonshotai/kimi-k2-thinking                                    | 126.6              | 527.5               |
+| perplexity/sonar-pro                                           | 633                | 3165                |
+| perplexity/sonar-reasoning-pro, perplexity/sonar-deep-research | 422                | 1688                |
 
 ## Pixverse
 
-| Product Name                     | Configuration                                    | Credits     | Category |
-| :------------------------------- | :----------------------------------------------- | :---------- | :------- |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: fast, quality: 360p    | 189.9 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: fast, quality: 540p    | 189.9 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: fast, quality: 720p    | 253.2 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: normal, quality: 1080p | 253.2 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: normal, quality: 360p  | 94.95 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: normal, quality: 540p  | 94.95 / run | Video    |
-| Pixverse 5 seconds Video Product | model: v3.5, motion_mode: normal, quality: 720p  | 126.6 / run | Video    |
-| Pixverse 8 seconds Video Product | model: v3.5, motion_mode: normal, quality: 360p  | 189.9 / run | Video    |
-| Pixverse 8 seconds Video Product | model: v3.5, motion_mode: normal, quality: 540p  | 189.9 / run | Video    |
-| Pixverse 8 seconds Video Product | model: v3.5, motion_mode: normal, quality: 720p  | 253.2 / run | Video    |
+Model **v3.5** (fixed in the API; not selectable).
+
+**1080p** is limited to **5s** with **normal** motion. **8s** clips only support **normal** motion (fast is coerced to normal).
+
+| model | duration | motion_mode | quality    | Credits     |
+| :---- | :------- | :---------- | :--------- | :---------- |
+| v3.5  | 5s       | fast        | 360p, 540p | 189.9 / run |
+|       | 5s       | fast        | 720p       | 253.2 / run |
+|       | 5s       | normal      | 360p, 540p | 94.95 / run |
+|       | 5s       | normal      | 720p       | 126.6 / run |
+|       | 5s       | normal      | 1080p      | 253.2 / run |
+|       | 8s       | normal      | 360p, 540p | 189.9 / run |
+|       | 8s       | normal      | 720p       | 253.2 / run |
 
 ## Quiver
 
-| Product Name        | Configuration        | Credits     | Category |
-| :------------------ | :------------------- | :---------- | :------- |
-| Quiver Text to SVG  | model: arrow-1.1     | 60.35 / run | Image    |
-| Quiver Image to SVG | model: arrow-1.1     | 45.26 / run | Image    |
-| Quiver Text to SVG  | model: arrow-1.1-max | 75.43 / run | Image    |
-| Quiver Image to SVG | model: arrow-1.1-max | 60.35 / run | Image    |
+### Image
+
+| model         | Credits     |
+| :------------ | :---------- |
+| arrow-1.1     | 60.35 / run |
+| arrow-1.1-max | 75.43 / run |
+| arrow-preview | 90.52 / run |
 
 ## Recraft
 
-| Product Name         | Configuration | Credits    | Category |
-| :------------------- | :------------ | :--------- | :------- |
-| Recraft Create Style      | endpoint: v2/style/create                                       | 8.44 / run  | Image    |
-| Recraft Text to Image      | endpoint: v2/auto/text-to-image                                   | 8.44 / run  | Image    |
-| Recraft Image to Image     | endpoint: v2/auto/image-to-image                                 | 8.44 / run  | Image    |
-| Recraft Inpainting         | endpoint: v2/auto/inpainting                                    | 8.44 / run  | Image    |
-| Recraft Text to Vector     | endpoint: v2/auto/text-to-vector                                 | 16.88 / run | Image    |
-| Recraft Vectorize Image    | endpoint: v2/auto/vectorize-image                                | 2.11 / run  | Image    |
-| Recraft Replace Background | endpoint: v2/image/replace-background                            | 8.44 / run  | Image    |
-| Recraft Remove Background  | endpoint: v2/image/remove-background                             | 2.11 / run  | Image    |
-| Recraft Crisp Upscale      | endpoint: v2/image/crisp-upscale                                 | 0.84 / run  | Image    |
-| Recraft Creative Upscale   | endpoint: v2/image/creative-upscale                              | 52.75 / run | Image    |
-| Recraft V4 Text to Image   | model: recraftv4                                                 | 8.44 / run  | Image    |
-| Recraft V4 Text to Image   | model: recraftv4_pro                                             | 52.75 / run | Image    |
-| Recraft V4 Text to Vector  | model: recraftv4                                                 | 16.88 / run | Image    |
-| Recraft V4 Text to Vector  | model: recraftv4_pro                                             | 63.30 / run | Image    |
+### Image
+
+Flat per-run pricing unless noted. Nodes with **`n`** bill **(credits / image) × `n`**. v3 generation nodes send model **recraftv3** in the API request (not selectable in the node).
+
+| model         | Node                                                                    | Credits               |
+| :------------ | :---------------------------------------------------------------------- | :-------------------- |
+| recraftv4_pro | Recraft V4 Text to Image                                                | 52.75 / image (× `n`) |
+| recraftv4_pro | Recraft V4 Text to Vector                                               | 63.30 / image (× `n`) |
+| recraftv4     | Recraft V4 Text to Image                                                | 8.44 / image (× `n`)  |
+| recraftv4     | Recraft V4 Text to Vector                                               | 16.88 / image (× `n`) |
+| recraftv3     | Recraft Text to Image, Recraft Image to Image, Recraft Image Inpainting | 8.44 / image (× `n`)  |
+| recraftv3     | Recraft Text to Vector                                                  | 16.88 / image (× `n`) |
+| —             | Recraft Create Style                                                    | 8.44 / run            |
+| —             | Recraft Replace Background                                              | 8.44 / run            |
+| —             | Recraft Vectorize Image, Recraft Remove Background                      | 2.11 / run            |
+| —             | Recraft Crisp Upscale Image                                             | 0.84 / run            |
+| —             | Recraft Creative Upscale Image                                          | 52.75 / run           |
 
 ## Reve
 
-> Prices shown are base prices (test\_time\_scaling=1, no postprocessing). Actual cost may be higher with upscaling or background removal enabled.
+### Image
 
-| Product Name      | Configuration                   | Credits     | Category |
-| :---------------- | :------------------------------ | :---------- | :------- |
-| Reve Image Create | model: reve-create@20250915     | 7.24 / run  | Image    |
-| Reve Image Edit   | model: reve-edit@20250915       | 12.07 / run | Image    |
-| Reve Image Edit   | model: reve-edit-fast@20251030  | 2.11 / run  | Image    |
-| Reve Image Remix  | model: reve-remix@20250915      | 12.07 / run | Image    |
-| Reve Image Remix  | model: reve-remix-fast@20251030 | 2.11 / run  | Image    |
+Credits below are approximate **base** rates (`test_time_scaling=1`, upscale off). **`test_time_scaling` > 1**, **upscale**, and **remove background** can increase actual charges from the API.
 
-## Rodin
+| model                                   | Node                              | upscale | Credits     |
+| :-------------------------------------- | :-------------------------------- | :------ | :---------- |
+| reve-create@20250915                    | Reve Image Create                 | off     | 7.24 / run  |
+|                                         |                                   | 2x      | 9.64 / run  |
+|                                         |                                   | 3x      | 12.47 / run |
+|                                         |                                   | 4x      | 16.08 / run |
+| reve-edit@20250915, reve-remix@20250915 | Reve Image Edit, Reve Image Remix | off     | 12.07 / run |
+|                                         |                                   | 2x      | 14.47 / run |
+|                                         |                                   | 3x      | 17.28 / run |
+|                                         |                                   | 4x      | 20.91 / run |
+| reve-edit-fast@20251030                 | Reve Image Edit                   | —       | 2.11 / run  |
+| reve-remix-fast@20251030                | Reve Image Remix                  | —       | 2.11 / run  |
 
-### Hyper3D Rodin (Gen-2)
+Fast edit/remix models use a flat base rate; upscale does not change the displayed estimate.
 
-| Product Name                      | Configuration | Credits     | Category |
-| :-------------------------------- | :------------ | :---------- | :------- |
-| Rodin 3D Generation (no addons)   | NA            | 84.4 / run  | 3D       |
-| Rodin 3D Generation (with AddOns) | NA            | 253.2 / run | 3D       |
+## Rodin 3D
 
-### Hyper3D Rodin Gen-2.5 (`Rodin3D_Gen25_Image` / `Rodin3D_Gen25_Text`)
+| generation | Node                                                                                                    | mode          | addon_highpack | Credits      |
+| :--------- | :------------------------------------------------------------------------------------------------------ | :------------ | :------------- | :----------- |
+| Gen-2.5    | Rodin 3D Gen-2.5 - Image to 3D, Rodin 3D Gen-2.5 - Text to 3D                                           | Regular, Fast | off            | 158.25 / run |
+| Gen-2.5    |                                                                                                         | Extreme-High  | off            | 316.5 / run  |
+| Gen-2.5    |                                                                                                         | any           | on             | +168.8 / run |
+| Gen-2      | Rodin 3D Generate - Regular Generate, Detail Generate, Smooth Generate, Sketch Generate, Gen-2 Generate | —             | —              | 84.4 / run   |
 
-| Product Name                | Configuration                                 | Credits       | Category |
-| :-------------------------- | :-------------------------------------------- | :------------ | :------- |
-| Rodin Gen-2.5 (Regular/Fast) | mode: Regular or Fast                         | 158.25 / run  | 3D       |
-| Rodin Gen-2.5 (Extreme-High) | mode: Extreme-High                            | 316.5 / run   | 3D       |
-| Rodin Gen-2.5 HighPack Addon | addon_highpack: true                          | +168.8 / run  | 3D       |
+**HighPack** (`addon_highpack`) adds **168.8** credits on top of the Gen-2.5 base rate for that mode.
 
 ## Runway
 
-| Product Name                            | Configuration      | Credits     | Category |
-| :-------------------------------------- | :----------------- | :---------- | :------- |
-| prod-v1-Runway Video Generation Product | model: gen3a_turbo | 15.09 / sec | Video    |
-| prod-v1-Runway Video Generation Product | model: gen4_turbo  | 10.55 / sec | Video    |
-| prod-v1-Runway Video Generation Product | model: aleph2     | 84.48 / sec | Video    |
-| RunwayML Image Generation Product       | model: gen4_image     | 24.14 / run | Image    |
-| Runway First & Last Frame Generation Product | model: gen4_turbo | 15.09 / sec | Video    |
+### Video
+
+Gen3a Turbo, Gen4 Turbo, and First-Last-Frame: **5s** or **10s**. Total credits = **(credits / sec) × `duration`**.
+
+| model       | Credits     |
+| :---------- | :---------- |
+| gen3a_turbo | 15.09 / sec |
+| gen4_turbo  | 15.09 / sec |
+| aleph2      | 84.48 / sec |
+
+**Runway Aleph2 Keyframe** and **Runway Aleph2 Prompt Image** are helper nodes with no separate charge; cost is on **Runway Aleph2 Video to Video**.
+
+### Image
+
+| model      | Credits     |
+| :--------- | :---------- |
+| gen4_image | 23.21 / run |
 
 ## Sonilo
 
-| Product Name          | Configuration               | Credits    | Category |
-| :-------------------- | :-------------------------- | :--------- | :------- |
-| Sonilo Music Generate | model: sonilo, type: video-to-music | 1.9 / sec  | Audio    |
-| Sonilo Music Generate | model: sonilo, type: text-to-music  | 1.055 / sec | Audio    |
+Text to Music: total credits = **(credits / sec) × `duration`** (1–360 seconds).
+
+| Node                  | Credits      |
+| :-------------------- | :----------- |
+| Sonilo Video to Music | 1.9 / sec    |
+| Sonilo Text to Music  | 0.5275 / sec |
 
 ## Stability AI
 
-| Product Name                               | Configuration                                                                 | Credits     | Category |
-| :----------------------------------------- | :---------------------------------------------------------------------------- | :---------- | :------- |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/core                                   | 6.33 / run  | Image    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/ultra                                  | 16.88 / run | Image    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/conservative                            | 84.4 / run  | Image    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/creative                                | 126.6 / run | Image    |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/fast                                    | 4.22 / run  | Image    |
-| Stability AI SD3 Image Products            | model: sd3.5-large                                                            | 13.71 / run | Image    |
-| Stability AI SD3 Image Products            | model: sd3.5-large-turbo                                                      | 8.44 / run  | Image    |
-| Stability AI SD3 Image Products            | model: sd3.5-medium                                                           | 7.39 / run  | Image    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/audio-to-audio, model: stable-audio-2.5 | 42.2 / run  | Audio    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/inpaint, model: stable-audio-2.5        | 42.2 / run  | Audio    |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/text-to-audio, model: stable-audio-2.5  | 42.2 / run  | Audio    |
+### Image
+
+| Node                                      | model        | Credits      |
+| :---------------------------------------- | :----------- | :----------- |
+| Stability AI Stable Image Ultra           |              | 16.88 / run  |
+| Stability AI Stable Diffusion 3.5 Image   | sd3.5-large  | 13.715 / run |
+|                                           | sd3.5-medium | 7.385 / run  |
+| Stability AI Upscale Conservative         |              | 84.4 / run   |
+| Stability AI Upscale Creative             |              | 126.6 / run  |
+| Stability AI Upscale Fast                 |              | 4.22 / run   |
+
+### Audio
+
+| model             | Credits    |
+| :---------------- | :--------- |
+| stable-audio-2.5  | 42.2 / run |
 
 ## Tencent
 
-| Product Name                | Configuration                                     | Credits     | Category |
-| :-------------------------- | :------------------------------------------------ | :---------- | :------- |
-| Tencent 3D Generate Type    | endpoint: hunyuan/3d-pro, generate_type: Geometry | 63.3 / run  | 3D       |
-| Tencent 3D Generate Type    | endpoint: hunyuan/3d-pro, generate_type: LowPoly  | 126.6 / run | 3D       |
-| Tencent 3D Generate Type    | endpoint: hunyuan/3d-pro, generate_type: Normal   | 105.5 / run | 3D       |
-| Tencent 3D Generate Type    | endpoint: hunyuan/3d-pro, generate_type: Sketch   | 105.5 / run | 3D       |
-| Tencent 3D Face Count       | custom_face_count: true, endpoint: hunyuan/3d-pro | 42.2 / run  | 3D       |
-| Tencent 3D PBR              | enable_pbr: true, endpoint: hunyuan/3d-pro        | 42.2 / run  | 3D       |
-| Tencent 3D Multiview Images | endpoint: hunyuan/3d-pro, multi_view: true        | 42.2 / run  | Image    |
-| Tencent 3D                  | endpoint: hunyuan/3d-part                         | 126.6 / run | 3D       |
-| Tencent 3D                  | endpoint: hunyuan/3d-texture-edit                 | 126.6 / run | 3D       |
-| Tencent 3D                  | endpoint: hunyuan/3d-uv                           | 42.2 / run  | 3D       |
-| Tencent 3D                  | endpoint: hunyuan/3d-smart-topology               | 211 / run   | 3D       |
+**`3.1`** uses the same rates as **`3.0`** but does not support LowPoly.
 
+### 3D: Generation
+
+| model | generate_type | Credits     |
+| :---- | :------------ | :---------- |
+| 3.0   | Geometry      | 63.3 / run  |
+|       | Normal        | 105.5 / run |
+|       | LowPoly       | 126.6 / run |
+
+Add-ons stack on the base rate:
+
+| model | option                         | Credits      |
+| :---- | :----------------------------- | :----------- |
+| 3.0   | PBR (`pbr` on)                 | +42.2 / run  |
+|       | Custom `face_count` (≠ 500000) | +42.2 / run  |
+|       | Multiview images connected     | +42.2 / run  |
+
+Multiview applies only to **Hunyuan3D: Image(s) to Model** when `image_left`, `image_right`, or `image_back` is connected.
+
+### 3D: Post-processing
+
+| Node                       | Credits      |
+| :------------------------- | :----------- |
+| Hunyuan3D: Model to UV     | 42.2 / run   |
+| Hunyuan3D: Smart Topology  | 211 / run    |
+
+**Hunyuan3D: 3D Texture Edit** and **Hunyuan3D: 3D Part** each cost **126.6 / run**.
 
 ## Topaz
 
-### Image Enhancement
+### Image
 
-| Product Name                    | Configuration                       | Credits     | Category |
-| :------------------------------ | :---------------------------------- | :---------- | :------- |
-| Topaz Image Enhance (Reimagine) | input resolution: 720p (1280x720)   | 13.93 / run | Image    |
-| Topaz Image Enhance (Reimagine) | input resolution: 1080p (1920x1080) | 27.85 / run | Image    |
-| Topaz Image Enhance (Reimagine) | input resolution: 1440p (2560x1440) | 27.85 / run | Image    |
-| Topaz Image Enhance (Reimagine) | input resolution: 4K (3840x2160)    | 69.63 / run | Image    |
+Rates are returned by the Topaz API at poll time (**API credits × 0.08** USD). Typical charges by input resolution:
 
-### Video Enhancement
+| model     | input resolution    | Credits     |
+| :-------- | :------------------ | :---------- |
+| Reimagine | 720p (1280×720)     | 13.93 / run |
+|           | 1080p (1920×1080)   | 27.85 / run |
+|           | 1440p (2560×1440)   | 27.85 / run |
+|           | 4K (3840×2160)      | 69.63 / run |
 
-| Product Name        | Configuration                                                                  | Credits     | Category |
-| :------------------ | :----------------------------------------------------------------------------- | :---------- | :------- |
-| Topaz Video Enhance | model: Starlight Precise 2.5 (slp-2.5), upscaler_resolution: FullHD (1080p)    | 12.99 / sec | Video    |
-| Topaz Video Enhance | model: Starlight Precise 2.5 (slp-2.5), upscaler_resolution: 4K (2160p)        | 28.08 / sec | Video    |
-| Topaz Video Enhance | model: Starlight (Astra) Fast (slf-1), upscaler_resolution: FullHD (1080p)     | 6.50 / sec  | Video    |
-| Topaz Video Enhance | model: Starlight (Astra) Fast (slf-1), upscaler_resolution: 4K (2160p)         | 14.16 / sec | Video    |
-| Topaz Video Enhance | model: Starlight (Astra) Creative (slc-1), upscaler_resolution: FullHD (1080p) | 43.62 / sec | Video    |
-| Topaz Video Enhance | model: Starlight (Astra) Creative (slc-1), upscaler_resolution: 4K (2160p)     | 77.99 / sec | Video    |
-| Topaz Video Enhance | interpolation_model: apo-8, input resolution: 720p                             | 2.55 / sec  | Video    |
-| Topaz Video Enhance | interpolation_model: apo-8, input resolution: 1080p                            | 5.57 / sec  | Video    |
-| Topaz Video Enhance | interpolation_model: apo-8, input resolution: 4K                               | 21.59 / sec | Video    |
-| Topaz Video Enhance | model: Astra 2 (ast-2), resolution: 1080p                                       | 1.688 / frame | Video    |
-| Topaz Video Enhance | model: Astra 2 (ast-2), resolution: 4K                                           | 2.813 / frame | Video    |
+### Video
+
+Approximate rates shown in the node are **per source frame** (not per second). Total credits ≈ **(credits / src frame) × input frame count**. With **apo-8** interpolation enabled, add **~0.14** (1080p) or **~0.28** (4K) per source frame to the upscale rate.
+
+| upscaler_model             | upscaler_resolution | Credits / src frame |
+| :------------------------- | :------------------ | :------------------ |
+| Starlight (Astra) Fast     | FullHD (1080p)      | ~0.43               |
+|                            | 4K (2160p)          | ~0.85               |
+| Starlight Precise 2.5      | FullHD (1080p)      | ~0.70               |
+|                            | 4K (2160p)          | ~1.54               |
+| Astra 2                    | FullHD (1080p)      | ~1.72               |
+|                            | 4K (2160p)          | ~2.85               |
+| Starlight (Astra) Creative | FullHD (1080p)      | ~2.25               |
+|                            | 4K (2160p)          | ~3.99               |
+
+Upscaler **Disabled** with **apo-8** interpolation only: the UI shows **Interpolation only**; charge comes from the API estimate at poll time.
+
+**Topaz Video Enhance (Legacy)** is deprecated. It has no fixed pre-run estimate; charge comes from the API estimate at poll time.
 
 ## Tripo
 
-| Product Name                             | Configuration                                                                     | Credits       | Category |
-| :--------------------------------------- | :-------------------------------------------------------------------------------  | :------------ | :------- |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: detailed, type: image_to_model              | 84.4 / run    | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: detailed, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: detailed, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: standard, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: standard, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.0-20240919, texture_quality: standard, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: detailed, type: image_to_model     | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: detailed, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: detailed, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: standard, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: standard, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v2.5-20250123, texture_quality: standard, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: detailed, type: image_to_model     | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: detailed, type: multiview_to_model | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: detailed, type: text_to_model      | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: standard, type: image_to_model     | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: standard, type: multiview_to_model | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.0-20250812, texture_quality: standard, type: text_to_model      | 42.2 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: detailed, type: image_to_model               | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: detailed, type: multiview_to_model           | 84.4 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: detailed, type: text_to_model                | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: standard, type: image_to_model               | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: standard, type: multiview_to_model           | 63.3 / run  | 3D       |
-| Tripo Generation (with Textures) Product | model: v3.1, texture_quality: standard, type: text_to_model                | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.0-20240919, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.0-20240919, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.0-20240919, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.5-20250123, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.5-20250123, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v2.5-20250123, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.0-20250812, type: image_to_model                                | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.0-20250812, type: multiview_to_model                            | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.0-20250812, type: text_to_model                                 | 21.1 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.1, type: image_to_model                                         | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.1, type: multiview_to_model                                     | 42.2 / run  | 3D       |
-| Tripo Generation (no textures) Product   | model: v3.1, type: text_to_model                                          | 21.1 / run  | 3D       |
-| Tripo Style Product                      | NA                                                                        | 10.55 / run | 3D       |
-| Tripo Quadrangular Product               | NA                                                                        | 10.55 / run | 3D       |
-| Tripo Add Texture Product                | texture_quality: detailed                                                 | 42.2 / run  | 3D       |
-| Tripo Add Texture Product                | texture_quality: standard                                                 | 21.1 / run  | 3D       |
-| Tripo Post-Processing Product            | type: animate_retarget                                                    | 21.1 / run  | 3D       |
-| Tripo Post-Processing Product            | type: animate_rig                                                         | 52.75 / run | 3D       |
-| Tripo Post-Processing Product            | type: stylize_model                                                       | 42.2 / run  | 3D       |
-| Tripo Convert Product                    | convert_format: advanced                                                  | 21.1 / run  | 3D       |
-| Tripo Convert Product                    | convert_format: basic                                                     | 10.55 / run | 3D       |
-| Tripo V1-4 Generation Product            | type: image_to_model                                                      | 63.3 / run  | 3D       |
-| Tripo V1-4 Generation Product            | type: refine_model                                                        | 63.3 / run  | 3D       |
-| Tripo V1-4 Generation Product            | type: text_to_model                                                       | 42.2 / run  | 3D       |
-| Tripo Geometry Quality Product           | geometry_quality: detailed                                                | 42.2 / run  | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: text_to_model, output_mode: Geometry only                | 63.3 / run    | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: standard | 84.4 / run    | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: detailed | 105.5 / run   | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: image_to_model, output_mode: Geometry only               | 84.4 / run    | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: standard | 105.5 / run   | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / run   | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: multiview_to_model, output_mode: Geometry only           | 84.4 / run    | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: standard | 105.5 / run   | 3D       |
-| Tripo P1 Generation Product              | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / run   | 3D       |
+Legacy generation prices are approximate. The node converts internal Tripo credits to USD at **credits × 0.01**.
 
-| Tripo Import 3D Product | NA | Free | 3D |
+### Generation: v1.4
+
+| model_version  | Node                                              | Credits    |
+| :------------- | :------------------------------------------------ | :--------- |
+| v1.4-20240625  | Tripo: Text to Model                              | 42.2 / run |
+|                | Tripo: Image to Model, Tripo: Multiview to Model | 63.3 / run |
+
+v1.4 prices are flat; `texture`, `quad`, and quality settings do not change the estimate.
+
+**Tripo: Refine Draft model** (v1.4 drafts only): **63.3 / run**.
+
+### Generation: v2.0 / v2.5
+
+`model_version` **v2.0-20240919** or **v2.5-20250123**. `texture` or `pbr` counts as textured. On v2.0 and v2.5, **`geometry_quality: detailed` does not change the price**.
+
+**Tripo: Text to Model**
+
+| texture | texture_quality | Credits    |
+| :------ | :-------------- | :--------- |
+| off     | standard        | 21.1 / run |
+| on      | standard        | 42.2 / run |
+| on      | detailed        | 63.3 / run |
+
+**Tripo: Image to Model** and **Tripo: Multiview to Model**
+
+| texture | texture_quality | Credits    |
+| :------ | :-------------- | :--------- |
+| off     | standard        | 42.2 / run |
+| on      | standard        | 63.3 / run |
+| on      | detailed        | 84.4 / run |
+
+| option | Credits      |
+| :----- | :----------- |
+| `quad` | +10.55 / run |
+
+`quad` applies to **Tripo: Text to Model** and **Tripo: Image to Model** only.
+
+### Generation: v3.0 / v3.1
+
+Same nodes with `model_version` **v3.0-20250812** or **v3.1-20260211**. **`geometry_quality: detailed`** adds **+42.2 / run** on top of the texture rows below.
+
+**Tripo: Text to Model**
+
+| texture | texture_quality | geometry_quality | Credits     |
+| :------ | :-------------- | :--------------- | :---------- |
+| off     | standard        | standard         | 21.1 / run  |
+| off     | standard        | detailed         | 63.3 / run  |
+| on      | standard        | standard         | 42.2 / run  |
+| on      | detailed        | standard         | 63.3 / run  |
+| on      | standard        | detailed         | 84.4 / run  |
+| on      | detailed        | detailed         | 105.5 / run |
+
+**Tripo: Image to Model** and **Tripo: Multiview to Model**
+
+| texture | texture_quality | geometry_quality | Credits     |
+| :------ | :-------------- | :--------------- | :---------- |
+| off     | standard        | standard         | 42.2 / run  |
+| off     | standard        | detailed         | 84.4 / run  |
+| on      | standard        | standard         | 63.3 / run  |
+| on      | detailed        | standard         | 84.4 / run  |
+| on      | standard        | detailed         | 105.5 / run |
+| on      | detailed        | detailed         | 126.6 / run |
+
+`quad` add-on (+10.55 / run) applies to **Tripo: Text to Model** and **Tripo: Image to Model** only.
+
+### Generation: P1
+
+| model        | output_mode   | texture_quality | Credits (Text) | Credits (Image / Multiview) |
+| :----------- | :------------ | :-------------- | :------------- | :-------------------------- |
+| P1-20260311  | Geometry only | —               | 63.3 / run     | 84.4 / run                  |
+|              | Textured      | standard        | 84.4 / run     | 105.5 / run                 |
+|              | Textured      | detailed        | 105.5 / run    | 126.6 / run                 |
+
+### Post-processing
+
+| Node                         | Credits      |
+| :--------------------------- | :----------- |
+| Tripo: Texture model         | 21.1 / run (standard), 42.2 / run (detailed) |
+| Tripo: Rig model             | 52.75 / run  |
+| Tripo: Retarget rigged model | 21.1 / run   |
+| Tripo: Convert model         | 10.55 / run (basic), 21.1 / run (advanced options) |
+| Tripo: Import Model          | Free         |
+
+**Tripo: Convert model** charges **21.1 / run** when `quad` is on, `face_limit` is set, `texture_size` ≠ 4096, `texture_format` ≠ JPEG, `flatten_bottom` or `pivot_to_center_bottom` is on, `flatten_bottom_threshold` ≠ 0, or `scale_factor` ≠ 1; otherwise **10.55 / run**.
 ## Vidu
 
-### Video Generation: Q3
+### Video: Q3
 
-| Product Name                     | Configuration                           | Credits     | Category |
-| :------------------------------- | :-------------------------------------- | :---------- | :------- |
-| Vidu Q3 Video Generation Product | model: vidu-q3-pro, resolution: 1080P   | 33.76 / sec | Video    |
-| Vidu Q3 Video Generation Product | model: vidu-q3-pro, resolution: 720P    | 31.65 / sec | Video    |
-| Vidu Q3 Video Generation Product | model: vidu-q3-pro, resolution: 540P    | 14.77 / sec | Video    |
-| Vidu Q3 Video Generation Product | model: vidu-q3-turbo, resolution: 1080P | 16.88 / sec | Video    |
-| Vidu Q3 Video Generation Product | model: vidu-q3-turbo, resolution: 720P  | 12.66 / sec | Video    |
-| Vidu Q3 Video Generation Product | model: vidu-q3-turbo, resolution: 540P  | 8.44 / sec  | Video    |
+Total credits = **(credits / sec) × `duration`**.
 
-### Video Generation: Q2
+| model        | resolution | Credits / sec |
+| :----------- | :--------- | :------------ |
+| viduq3-turbo | 720p       | 12.66         |
+|              | 1080p      | 16.88         |
+| viduq3-pro   | 720p       | 31.65         |
+|              | 1080p      | 33.76         |
+|              | 2K         | 42.2          |
 
-> Off-peak price is half the normal price. Decimals round up.
+**2K** is only on **Vidu Q3 Image-to-Video Generation** with **viduq3-pro**.
 
-| Product Name                     | Configuration                                                            | Credits                             | Category |
-| :------------------------------- | :----------------------------------------------------------------------- | :---------------------------------- | :------- |
-| Vidu Q2 Video Generation Product | model: q2-turbo, type: img2video / start-end2video, resolution: 540P     | Starts at 6.33, +2.11/sec           | Video    |
-| Vidu Q2 Video Generation Product | model: q2-turbo, type: img2video / start-end2video, resolution: 720P     | Starts at 8.44, +10.55/sec after 2s | Video    |
-| Vidu Q2 Video Generation Product | model: q2-turbo, type: img2video / start-end2video, resolution: 1080P    | Starts at 36.92, +10.55/sec         | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: img2video / start-end2video, resolution: 540P       | Starts at 8.44, +5.28/sec after 2s  | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: img2video / start-end2video, resolution: 720P       | Starts at 15.82, +10.55/sec         | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: img2video / start-end2video, resolution: 1080P      | Starts at 58.03, +15.82/sec         | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro-fast, type: img2video / start-end2video, resolution: 720P  | Starts at 8.44, +2.11/sec           | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro-fast, type: img2video / start-end2video, resolution: 1080P | Starts at 16.88, +4.22/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: text2video, resolution: 540P                            | Starts at 10.55, +2.11/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: text2video, resolution: 720P                            | Starts at 15.82, +5.28/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: text2video, resolution: 1080P                           | Starts at 21.1, +10.55/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: reference2video, resolution: 540P                       | Starts at 15.82, +5.28/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: reference2video, resolution: 720P                       | Starts at 26.38, +5.28/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2, type: reference2video, resolution: 1080P                      | Starts at 79.12, +10.55/sec         | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: reference2video, resolution: 540P                   | Starts at 21.1, +5.28/sec           | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: reference2video, resolution: 720P                   | Starts at 31.65, +5.28/sec          | Video    |
-| Vidu Q2 Video Generation Product | model: q2-pro, type: reference2video, resolution: 1080P                  | Starts at 89.67, +10.55/sec         | Video    |
+### Video: Q2
 
-### Video Generation: Q1
+**Linear nodes** (all except Multi-Frame): **base + (credits / sec) × (`duration` − 1)**.
 
-| Product Name                     | Configuration                                                                          | Credits    | Category |
-| :------------------------------- | :------------------------------------------------------------------------------------- | :--------- | :------- |
-| Vidu Q1 Video Generation Product | model: vidu-q1, type: reference2video, style: general, duration: 5s, resolution: 1080P | 84.4 / run | Video    |
-| Vidu Q1 Video Generation Product | model: vidu-q1, type: img2video, style: general, duration: 5s, resolution: 1080P       | 84.4 / run | Video    |
-| Vidu Q1 Video Generation Product | model: vidu-q1, type: start-end2video, style: general, duration: 5s, resolution: 1080P | 84.4 / run | Video    |
-| Vidu Q1 Video Generation Product | model: vidu-q1, type: text2video, style: general, duration: 5s, resolution: 1080P      | 84.4 / run | Video    |
-| Vidu Q1 Video Generation Product | model: vidu-q1, type: text2video, style: anime, duration: 5s, resolution: 1080P        | 84.4 / run | Video    |
+**Multi-Frame:** **`frames` × base + (credits / sec) × sum of segment durations** (uses the Extension / Multi-Frame base column).
 
-### Video Generation: Vidu 2.0
+**Reference** (`viduq2`): add **+15.825 / run** when `audio` is on.
 
-| Product Name                      | Configuration                                                           | Credits     | Category |
-| :-------------------------------- | :---------------------------------------------------------------------- | :---------- | :------- |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: img2video, duration: 4S, resolution: 360P        | 21.1 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: img2video, duration: 4S, resolution: 720P        | 42.2 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: img2video, duration: 4S, resolution: 1080P       | 105.5 / run | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: img2video, duration: 8S, resolution: 720P        | 105.5 / run | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 360P  | 84.4 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 720P  | 84.4 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 360P  | 21.1 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 720P  | 42.2 / run  | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 1080P | 105.5 / run | Video    |
-| Vidu 2.0 Video Generation Product | model: vidu-2.0, type: start-end2video, duration: 8S, resolution: 720P  | 105.5 / run | Video    |
+| model           | resolution | Credits / sec after 1s | Base (1s) linear nodes | Base (1s) Extension / Multi-Frame |
+| :-------------- | :--------- | :--------------------- | :--------------------- | :-------------------------------- |
+| viduq2          | 720p       | 5.275                  | 15.825                 | —                                 |
+|                 | 1080p      | 10.55                  | 21.1                   | —                                 |
+| viduq2-pro-fast | 720p       | 2.11                   | 8.44                   | —                                 |
+|                 | 1080p      | 4.22                   | 16.88                  | —                                 |
+| viduq2-pro      | 720p       | 10.55                  | 15.825                 | 31.65                             |
+|                 | 1080p      | 15.825                 | 58.025                 | 63.3                              |
+| viduq2-turbo    | 1080p      | 10.55                  | 36.925                 | 42.2                              |
+|                 | 720p       | 5.275 (Ext/MF); 10.55 (I2V/Start-End after 2s) | — | 15.825                            |
 
-### Image Generation
+**viduq2** linear bases above are for **Text-to-Video**. **Reference-to-Video** uses the same per-second rates but base **26.375** (720p) or **79.125** (1080p).
 
-| Product Name                  | Configuration                                                               | Credits     | Category |
-| :---------------------------- | :-------------------------------------------------------------------------- | :---------- | :------- |
-| Vidu Image Generation Product | model: viduq2, type: Text to Image, resolution: 1080P                       | 6.33 / run  | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Text to Image, resolution: 2K                          | 8.44 / run  | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Text to Image, resolution: 4K                          | 10.55 / run | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 1080P | 8.44 / run  | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 2K    | 12.66 / run | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 4K    | 21.1 / run  | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 1080P | 10.55 / run | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 2K    | 16.88 / run | Image    |
-| Vidu Image Generation Product | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 4K    | 31.65 / run | Image    |
-| Vidu Image Generation Product | model: viduq1, type: Reference to Image, ref images: 1–7, resolution: 1080P | 21.1 / run  | Image    |
+**viduq2-pro-fast**, **viduq2-pro**, and **viduq2-turbo** linear bases are for **Image-to-Video** and **Start/End Frame-to-Video**. **viduq2-turbo** at **720p** on those nodes: **8.44** at 1s (I2V), **10.55** at 2s (flat on I2V; Start/End minimum duration is 2s), then **+10.55 / sec** after 2s. The **5.275 / sec** rate applies only to Extension and Multi-Frame, not I2V or Start/End.
 
+### Video: Q1
 
-### Video Extension
+Fixed **5s** at **1080p**.
 
-| Product Name                 | Configuration                      | Credits                     | Category |
-| :--------------------------- | :--------------------------------- | :-------------------------- | :------- |
-| Vidu Video Extension Product | model: q2-turbo, resolution: 540P  | Starts at 10.55, +2.11/sec  | Video    |
-| Vidu Video Extension Product | model: q2-turbo, resolution: 720P  | Starts at 15.82, +5.28/sec  | Video    |
-| Vidu Video Extension Product | model: q2-turbo, resolution: 1080P | Starts at 42.2, +10.55/sec  | Video    |
-| Vidu Video Extension Product | model: q2-pro, resolution: 540P    | Starts at 15.82, +5.28/sec  | Video    |
-| Vidu Video Extension Product | model: q2-pro, resolution: 720P    | Starts at 31.65, +10.55/sec | Video    |
-| Vidu Video Extension Product | model: q2-pro, resolution: 1080P   | Starts at 63.3, +15.82/sec  | Video    |
+| model   | Credits    |
+| :------ | :--------- |
+| viduq1  | 84.4 / run |
 
-### Other Features
+## Wan
 
-| Product Name             | Configuration | Credits     | Category |
-| :----------------------- | :------------ | :---------- | :------- |
-| Vidu Lip Sync Product    | —             | 21.1 / 5s   | Video    |
-| Vidu Motion Sync Product | —             | 10.55 / sec | Video    |
+| model                                                          | resolution | Credits                |
+| :------------------------------------------------------------- | :--------- | :--------------------- |
+| wan2.5-t2i-preview, wan2.5-i2i-preview                         | —          | 6.33 / run             |
+| wan2.7-t2v, wan2.7-i2v                                         | 720P       | 21.1 / sec             |
+|                                                                | 1080P      | 31.65 / sec            |
+| wan2.7-i2v (continuation)                                      | 720P       | 21.1 / sec (range)     |
+|                                                                | 1080P      | 31.65 / sec (range)    |
+| wan2.7-videoedit                                               | 720P       | 21.1 / sec (in + out)  |
+|                                                                | 1080P      | 31.65 / sec (in + out) |
+| wan2.7-r2v                                                     | 720P       | 21.1 / sec (range)     |
+|                                                                | 1080P      | 31.65 / sec (range)    |
+| wan2.5-t2v-preview, wan2.5-i2v-preview                         | 480p       | 10.55 / sec            |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 720p       | 21.1 / sec             |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 1080p      | 31.65 / sec            |
+| wan2.6-r2v                                                     | 720p       | 21.1 / sec (range)     |
+|                                                                | 1080p      | 31.65 / sec (range)    |
 
-## WAN
+## WaveSpeed
 
-| Product Name                 | Configuration                                | Credits     | Category |
-| :--------------------------- | :------------------------------------------- | :---------- | :------- |
-| Wan Image Generation Product | model: wan2.5-i2i-preview                    | 6.33 / run  | Image    |
-| Wan Image Generation Product | model: wan2.5-t2i-preview                    | 6.33 / run  | Image    |
-| Wan Image Generation Product | model: wan2.6-t2i                            | 6.33 / run  | Image    |
-| Wan Video Generation Product | model: wan2.5-i2v-preview, resolution: 1080P | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.5-i2v-preview, resolution: 480P  | 10.55 / sec | Video    |
-| Wan Video Generation Product | model: wan2.5-i2v-preview, resolution: 720P  | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.5-t2v-preview, resolution: 1080P | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.5-t2v-preview, resolution: 480P  | 10.55 / sec | Video    |
-| Wan Video Generation Product | model: wan2.5-t2v-preview, resolution: 720P  | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.6-i2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.6-i2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.6-r2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.6-r2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.6-t2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.6-t2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.7-i2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.7-i2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.7-r2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.7-r2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.7-t2v, resolution: 1080P         | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.7-t2v, resolution: 720P          | 21.1 / sec  | Video    |
-| Wan Video Generation Product | model: wan2.7-videoedit, resolution: 1080P   | 31.65 / sec | Video    |
-| Wan Video Generation Product | model: wan2.7-videoedit, resolution: 720P    | 21.1 / sec  | Video    |
-
-## Wavespeed
-
-| Product Name       | Configuration                     | Credits     | Category |
-| :----------------- | :-------------------------------- | :---------- | :------- |
-| Wavespeed Flashvsr | resolution: 1080p                 | 18.99 / run | Image    |
-| Wavespeed Flashvsr | resolution: 2k                    | 25.32 / run | Image    |
-| Wavespeed Flashvsr | resolution: 4k                    | 33.76 / run | Image    |
-| Wavespeed Flashvsr | resolution: 720p                  | 12.66 / run | Image    |
-| Wavespeed Image    | endpoint: seedvr2                 | 2.11 / run  | Image    |
-| Wavespeed Image    | endpoint: ultimate-image-upscaler | 12.66 / run | Image    |
+| model      | resolution | Credits      |
+| :--------- | :--------- | :----------- |
+| flashvsr   | 720p       | 2.532 / sec  |
+|            | 1080p      | 3.798 / sec  |
+|            | 2K         | 5.064 / sec  |
+|            | 4K         | 6.752 / sec  |
+| SeedVR2    | —          | 2.11 / run   |
+| Ultimate   | —          | 12.66 / run  |
 
 ## xAI
 
 <Note>
 Video endpoints charge for moderated content.
 </Note>
-| Product Name                                 | Configuration                                                                                           | Credits     | Category |
-| :------------------------------------------- | :------------------------------------------------------------------------------------------------------ | :---------- | :------- |
-| xAI Image Generation                         | endpoint: v1/images/generations, model: grok-imagine-image-beta, resolution: 1k                         | 6.96 / run  | Image    |
-| xAI Image Generation                         | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 1k                      | 10.55 / run | Image    |
-| xAI Image Generation                         | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 2k                      | 14.77 / run | Image    |
-| xAI Image Edit Output                        | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 6.96 / run  | Image    |
-| xAI Image Edit Output                        | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 1k                            | 10.55 / run | Image    |
-| xAI Image Edit Output                        | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 2k                            | 14.77 / run | Image    |
-| xAI Image Edit Input                         | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 0.42 / run  | Image    |
-| xAI Image Edit Input                         | endpoint: v1/images/edits, model: grok-imagine-image-quality                                           | 2.11 / run  | Image    |
-| xAI Video Generation Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 38.19 / sec | Video    |
-| xAI Video Generation Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p                       | 38.19 / sec | Video    |
-| xAI Video Generation Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 480p                     | 24.14 / sec | Video    |
-| xAI Video Generation Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 720p                     | 42.24 / sec | Video    |
-| xAI Video Generation Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 1080p                    | 75.43 / sec | Video    |
-| xAI Video Generation Input Image             | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, type: image-to-video                 | 3.02 / sec  | Video    |
-| xAI Video Generation Input Image             | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p, type: image-to-video | 0.42 / sec  | Video    |
-| xAI Video Generation Input Image             | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p, type: image-to-video | 0.42 / sec  | Video    |
-| xAI Video Edit Input+Output Video Per Second | endpoint: v1/videos/edits, model: grok-imagine-video-beta, resolution: 480p                             | 40.3 / sec  | Video    |
-| xAI Image Edit Input                         | endpoint: v1/images/edits, model: v1/images/edits, resolution: 1k                                       | 0.42 / run  | Image    |
-| xAI Video Edit Input+Output Video Per Second | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 40.3 / sec  | Video    |
-| xAI Credits                                  | NA                                                                                                      | 2.11 / run  | Image    |
 
-## Other (Cloud)
+### Image
 
-| Product Name      | Configuration          | Credits    | Category |
-| :---------------- | :--------------------- | :--------- | :------- |
-| GPU Hours Product | gpu_type: rtx_pro_6000 | 0.27 / sec | Image    |
+| model                      | resolution | task     | Credits                                      |
+| :------------------------- | :--------- | :------- | :------------------------------------------- |
+| grok-imagine-image-quality | 1K         | generate | 10.55 / output image                         |
+|                            | 2K         | generate | 14.77 / output image                         |
+| grok-imagine-image-pro     | —          | generate | 14.77 / output image                         |
+| grok-imagine-image         | —          | generate | 4.22 / output image                          |
+| grok-imagine-image-quality | 1K         | edit     | 2.11 input + 10.55 / output image            |
+|                            | 2K         | edit     | 2.11 input + 14.77 / output image            |
+| grok-imagine-image-pro     | —          | edit     | 0.422 input + 14.77 / output image         |
+| grok-imagine-image         | —          | edit     | 0.422–1.266 input + 4.22 / output image    |
+
+### Video
+
+| model                      | resolution | Credits                                                    |
+| :------------------------- | :--------- | :--------------------------------------------------------- |
+| grok-imagine-video         | 480p       | 10.55 / sec output (+0.422 input image)                    |
+|                            | 720p       | 14.77 / sec output (+0.422 input image)                    |
+| grok-imagine-video-1.5     | 480p       | 24.14 / sec output (+3.02 input image)                     |
+|                            | 720p       | 42.24 / sec output (+3.02 input image)                     |
+|                            | 1080p      | 75.43 / sec output (+3.02 input image)                     |
+| grok-imagine-video (edit)  | —          | 12.66 / sec (input + output video)                         |
+| grok-imagine-video (reference) | 480p   | 15.09 / sec output + 0.603 / ref image                     |
+|                            | 720p       | 21.12 / sec output + 0.603 / ref image                     |
+| grok-imagine-video (extend)| —          | 6.03–45.26 input + 15.09 × extension sec output / run      |
+
+## Cloud GPU
+
+| gpu_type       | Credits    |
+| :------------- | :--------- |
+| rtx_pro_6000   | 0.27 / sec |

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -9,6 +9,22 @@ The following table lists the pricing of the current Partner Nodes. All prices a
 
 211 credits = 1 USD
 
+## Anthropic
+
+Anthropic partner nodes bill the same underlying USD usage as the public Anthropic API. **Credits = USD × 211** (see page header). Input and output rates below are per 1K tokens, matching the `ClaudeNode` price display. Cache reads and writes use Anthropic multipliers (0.1×, 1.25×, and 2.0× the input rate) on cached token counts.
+
+### Chat (`ClaudeNode`)
+
+| Model | Input credits / 1K | 5m Cache Write credits / 1K | 1h Cache Write credits / 1K | Cache Hit credits / 1K | Output credits / 1K |
+| :---- | -----------------: | --------------------------: | --------------------------: | ---------------------: | ------------------: |
+| Opus 4.7 | 1.055 | 1.31875 | 2.11 | 0.1055 | 5.275 |
+| Opus 4.6 | 1.055 | 1.31875 | 2.11 | 0.1055 | 5.275 |
+| Sonnet 4.6 | 0.633 | 0.79125 | 1.266 | 0.0633 | 3.165 |
+| Sonnet 4.5 | 0.633 | 0.79125 | 1.266 | 0.0633 | 3.165 |
+| Haiku 4.5 | 0.211 | 0.26375 | 0.422 | 0.0211 | 1.055 |
+
+Optional images add tokens billed at the same model input rates.
+
 ## Beeble
 
 ### Video — SwitchX Video Edit
@@ -27,37 +43,17 @@ The following table lists the pricing of the current Partner Nodes. All prices a
 
 ## BFL
 
-| Node | Credits |
-| :--- | :------ |
-| Flux 1.1 [pro] Ultra Image | 12.66 / run |
-| Flux.1 Kontext [pro] Image | 8.44 / run |
-| Flux.1 Kontext [max] Image | 16.88 / run |
-| Flux.1 Expand Image | 10.55 / run |
-| Flux.1 Fill Image | 10.55 / run |
-| Flux Erase Image | 6.33 / run + 0.84 / extra MP |
-| Flux Virtual Try-On | 7.91 / run + 1.06 / extra MP |
-| Flux.2 [pro] | 6.33 / run + 3.17 / extra MP |
-| Flux.2 [max] | 14.77 / run + 6.33 / extra MP |
-
-## Anthropic
-
-Anthropic partner nodes bill the same underlying USD usage as the public Anthropic API. **Credits = USD × 211** (see page header). Token prices below are per million tokens. Cache pricing multipliers match Anthropic's prompt caching documentation.
-
-### Chat (`ClaudeNode`)
-
-Models: per 1M tokens.
-
-| Model           | Input credits / 1M | 5m Cache Write credits / 1M | 1h Cache Write credits / 1M | Cache Hit credits / 1M | Output credits / 1M |
-| :-------------- | -----------------: | -------------------------: | -------------------------: | ---------------------: | ------------------: |
-| `claude-opus-4-7` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-6` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-5-20251101` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-1-20250805` | 3165 | 3956.25 | 6330 | 316.5 | 15825 |
-| `claude-sonnet-4-6` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-sonnet-4-5-20250929` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-haiku-4-5-20251001` | 211 | 263.75 | 422 | 21.1 | 1055 |
-
-Optional images add tokens billed at the same model input rates.
+| Node                       |            Credits            |
+| :------------------------- | :---------------------------: |
+| Flux 1.1 [pro] Ultra Image |          12.66 / run          |
+| Flux.1 Kontext [pro] Image |          8.44 / run           |
+| Flux.1 Kontext [max] Image |          16.88 / run          |
+| Flux.1 Expand Image        |          10.55 / run          |
+| Flux.1 Fill Image          |          10.55 / run          |
+| Flux Erase Image           | 6.33 / run + 0.84 / extra MP  |
+| Flux Virtual Try-On        | 7.91 / run + 1.06 / extra MP  |
+| Flux.2 [pro]               | 6.33 / run + 3.17 / extra MP  |
+| Flux.2 [max]               | 14.77 / run + 6.33 / extra MP |
 
 ## Bria
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -59,62 +59,90 @@ Optional images add tokens billed at the same model input rates.
 
 ### Image
 
-| Node | Credits |
-| :--- | :------ |
-| Bria FIBO Image Edit | 8.44 / run |
-| Bria Remove Image Background | 3.8 / run |
+| Node                         | Credits    |
+| :--------------------------- | :--------- |
+| Bria FIBO Image Edit         | 8.44 / run |
+| Bria Remove Image Background | 3.8 / run  |
 
 ### Video
 
-| Node | Credits |
-| :--- | :------ |
-| Bria Remove Video Background | 0.89 / sec |
-| Bria Video Green Screen | 0.89 / sec |
-| Bria Video Replace Background | 0.89 / sec |
+| Node                                       | Credits    |
+| :----------------------------------------- | :--------- |
+| Bria Remove Video Background               | 0.89 / sec |
+| Bria Video Green Screen                    | 0.89 / sec |
+| Bria Video Replace Background              | 0.89 / sec |
 | Bria Remove Video Background (Transparent) | 0.89 / sec |
 
 ## ByteDance
 
-| Product Name                                         | Configuration                                                   | Credits           | Category |
-| :--------------------------------------------------- | :-------------------------------------------------------------- | :---------------- | :------- |
-| BytePlus Seed Input Text Tokens (Per 1M tokens)     | model: seed-2-0-pro-260328                                     | 105.5 / 1M tokens | Text     |
-| BytePlus Seed Input Text Tokens (Per 1M tokens)     | model: seed-2-0-lite-260228                                    | 52.75 / 1M tokens  | Text     |
-| BytePlus Seed Input Text Tokens (Per 1M tokens)     | model: seed-2-0-mini-260215                                    | 21.1 / 1M tokens   | Text     |
-| BytePlus Seed Output Text Tokens (Per 1M tokens)    | model: seed-2-0-pro-260328                                     | 633 / 1M tokens    | Text     |
-| BytePlus Seed Output Text Tokens (Per 1M tokens)    | model: seed-2-0-lite-260228                                    | 422 / 1M tokens    | Text     |
-| BytePlus Seed Output Text Tokens (Per 1M tokens)    | model: seed-2-0-mini-260215                                    | 84.4 / 1M tokens   | Text     |
-| BytePlus Seed Cache Hit Input Tokens (Per 1M tokens)| model: seed-2-0-pro-260328                                     | 21.1 / 1M tokens   | Text     |
-| BytePlus Seed Cache Hit Input Tokens (Per 1M tokens)| model: seed-2-0-lite-260228                                    | 10.55 / 1M tokens  | Text     |
-| BytePlus Seed Cache Hit Input Tokens (Per 1M tokens)| model: seed-2-0-mini-260215                                    | 4.22 / 1M tokens   | Text     |
-| BytePlus Image Generation Product                    | model: seededit-3-0-i2i-250628                                  | 6.33 / run        | Image    |
-| BytePlus Image Generation Product                    | model: seedream-3-0-t2i-250415                                  | 6.33 / run        | Image    |
-| BytePlus Image Generation Product                    | model: seedream-4-0-250828                                      | 6.33 / run        | Image    |
-| BytePlus Image Generation Product                    | model: seedream-4-5-251128                                      | 8.44 / run        | Image    |
-| BytePlus Image Generation Product                    | model: seedream-5-0-260128                                      | 7.39 / run        | Image    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-lite-i2v-250428, video_type: image-to-video | 379.8 / 1M tokens | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-lite-t2v-250428, video_type: text-to-video  | 379.8 / 1M tokens | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-pro-250528, video_type: image-to-video      | 527.5 / 1M tokens | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-pro-250528, video_type: text-to-video       | 527.5 / 1M tokens | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-pro-fast-251015, video_type: image-to-video | 211 / 1M tokens   | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedance-1-0-pro-fast-251015, video_type: text-to-video  | 211 / 1M tokens   | Video    |
-| BytePlus Video Generation Product (Per 1M tokens)    | model: seedream-4-5-251128, video_type: text-to-video           | 211 / 1M tokens   | Video    |
-| BytePlus Video Generation With Audio (Per 1M tokens) | generate_audio: false, model: seedance-1-5-pro-251215           | 253.2 / 1M tokens | Video    |
-| BytePlus Video Generation With Audio (Per 1M tokens) | generate_audio: true, model: seedance-1-5-pro-251215            | 506.4 / 1M tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: text-to-video (no video input: text or image)  | 2.112 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: image-to-video (no video input: text or image) | 2.112 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 720P, video_type: video-to-video (with video input)              | 1.297 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: text-to-video (no video input: text or image)  | 2.323 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: image-to-video (no video input: text or image) | 2.323 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 1080P, video_type: video-to-video (with video input)              | 1.418 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: text-to-video (no video input: text or image)     | 1.207 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: image-to-video (no video input: text or image)    | 1.207 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0, resolution: 4K, video_type: video-to-video (with video input)                 | 0.724 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: text-to-video (no video input: text or image)  | 1.690 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: image-to-video (no video input: text or image) | 1.690 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: video-to-video (with video input)              | 0.995 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: text-to-video (no video input: text or image)  | 1.056 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: image-to-video (no video input: text or image) | 1.056 / K tokens | Video    |
-| BytePlus Video Generation Product (Per K tokens)     | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: video-to-video (with video input)              | 0.634 / K tokens | Video    |
+### LLM — ByteDance Seed
+
+Per 1K tokens, matching the `ByteDanceSeedNode` price display. Final cost scales with actual token usage.
+
+| Model | Input credits / 1K | Cache hit credits / 1K | Output credits / 1K |
+| :---- | -----------------: | ---------------------: | ------------------: |
+| Seed 2.0 Pro | 0.1055 | 0.0211 | 0.633 |
+| Seed 2.0 Lite | 0.0633 | 0.01055 | 0.422 |
+| Seed 2.0 Mini | 0.05275 | 0.00422 | 0.1899 |
+
+### Image — ByteDance Seedream 4.5 & 5.0
+
+Per image generated (approximate).
+
+| model | Credits / image |
+| :---- | :-------------- |
+| seedream 5.0 lite | 7.39 |
+| seedream-4-5-251128 | 8.44 |
+| seedream-4-0-250828 | 6.33 |
+
+### Image — ByteDance Image (deprecated)
+
+| model | Credits / run |
+| :---- | :------------ |
+| seedream-3-0-t2i-250415 | 6.33 |
+
+### Video — Seedance 1.x
+
+Used by **ByteDance Text to Video**, **Image to Video**, and **First-Last-Frame to Video**. **ByteDance Reference Images to Video** supports Seedance 1.0 Pro and Lite at 480p and 720p only.
+
+Approximate credits for **10 seconds** of video; scale linearly with `duration`. For **Seedance 1.5 Pro**, enable `generate_audio` to double the cost.
+
+| model | resolution | generate_audio | Credits / 10 sec (approx) |
+| :---- | :--------- | :------------- | :------------------------ |
+| seedance-1-5-pro-251215 | 480p | off | 25.32 |
+| seedance-1-5-pro-251215 | 480p | on | 50.64 |
+| seedance-1-5-pro-251215 | 720p | off | 54.86 |
+| seedance-1-5-pro-251215 | 720p | on | 109.72 |
+| seedance-1-5-pro-251215 | 1080p | off | 122.38 |
+| seedance-1-5-pro-251215 | 1080p | on | 244.76 |
+| seedance-1-0-pro-250528 | 480p | — | 48.53 – 50.64 |
+| seedance-1-0-pro-250528 | 720p | — | 107.61 – 118.16 |
+| seedance-1-0-pro-250528 | 1080p | — | 248.98 – 257.42 |
+| seedance-1-0-pro-fast-251015 | 480p | — | 18.99 – 21.1 |
+| seedance-1-0-pro-fast-251015 | 720p | — | 44.31 – 48.53 |
+| seedance-1-0-pro-fast-251015 | 1080p | — | 99.17 – 103.39 |
+| seedance-1-0-lite-i2v-250428 | 480p | — | 35.87 – 37.98 |
+| seedance-1-0-lite-i2v-250428 | 720p | — | 78.07 – 86.51 |
+| seedance-1-0-lite-i2v-250428 | 1080p | — | 179.35 – 185.68 |
+
+### Video — Seedance 2.0
+
+Used by **ByteDance Seedance 2.0 Text to Video**, **First-Last-Frame to Video**, and **Reference to Video**. Billed from output token usage at the rates below. 480p uses the same per-K rate as 720p.
+
+| model | resolution | Video input | Credits / K tokens |
+| :---- | :--------- | :---------- | -----------------: |
+| Seedance 2.0 | 720p | no | 2.112 |
+| Seedance 2.0 | 720p | yes | 1.297 |
+| Seedance 2.0 | 1080p | no | 2.323 |
+| Seedance 2.0 | 1080p | yes | 1.418 |
+| Seedance 2.0 | 4k | no | 1.207 |
+| Seedance 2.0 | 4k | yes | 0.724 |
+| Seedance 2.0 Fast | 720p | no | 1.690 |
+| Seedance 2.0 Fast | 720p | yes | 0.995 |
+| Seedance 2.0 Mini | 720p | no | 1.056 |
+| Seedance 2.0 Mini | 720p | yes | 0.634 |
+
+**Video input** means reference video is connected (Reference to Video node). Text, image, and audio references count as no video input.
 
 > **Seedance 2.0 token calculation:** Output tokens = (Input video duration + Output video duration) × Output video length × Output video width × Output video frame rate ÷ 1024. When input is text, image, or audio, input duration = 0. Seedance 2.0 outputs at 24fps. For video-to-video inputs, a minimum token usage limit applies.
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -11,12 +11,19 @@ The following table lists the pricing of the current Partner Nodes. All prices a
 
 ## Beeble
 
-| Product Name               | Configuration                             | Credits       | Category |
-| :------------------------- | :---------------------------------------- | :------------ | :------- |
-| SwitchX | model: switchx, output_type: video, resolution: 720p | 30.17 / 30 frames | Video    |
-| SwitchX | model: switchx, output_type: video, resolution: 1080p | 90.52 / 30 frames | Video    |
-| SwitchX | model: switchx, output_type: image, resolution: 720p  | 30.17 / run       | Image    |
-| SwitchX | model: switchx, output_type: image, resolution: 1080p | 90.52 / run       | Image    |
+### Video — SwitchX Video Edit
+
+| max_resolution | Credits           |
+| :------------- | :---------------- |
+| 720p           | 30.17 / 30 frames |
+| 1080p          | 90.52 / 30 frames |
+
+### Image — SwitchX Image Edit
+
+| max_resolution | Credits     |
+| :------------- | :---------- |
+| 720p           | 30.17 / run |
+| 1080p          | 90.52 / run |
 
 ## BFL
 

--- a/zh/tutorials/partner-nodes/pricing.mdx
+++ b/zh/tutorials/partner-nodes/pricing.mdx
@@ -3,48 +3,47 @@ title: "定价"
 description: "本文列出了当前合作节点的价格。所有价格均以积分计价（211 积分 = 1 美元）。"
 sidebarTitle: "定价"
 mode: wide
-translationSourceHash: 01471717
+translationSourceHash: 48347eb0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": 845592d4
-  "Beeble": 885c0b0f
-  "BFL": c049375b
-  "Anthropic": 7966fafa
-  "Bria": c7c492a1
-  "ByteDance": c45deeb8
-  "ElevenLabs": 6adeca08
-  "Freepik": cf21eaf2
-  "Google": 22aa3ea9
-  "HappyHorse": 28d2c09d
-  "Hitpaw": 3f19a1ce
-  "Ideogram": 6b1fa01c
-  "Krea": 67613c4e
-  "Kling": ba141835
-  "Lightricks": c29a5b7e
-  "Luma": 41bd0a3f
-  "Meshy": 3a0f5a43
-  "Minimax": e2e387a5
-  "Moonvalley": 8ca8c186
-  "OpenAI": 6842a6d6
-  "OpenRouter": a437d408
-  "Pika": 117ad27b
-  "Pixverse": 6fa7019b
-  "Quiver": 199f7f57
-  "Recraft": 48d0028a
-  "Reve": 82943ad5
-  "Rodin": 69c74113
-  "Runway": f2115adb
-  "Sonilo": 9b1be9b8
-  "Stability AI": 488faf10
-  "Tencent": 5d02a5cc
-  "Topaz": 8f39ff22
-  "Tripo": 2f8e0275
-  "Vidu": 50f09885
-  "WAN": b01edeb4
-  "Wavespeed": 17bdbfd6
-  "xAI": edfd0753
-  "Other (Cloud)": 9101685b
+  "Anthropic": a7ca54bf
+  "Beeble": d1b19f61
+  "BFL": 3ff6bff0
+  "Bria": 232ed8f6
+  "ByteDance": 19edbf0b
+  "ElevenLabs": 166ecbf9
+  "Magnific": 4000e7e1
+  "Google": 7b3926a3
+  "HappyHorse": bceb584a
+  "Hitpaw": 320c0537
+  "Ideogram": d9748301
+  "Krea": fb20c257
+  "Kling": cdf2c899
+  "Lightricks": 4870964f
+  "Luma": 655207a5
+  "Meshy": 6cd06881
+  "Minimax": 28c7cf5e
+  "OpenAI": 27febd17
+  "OpenRouter": 07b4b92f
+  "Pixverse": 8612b816
+  "Quiver": b9d45a82
+  "Recraft": 7eb9a1a7
+  "Reve": 5be5c43a
+  "Rodin 3D": 2eb41834
+  "Runway": 94ec479a
+  "Sonilo": 48b9c581
+  "Stability AI": ddca722f
+  "Tencent": f1efbad9
+  "Topaz": 3eabf417
+  "Tripo": 0d9ddbf9
+  "Vidu": 8ae05bc9
+  "Wan": c51a9eef
+  "WaveSpeed": 349a7c9d
+  "xAI": 7e81e67b
+  "Cloud GPU": 103c55e6
 ---
+
 
 
 
@@ -53,1070 +52,1076 @@ translationBlockHashes:
 
 211 积分 = 1 美元
 
+## Anthropic
+
+Anthropic 合作节点的计费方式与公开的 Anthropic API 相同，均基于底层 USD 用量。**积分 = USD × 211**（参见页面顶部）。以下输入和输出费率按每 1K Token 计算，与 `ClaudeNode` 价格显示一致。缓存读取和写入使用 Anthropic 的乘数（输入费率的 0.1 倍、1.25 倍和 2.0 倍）作用于缓存的 Token 数量。
+
+### 聊天（`ClaudeNode`）
+
+| 模型         | 输入积分 / 1K | 5 分钟缓存写入积分 / 1K | 1 小时缓存写入积分 / 1K | 缓存命中积分 / 1K | 输出积分 / 1K |
+| :----------- | ------------: | ----------------------: | ----------------------: | ----------------: | ------------: |
+| Opus 4.7     |        1.055  |                 1.31875 |                  2.11   |            0.1055 |        5.275  |
+| Opus 4.6     |        1.055  |                 1.31875 |                  2.11   |            0.1055 |        5.275  |
+| Sonnet 4.6   |        0.633  |                 0.79125 |                 1.266   |            0.0633 |        3.165  |
+| Sonnet 4.5   |        0.633  |                 0.79125 |                 1.266   |            0.0633 |        3.165  |
+| Haiku 4.5    |        0.211  |                 0.26375 |                 0.422   |            0.0211 |        1.055  |
+
+可选的图像会增加 Token，按照相同的模型输入费率计费。
+
 ## Beeble
 
-| 产品名称                     | 配置                                       | 积分           | 类别   |
-| :------------------------- | :---------------------------------------- | :------------ | :----- |
-| SwitchX | model: switchx, output_type: video, resolution: 720p | 30.17 / 30 帧 | 视频   |
-| SwitchX | model: switchx, output_type: video, resolution: 1080p | 90.52 / 30 帧 | 视频   |
-| SwitchX | model: switchx, output_type: image, resolution: 720p  | 30.17 / 次运行 | 图像   |
-| SwitchX | model: switchx, output_type: image, resolution: 1080p | 90.52 / 次运行 | 图像   |
+### 视频：SwitchX 视频编辑
+
+| 最大分辨率 | 积分             |
+| :--------- | :--------------- |
+| 720p       | 30.17 / 30 帧    |
+| 1080p      | 90.52 / 30 帧    |
+
+### 图像：SwitchX 图像编辑
+
+| 最大分辨率 | 积分       |
+| :--------- | :--------- |
+| 720p       | 30.17 / 次 |
+| 1080p      | 90.52 / 次 |
 
 ## BFL
 
-| 模型                      | 积分     | 类别 |
-| :-------------------------- | :----------- | :-------- |
-| flux-dev                   | 5.28 / 次   | 图像    |
-| flux-kontext-max           | 16.88 / 次  | 图像    |
-| flux-kontext-pro           | 8.44 / 次   | 图像    |
-| flux-pro-1.0-canny         | 10.55 / 次  | 图像    |
-| flux-pro-1.0-depth         | 10.55 / 次  | 图像    |
-| flux-pro-1.0-expand        | 10.55 / 次  | 图像    |
-| flux-pro-1.0-fill          | 10.55 / 次  | 图像    |
-| flux-tools/erase-v1        | 6.33 / 次 + 0.84 / 额外 MP | 图像    |
-| flux-tools/vto-v1          | 7.91 / 次 + 1.06 / 额外 MP | 图像    |
-| flux-pro-1.1               | 8.44 / 次   | 图像    |
-| flux-pro-1.1-ultra         | 12.66 / 次  | 图像    |
-| /v1/flux-pro               | 10.55 / 次  | 图像    |
-| flux-2-pro                 | 6.33 / 次 + 3.17 / 额外 MP | 图像    |
-| flux-2-max                 | 14.77 / 次 + 6.33 / 额外 MP | 图像    |
-
-## Anthropic
-
-Anthropic 合作节点使用与 Anthropic 公开 API 相同的美元计费逻辑。**积分 = 美元 × 211**（见页眉说明）。以下 token 价格为每百万 token 定价。缓存定价倍率与 Anthropic prompt caching 文档一致。
-
-### Chat (`ClaudeNode`)
-
-以下价格按每百万 token 计算。
-
-| 模型             | 输入积分 / 1M | 5分钟缓存写入积分 / 1M | 1小时缓存写入积分 / 1M | 缓存命中积分 / 1M | 输出积分 / 1M |
-| :-------------- | ------------: | --------------------: | --------------------: | ----------------: | ------------: |
-| `claude-opus-4-7` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-6` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-5-20251101` | 1055 | 1318.75 | 2110 | 105.5 | 5275 |
-| `claude-opus-4-1-20250805` | 3165 | 3956.25 | 6330 | 316.5 | 15825 |
-| `claude-sonnet-4-6` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-sonnet-4-5-20250929` | 633 | 791.25 | 1266 | 63.3 | 3165 |
-| `claude-haiku-4-5-20251001` | 211 | 263.75 | 422 | 21.1 | 1055 |
-
-可选图像按相同的模型输入费率计费。
+| 节点                       |            积分            |
+| :------------------------- | :-------------------------: |
+| Flux 1.1 [pro] Ultra 图像 |          12.66 / 次          |
+| Flux.1 Kontext [pro] 图像 |          8.44 / 次           |
+| Flux.1 Kontext [max] 图像 |          16.88 / 次          |
+| Flux.1 展开图像            |          10.55 / 次          |
+| Flux.1 Fill 图像           |          10.55 / 次          |
+| Flux 擦除图像              | 6.33 / 次 + 0.84 / 额外 MP  |
+| Flux 虚拟试穿              | 7.91 / 次 + 1.06 / 额外 MP  |
+| Flux.2 [pro]               | 6.33 / 次 + 3.17 / 额外 MP  |
+| Flux.2 [max]               | 14.77 / 次 + 6.33 / 额外 MP |
 
 ## Bria
 
-| 产品名称 | 配置 | 积分 | 类别 |
-| :--- | :--- | :--- | :--- |
-| Bria 图像编辑 | endpoint: v2/image/edit, model: fibo | 8.44 / run | 图像 |
-| Bria 图像移除背景 | endpoint: v2/image/edit/remove_background | 3.8 / run | 图像 |
-| Bria 视频移除背景 | endpoint: v2/video/edit/remove_background | 0.89 / sec | 视频 |
-| Bria 视频绿幕 | endpoint: v2/video/edit/green_screen | 0.89 / sec | 视频 |
-| Bria 视频替换背景 | endpoint: v2/video/edit/replace_background | 0.89 / sec | 视频 |
-| Bria 透明视频背景 | endpoint: v2/video/edit/remove_background | 0.89 / sec | 视频 |
+### 图像
+
+| 节点                         | 积分        |
+| :--------------------------- | :---------- |
+| Bria FIBO 图像编辑           | 8.44 / 次   |
+| Bria 移除图像背景            | 3.8 / 次    |
+
+### 视频
+
+| 节点                                     | 积分          |
+| :--------------------------------------- | :------------ |
+| Bria 移除视频背景                        | 0.89 / 秒     |
+| Bria 视频绿幕                            | 0.89 / 秒     |
+| Bria 视频替换背景                        | 0.89 / 秒     |
+| Bria 移除视频背景（透明）                | 0.89 / 秒     |
 
 ## 字节跳动
 
-| 产品名称                                         | 配置                                                              | 积分                 | 类别   |
-| :----------------------------------------------- | :---------------------------------------------------------------- | :------------------- | :----- |
-| BytePlus Seed Input Text Tokens (每百万 tokens)  | model: seed-2-0-pro-260328                                        | 105.5 / 百万 tokens  | Text   |
-| BytePlus Seed Input Text Tokens (每百万 tokens)  | model: seed-2-0-lite-260228                                       | 52.75 / 百万 tokens  | Text   |
-| BytePlus Seed Input Text Tokens (每百万 tokens)  | model: seed-2-0-mini-260215                                       | 21.1 / 百万 tokens   | Text   |
-| BytePlus Seed Output Text Tokens (每百万 tokens) | model: seed-2-0-pro-260328                                        | 633 / 百万 tokens    | Text   |
-| BytePlus Seed Output Text Tokens (每百万 tokens) | model: seed-2-0-lite-260228                                       | 422 / 百万 tokens    | Text   |
-| BytePlus Seed Output Text Tokens (每百万 tokens) | model: seed-2-0-mini-260215                                       | 84.4 / 百万 tokens   | Text   |
-| BytePlus Seed Cache Hit Input Tokens (每百万 tokens) | model: seed-2-0-pro-260328                                    | 21.1 / 百万 tokens   | Text   |
-| BytePlus Seed Cache Hit Input Tokens (每百万 tokens) | model: seed-2-0-lite-260228                                   | 10.55 / 百万 tokens  | Text   |
-| BytePlus Seed Cache Hit Input Tokens (每百万 tokens) | model: seed-2-0-mini-260215                                   | 4.22 / 百万 tokens   | Text   |
-| BytePlus Image Generation Product                 | model: seededit-3-0-i2i-250628                                     | 6.33 / 次           | Image  |
-| BytePlus Image Generation Product                 | model: seedream-3-0-t2i-250415                                     | 6.33 / 次           | Image  |
-| BytePlus Image Generation Product                 | model: seedream-4-0-250828                                         | 6.33 / 次           | Image  |
-| BytePlus Image Generation Product                 | model: seedream-4-5-251128                                         | 8.44 / 次           | Image  |
-| BytePlus Image Generation Product                 | model: seedream-5-0-260128                                         | 7.39 / 次           | Image  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-lite-i2v-250428, video_type: image-to-video    | 379.8 / 百万 tokens  | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-lite-t2v-250428, video_type: text-to-video     | 379.8 / 百万 tokens  | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-pro-250528, video_type: image-to-video         | 527.5 / 百万 tokens  | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-pro-250528, video_type: text-to-video          | 527.5 / 百万 tokens  | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-pro-fast-251015, video_type: image-to-video    | 211 / 百万 tokens    | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedance-1-0-pro-fast-251015, video_type: text-to-video     | 211 / 百万 tokens    | Video  |
-| BytePlus Video Generation Product (每百万 tokens) | model: seedream-4-5-251128, video_type: text-to-video              | 211 / 百万 tokens    | Video  |
-| BytePlus Video Generation With Audio (每百万 tokens) | generate_audio: 否, model: seedance-1-5-pro-251215              | 253.2 / 百万 tokens  | Video  |
-| BytePlus Video Generation With Audio (每百万 tokens) | generate_audio: 是, model: seedance-1-5-pro-251215               | 506.4 / 百万 tokens  | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 720P, video_type: text-to-video (无视频输入: 文本或图像)   | 2.112 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 720P, video_type: image-to-video (无视频输入: 文本或图像)  | 2.112 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 720P, video_type: video-to-video (有视频输入)               | 1.297 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 1080P, video_type: text-to-video (无视频输入: 文本或图像)  | 2.323 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 1080P, video_type: image-to-video (无视频输入: 文本或图像) | 2.323 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 1080P, video_type: video-to-video (有视频输入)              | 1.418 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 4K, video_type: text-to-video (无视频输入: 文本或图像)      | 1.207 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 4K, video_type: image-to-video (无视频输入: 文本或图像)     | 1.207 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0, resolution: 4K, video_type: video-to-video (有视频输入)                  | 0.724 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: text-to-video (无视频输入: 文本或图像)  | 1.690 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: image-to-video (无视频输入: 文本或图像) | 1.690 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-fast, resolution: 720P, video_type: video-to-video (有视频输入)              | 0.995 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: text-to-video (无视频输入: 文本或图像)  | 1.056 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: image-to-video (无视频输入: 文本或图像) | 1.056 / 千 tokens   | Video  |
-| BytePlus Video Generation Product (每千 tokens)   | model: dreamina-seedance-2-0-mini, resolution: 720P, video_type: video-to-video (有视频输入)              | 0.634 / 千 tokens   | Video  |
+以下积分与 ComfyUI 合作伙伴节点定价一致（**211 积分 = 1 美元**）。
 
-> **Seedance 2.0 token 计算方式：** 输出 tokens = (输入视频时长 + 输出视频时长) × 输出视频长度 × 输出视频宽度 × 输出视频帧率 ÷ 1024。当输入为文本、图像或音频时，输入时长计为 0。Seedance 2.0 输出帧率为 24fps。对于视频转视频输入，存在最低 token 用量限制。
+### LLM：字节跳动 Seed
+
+每百万 tokens。以下价格适用于提示词长度 **[0, 128]K**；更长提示词使用更高档位。
+
+| 模型                                                               | 输入积分 / 1M | 缓存命中积分 / 1M | 输出积分 / 1M |
+| :----------------------------------------------------------------- | :----------: | :--------------: | :------------: |
+| Seed 2.0 Pro (`seed-2-0-pro-260328`)                               |    105.5     |      21.1        |      633       |
+| Seed 2.0 Lite (`seed-2-0-lite-260228`)                             |    52.75     |      10.55       |      422       |
+| Seed 2.0 Mini (`seed-2-0-mini-260215`)                             |    21.1      |      4.22        |      84.4      |
+
+可选的图像和视频会以输入费率增加输入 tokens。
+
+### 图像：字节跳动 Seedream 4.5 & 5.0
+
+每成功生成一张图像。
+
+| 模型                                                      | 积分 / 图像 |
+| :-------------------------------------------------------- | :--------: |
+| seedream 5.0 lite (`seedream-5-0-260128`)                 |    7.39    |
+| seedream-4-5-251128                                       |    8.44    |
+| seedream-4-0-250828                                       |    6.33    |
+
+### 图像：字节跳动图片（弃用）
+
+| 模型                       | 积分 / 图像 |
+| :------------------------- | :--------: |
+| seedream-3-0-t2i-250415    |    6.33    |
+
+### 视频：Seedance 2.0
+
+480p 和 720p 使用相同费率。Fast 和 Mini 不支持 1080p 或 4K。
+
+预计 token 消耗：
+
+`(输入视频时长 + 输出视频时长) × 输出视频宽度 × 输出视频高度 × 输出视频帧率 ÷ 1024`
+
+当输入仅为文本、图像或音频时，输入视频时长为 0。实际使用量以 API 为准。
+
+| 模型                    | 分辨率      | 视频输入 | 积分 / 1K tokens |
+| :---------------------- | :---------- | :------- | :--------------: |
+| Seedance 2.0            | 480p, 720p  | 否       |      2.112       |
+| Seedance 2.0            | 480p, 720p  | 是       |      1.297       |
+| Seedance 2.0            | 1080p       | 否       |      2.323       |
+| Seedance 2.0            | 1080p       | 是       |      1.418       |
+| Seedance 2.0            | 4k          | 否       |      1.207       |
+| Seedance 2.0            | 4k          | 是       |      0.724       |
+| Seedance 2.0 Fast       | 480p, 720p  | 否       |      1.690       |
+| Seedance 2.0 Fast       | 480p, 720p  | 是       |      0.996       |
+| Seedance 2.0 Mini       | 480p, 720p  | 否       |      1.056       |
+| Seedance 2.0 Mini       | 480p, 720p  | 是       |      0.634       |
+
+**视频输入**指参考视频已连接。文本、图像和音频参考算作无视频输入。
+
+对于视频转视频输入，可能有最低 token 用量。Seedance 2.0 以 24fps 输出。
+
+### 视频：Seedance 1.x
+
+按 tokens 计费（与 Seedance 2.0 相同的估算公式）。与 Seedance 2.0 不同，**token 费率不随分辨率变化**；分辨率通过公式中的宽度×高度改变单个片段使用的 tokens 数，因此更高分辨率成本更高。
+
+**Token 费率**
+
+| 模型                           | 条件                       | 积分 / 1M tokens |
+| :----------------------------- | :------------------------- | :--------------: |
+| seedance-1-5-pro-251215        | `generate_audio: false`    |      253.2       |
+| seedance-1-5-pro-251215        | `generate_audio: true`     |      506.4       |
+| seedance-1-0-pro-250528        | —                          |      527.5       |
+| seedance-1-0-pro-fast-251015   | —                          |       211        |
+
+**近似积分 / 10 秒**（按 `时长 ÷ 10` 缩放。范围反映宽高比。）
+
+| 模型                           | 分辨率 | generate_audio | 积分 / 10 秒 |
+| :----------------------------- | :----- | :------------- | :----------: |
+| seedance-1-5-pro-251215        | 480p   | off            |    25.32     |
+| seedance-1-5-pro-251215        | 480p   | on             |    50.64     |
+| seedance-1-5-pro-251215        | 720p   | off            |    54.86     |
+| seedance-1-5-pro-251215        | 720p   | on             |    109.72    |
+| seedance-1-5-pro-251215        | 1080p  | off            | 122.38 – 124.49 |
+| seedance-1-5-pro-251215        | 1080p  | on             | 244.76 – 249.0 |
+| seedance-1-0-pro-250528        | 480p   | —              | 48.53 – 50.64 |
+| seedance-1-0-pro-250528        | 720p   | —              | 107.61 – 118.16 |
+| seedance-1-0-pro-250528        | 1080p  | —              | 248.98 – 257.42 |
+| seedance-1-0-pro-fast-251015   | 480p   | —              | 18.99 – 21.1 |
+| seedance-1-0-pro-fast-251015   | 720p   | —              | 44.31 – 48.53 |
+| seedance-1-0-pro-fast-251015   | 1080p  | —              | 99.17 – 103.39 |
+| seedance-1-0-lite-i2v-250428   | 480p   | —              | 35.87 – 37.98 |
+| seedance-1-0-lite-i2v-250428   | 720p   | —              | 78.07 – 86.51 |
+| seedance-1-0-lite-i2v-250428   | 1080p  | —              | 179.35 – 185.68 |
+
+**字节跳动参考图像转视频**（仅 480p 和 720p）：
+
+| 模型                           | 分辨率 | 积分 / 10 秒 |
+| :----------------------------- | :----- | :----------: |
+| seedance-1-0-pro-250528        | 480p   | 48.53 – 50.64 |
+| seedance-1-0-pro-250528        | 720p   | 107.61 – 118.16 |
+| seedance-1-0-lite-i2v-250428   | 480p   | 35.87 – 37.98 |
+| seedance-1-0-lite-i2v-250428   | 720p   | 78.07 – 86.51 |
 
 ## ElevenLabs
 
-| 产品名称                           | 配置                                              | 积分     | 类别 |
-| :--------------------------------- | :------------------------------------------------- | :------- | :--- |
-| 11labs 文本转语音                  | endpoint: v1/text-to-dialogue, model: eleven_v3            | 50.64 / run | 音频 |
-| 11labs 文本转语音                  | endpoint: v1/text-to-speech, model: eleven_multilingual_v2 | 50.64 / run | 音频 |
-| 11labs 文本转语音                  | endpoint: v1/text-to-speech, model: eleven_v3              | 50.64 / run | 音频 |
-| 11labs 语音转文本                  | endpoint: v1/speech-to-text, model: scribe_v2              | 92.84 / run | 音频 |
-| 11labs 语音转文本关键词            | endpoint: v1/speech-to-text, model: scribe_v2              | 18.57 / run | 音频 |
-| 11labs 语音转文本实体检测          | endpoint: scribe_v2, model: v1/speech-to-text              | 27.85 / run | 音频 |
-| 11labs 语音转语音（每分钟）        | endpoint: v1/speech-to-speech                              | 50.64 / min | 音频 |
-| 11labs 声音生成（每分钟）          | endpoint: v1/sound-generation                              | 29.54 / min | 音频 |
-| 11labs 音频隔离（每分钟）          | endpoint: v1/audio-isolation                               | 50.64 / min | 音频 |
-| 11labs 添加声音                    | endpoint: v1/voices/add                                    | 31.65 / run | 音频 |
+| 节点 | 积分 |
+| :--- | :--- |
+| ElevenLabs 文字转语音 | 50.64 / 1K 字符 |
+| ElevenLabs 文本转对话 | 50.64 / 1K 字符 |
+| ElevenLabs 语音转文本 | 1.54 / 分钟 |
+| ElevenLabs 语音转换 | 50.64 / 分钟 |
+| ElevenLabs 文本转音效 | 29.54 / 分钟 |
+| ElevenLabs 语音隔离 | 50.64 / 分钟 |
+| ElevenLabs 实时语音克隆 | 31.65 / 次 |
 
-## Freepik
+## Magnific
 
-| 产品名称                     | 配置                               | 积分         | 类别 |
-| :--------------------------- | :--------------------------------- | :----------- | :--- |
-| Freepik Image Per Generation | endpoint: magnific-relight        | 23.21 / run  | 图像 |
-| Freepik Image Per Generation | endpoint: magnific-style-transfer | 23.21 / run  | 图像 |
-| Freepik Image Per Generation | endpoint: skin-enhancer-creative  | 61.19 / run  | 图像 |
-| Freepik Image Per Generation | endpoint: skin-enhancer-faithful  | 78.07 / run  | 图像 |
-| Freepik Image Per Generation | endpoint: skin-enhancer-flexible  | 94.95 / run  | 图像 |
-| Freepik Image Cost           | NA                                 | 211 / run    | 图像 |
+### 图像：放大
+
+**Magnific 图像放大（创意版）**和**Magnific 图像放大（精确版 V2）**采用相同的计费方式。放大以2倍步长运行（`2x` = 1步，`4x` = 2步，`8x` = 3步，`16x` = 4步）。每一步后，像素数乘以4；每一步按该步输入图像的百万像素数计价。
+
+| 步输入百万像素 | 积分 / 每2倍步 |
+| :--------------- | :---------------- |
+| ≤1.3             | 35.91             |
+| ≤3.0             | 71.82             |
+| ≤6.4             | 107.73            |
+| >6.4             | 430.88            |
+
+**总积分** = 针对你的 `scale_factor` 的所有步骤积分之和。例如：对 1 MP 图像进行 **4x** 放大 → 第1步 1 MP（35.91）+ 第2步 4 MP（107.73）= **143.64 积分**。
+
+### 图像：编辑
+
+| 节点                                    | 积分     |
+| :-------------------------------------- | :---------- |
+| Magnific 图像风格迁移           | 23.21 / 次 |
+| Magnific 图像重光照                  | 23.21 / 次 |
+| Magnific 图像美肤增强（创意版） | 61.19 / 次 |
+| Magnific 图像美肤增强（忠实版） | 78.07 / 次 |
+| Magnific 图像美肤增强（灵活版） | 94.95 / 次 |
 
 ## Google
 
-| 产品名称                                | 配置                                              | 积分            | 类别 |
-| :------------------------------------------- | :---------------------------------------------------------- | :------------------ | :-------- |
-| prod-v1-Veo 2 Product                       | model: veo-2.0-generate-001                                | 105.5 / run        | 图像    |
-| prod-v1-Veo 2 Product                       | model: veo-3.0-generate-preview                            | 158.25 / run       | 图像    |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M tokens  | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3-pro-preview                                | 422 / 1M tokens    | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 527.5 / 1M tokens  | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 527.5 / 1M tokens  | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 2110 / 1M tokens   | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 633 / 1M tokens    | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 2532 / 1M tokens   | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 2532 / 1M tokens   | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 2532 / 1M tokens   | 文本     |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-flash-image-preview                      | 105.5 / 1M tokens  | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | 图像    |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | 图像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-2.5-flash-image                              | 6330 / 1M tokens   | 图像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-flash-image-preview                      | 12660 / 1M tokens  | 图像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3.1-pro-preview                              | 25320 / 1M tokens  | 图像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3-pro-image-preview                          | 25320 / 1M tokens  | 图像    |
-| Gemini Output Image Tokens (per 1M) Product | model: gemini-3-pro-preview                                | 25320 / 1M tokens  | 图像    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 2K      | 21.31 / run        | 图像    |
-| Nano Banana 2 Image Generation              | model: gemini-3.1-flash-image-preview, resolution: 4K      | 32.49 / run        | 图像    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 63.3 / 1M tokens   | 视频    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 63.3 / 1M tokens   | 视频    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | 视频    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | 视频    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | 视频    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | 视频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash-image                              | 211 / 1M tokens    | 音频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-flash                                    | 211 / 1M tokens    | 音频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-2.5-pro                                      | 263.75 / 1M tokens | 音频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3.1-pro-preview                              | 422 / 1M tokens    | 音频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-image-preview                          | 422 / 1M tokens    | 音频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3-pro-preview                                | 422 / 1M tokens    | 音频    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 否, model: veo-3.0-fast-generate-001     | 168.8 / run        | 视频    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 否, model: veo-3.0-generate-001          | 337.6 / run        | 视频    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 是, model: veo-3.0-fast-generate-001      | 253.2 / run        | 视频    |
-| Google Veo3/Veo3 Fast Video Generation      | generateAudio: 是, model: veo-3.0-generate-001           | 675.2 / run        | 视频    |
-| Google Veo2 Video Generation                | 不适用                                                         | 105.5 / run        | 视频    |
-| Google Veo3                                 | generateAudio: 否, model: veo-3.0-fast-generate-001     | 21.1 / run         | 图像    |
-| Google Veo3                                 | generateAudio: 否, model: veo-3.0-generate-001          | 42.2 / run         | 图像    |
-| Google Veo3                                 | generateAudio: 否, model: veo-3.1-fast-generate-preview | 21.1 / run         | 图像    |
-| Google Veo3                                 | generateAudio: 否, model: veo-3.1-generate-preview      | 42.2 / run         | 图像    |
-| Google Veo3                                 | generateAudio: 是, model: veo-3.0-fast-generate-001      | 31.65 / run        | 图像    |
-| Google Veo3                                 | generateAudio: 是, model: veo-3.0-generate-001           | 84.4 / run         | 图像    |
-| Google Veo3                                 | generateAudio: 是, model: veo-3.1-fast-generate-preview  | 31.65 / run        | 图像    |
-| Google Veo3                                 | generateAudio: 是, model: veo-3.1-generate-preview       | 84.4 / run         | 图像    |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-flash-image-preview                      | 633 / 1M tokens    | 文本     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-pro-preview                              | 2532 / 1M tokens   | 文本     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3-pro-image-preview                          | 2532 / 1M tokens   | 文本     |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3-pro-preview                                | 2532 / 1M tokens   | 文本     |
-| Gemini Input Text Tokens (per 1M) Product   | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | 文本     |
-| Gemini Output Text Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M tokens  | 文本     |
-| Gemini Input Image Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | 图像    |
-| Gemini Input Video Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 52.75 / 1M tokens  | 视频    |
-| Gemini Input Audio Tokens (per 1M) Product  | model: gemini-3.1-flash-lite-preview                       | 105.5 / 1M tokens  | 音频    |
-| Gemini Thoughts Tokens (per 1M) Product     | model: gemini-3.1-flash-lite-preview                       | 316.5 / 1M tokens  | 文本     |
+### 聊天：Google Gemini
+
+基于令牌计费；思考令牌按输出文本费率计费。
+
+| 模型                                                   | 输入积分 / 1K | 输出积分 / 1K |
+| :----------------------------------------------------- | ------------: | :------------ |
+| Gemini 3.1 Pro 预览（`gemini-3.1-pro-preview`）        |         0.422 | 2.532         |
+| Gemini 3.1 Flash-Lite 预览（`gemini-3.1-flash-lite-preview`） |       0.05275 | 0.3165        |
+| Gemini 2.5 Pro（`gemini-2.5-pro`）                      |       0.26375 | 2.11          |
+| Gemini 2.5 Flash（`gemini-2.5-flash`）                  |        0.0633 | 0.5275        |
+
+### 图像：Nano Banana
+
+基于令牌计费。
+
+| 模型                                            | 输入积分 / 1K | 输出（文本）积分 / 1K | 输出（图像）积分 / 1K |
+| :---------------------------------------------- | ------------: | --------------------: | :-------------------- |
+| Nano Banana（`gemini-2.5-flash-image`）          |        0.0633 |                0.5275 | 6.33                  |
+| Nano Banana Pro（`gemini-3-pro-image-preview`）  |         0.422 |                 2.532 | 25.32                 |
+| Nano Banana 2（`gemini-3.1-flash-image-preview`）|        0.1055 |                 0.633 | 12.66                 |
+
+### 视频：Google Veo
+
+总积分 = **（积分/秒）× 时长**。
+
+| 模型                                  | 分辨率 | 生成音频 | 积分/秒 |
+| :------------------------------------ | :----- | :------- | :------ |
+| veo-2.0-generate-001                  | —      | —        | 105.5   |
+| veo-3.1-lite                          | 720p   | 否       | 6.33    |
+| veo-3.1-lite                          | 720p   | 是       | 10.55   |
+| veo-3.1-lite                          | 1080p  | 否       | 10.55   |
+| veo-3.1-lite                          | 1080p  | 是       | 16.88   |
+| veo-3.1-fast-generate                 | 720p   | 否       | 16.88   |
+| veo-3.1-fast-generate                 | 720p   | 是       | 21.1    |
+| veo-3.1-fast-generate                 | 1080p  | 否       | 21.1    |
+| veo-3.1-fast-generate                 | 1080p  | 是       | 25.32   |
+| veo-3.1-fast-generate                 | 4k     | 否       | 52.75   |
+| veo-3.1-fast-generate                 | 4k     | 是       | 63.3    |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | 否  | 42.2    |
+| veo-3.1-generate, veo-3.0-generate-001 | 720p, 1080p | 是  | 84.4    |
+| veo-3.1-generate                      | 4k     | 否       | 84.4    |
+| veo-3.1-generate                      | 4k     | 是       | 126.6   |
+| veo-3.0-fast-generate-001             | —      | 否       | 21.1    |
+| veo-3.0-fast-generate-001             | —      | 是       | 31.65   |
 
 ## HappyHorse
 
-| 产品名称                        | 配置                               | 积分       | 类别   |
-| :------------------------------ | :--------------------------------- | :--------- | :----- |
-| HappyHorse 视频生成产品          | 模型: happyhorse1.0, 分辨率: 720P  | 29.54/秒   | 视频   |
-| HappyHorse 视频生成产品          | 模型: happyhorse1.0, 分辨率: 1080P | 50.64/秒   | 视频   |
-| HappyHorse 视频生成产品          | 模型: happyhorse1.1, 分辨率: 720P  | 42.24/秒   | 视频   |
-| HappyHorse 视频生成产品          | 模型: happyhorse1.1, 分辨率: 1080P | 54.31/秒   | 视频   |
+总积分 = **（积分/秒）× `duration`**。
 
-HappyHorse 1.1 支持文生视频、图生视频和参考生视频，价格相同。
+| 模型            | 分辨率   | 积分/秒 |
+| :-------------- | :------- | :------ |
+| HappyHorse 1.0  | 720P     | 29.54   |
+| HappyHorse 1.0  | 1080P    | 50.64   |
+| HappyHorse 1.1  | 720P     | 42.24   |
+| HappyHorse 1.1  | 1080P    | 54.31   |
+
+**HappyHorse 视频编辑**仅支持**HappyHorse 1.0**。按相同费率计费；总积分 = **（积分/秒）× 输出时长**（3–15秒，与输入视频匹配）。
 
 ## Hitpaw
 
-### 视频增强
+### 视频：HitPaw 视频增强
 
-| 产品名称 | 配置 | 积分 | 类别 |
-| :--- | :--- | :--- | :--- |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：720P，帧率：&lt;30fps | 2.11 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：720P，帧率：30-60fps | 4.22 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：720P，帧率：60-120fps | 8.44 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：720P，帧率：≥120fps | 12.66 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：1080P，帧率：&lt;30fps | 3.17 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：1080P，帧率：30-60fps | 6.33 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：1080P，帧率：60-120fps | 12.66 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：1080P，帧率：≥120fps | 18.99 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：2K，帧率：&lt;30fps | 4.22 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：2K，帧率：30-60fps | 8.23 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：2K，帧率：60-120fps | 16.46 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：2K，帧率：≥120fps | 24.69 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：4K，帧率：&lt;30fps | 5.28 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：4K，帧率：30-60fps | 10.76 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：4K，帧率：60-120fps | 21.31 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：4K，帧率：≥120fps | 32.07 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：8K，帧率：&lt;30fps | 6.96 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：8K，帧率：30-60fps | 13.93 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：8K，帧率：60-120fps | 27.85 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：标准，分辨率：8K，帧率：≥120fps | 41.78 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：720P，帧率：&lt;30fps | 3.17 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：720P，帧率：30-60fps | 6.54 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：720P，帧率：60-120fps | 13.08 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：720P，帧率：≥120fps | 19.41 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：1080P，帧率：&lt;30fps | 4.22 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：1080P，帧率：30-60fps | 8.44 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：1080P，帧率：60-120fps | 16.88 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：1080P，帧率：≥120fps | 25.32 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：2K，帧率：&lt;30fps | 5.49 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：2K，帧率：30-60fps | 10.97 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：2K，帧率：60-120fps | 21.94 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：2K，帧率：≥120fps | 32.92 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：4K，帧率：&lt;30fps | 7.17 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：4K，帧率：30-60fps | 14.35 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：4K，帧率：60-120fps | 28.49 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：4K，帧率：≥120fps | 42.83 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：8K，帧率：&lt;30fps | 9.28 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：8K，帧率：30-60fps | 18.57 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：8K，帧率：60-120fps | 37.14 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：极致，分辨率：8K，帧率：≥120fps | 55.7 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：720P，帧率：&lt;30fps | 3.17 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：720P，帧率：30-60fps | 6.33 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：720P，帧率：60-120fps | 12.66 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：720P，帧率：≥120fps | 18.99 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：1080P，帧率：&lt;30fps | 5.28 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：1080P，帧率：30-60fps | 10.55 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：1080P，帧率：60-120fps | 21.1 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：1080P，帧率：≥120fps | 31.65 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：2K，帧率：&lt;30fps | 8.02 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：2K，帧率：30-60fps | 15.82 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：2K，帧率：60-120fps | 31.65 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：2K，帧率：≥120fps | 47.48 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：4K / 8K，帧率：&lt;30fps | 11.82 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：4K / 8K，帧率：30-60fps | 23.84 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：4K / 8K，帧率：60-120fps | 47.48 / 秒 | 视频 |
-| Hitpaw 视频增强产品 | 类型：生成式，分辨率：4K / 8K，帧率：≥120fps | 71.32 / 秒 | 视频 |
+总积分 = **(积分/秒) × 视频时长**。费率取决于输入 FPS。
 
-### 照片增强
+**Portrait Restore / General Restore**（Portrait Restore 1x/2x、General Restore 1x/2x/4x）：
 
-| 产品名称 | 配置 | 积分 | 类别 |
-| :--- | :--- | :--- | :--- |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：&lt;8MP | 2.11 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：8-12MP | 4.22 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：12-24MP | 6.33 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：24-48MP | 14.77 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：48-108MP | 29.54 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：108-216MP | 50.64 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：标准，百万像素：216-432MP | 101.28 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式人像，百万像素：&lt;8MP | 4.22 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式人像，百万像素：8-12MP | 6.33 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式人像，百万像素：12-24MP | 8.44 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式人像，百万像素：24-34MP | 12.66 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式，百万像素：&lt;8MP | 10.55 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式，百万像素：8-12MP | 12.66 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式，百万像素：12-24MP | 16.88 / 次 | 图像 |
-| Hitpaw 照片增强产品 | 类型：生成式，百万像素：24-34MP | 31.65 / 次 | 图像 |
+| 分辨率 | FPS       | 积分/秒 |
+| :----- | :-------- | :------ |
+| 720P   | &lt;30fps | 2.11    |
+| 720P   | 30–60fps  | 4.22    |
+| 720P   | 60–120fps | 8.44    |
+| 720P   | ≥120fps   | 12.66   |
+| 1080P  | &lt;30fps | 3.17    |
+| 1080P  | 30–60fps  | 6.33    |
+| 1080P  | 60–120fps | 12.66   |
+| 1080P  | ≥120fps   | 18.99   |
+| 2K     | &lt;30fps | 4.22    |
+| 2K     | 30–60fps  | 8.23    |
+| 2K     | 60–120fps | 16.46   |
+| 2K     | ≥120fps   | 24.69   |
+| 4K     | &lt;30fps | 5.28    |
+| 4K     | 30–60fps  | 10.76   |
+| 4K     | 60–120fps | 21.31   |
+| 4K     | ≥120fps   | 32.07   |
+| 8K     | &lt;30fps | 6.96    |
+| 8K     | 30–60fps  | 13.93   |
+| 8K     | 60–120fps | 27.85   |
+| 8K     | ≥120fps   | 41.78   |
+
+**Ultra HD**（Ultra HD Model 2x）：
+
+| 分辨率 | FPS       | 积分/秒 |
+| :----- | :-------- | :------ |
+| 720P   | &lt;30fps | 3.17    |
+| 720P   | 30–60fps  | 6.54    |
+| 720P   | 60–120fps | 13.08   |
+| 720P   | ≥120fps   | 19.41   |
+| 1080P  | &lt;30fps | 4.22    |
+| 1080P  | 30–60fps  | 8.44    |
+| 1080P  | 60–120fps | 16.88   |
+| 1080P  | ≥120fps   | 25.32   |
+| 2K     | &lt;30fps | 5.49    |
+| 2K     | 30–60fps  | 10.97   |
+| 2K     | 60–120fps | 21.94   |
+| 2K     | ≥120fps   | 32.92   |
+| 4K     | &lt;30fps | 7.17    |
+| 4K     | 30–60fps  | 14.35   |
+| 4K     | 60–120fps | 28.49   |
+| 4K     | ≥120fps   | 42.83   |
+| 8K     | &lt;30fps | 9.28    |
+| 8K     | 30–60fps  | 18.57   |
+| 8K     | 60–120fps | 37.14   |
+| 8K     | ≥120fps   | 55.7    |
+
+**Generative**（Generative Model 1x；最高 4K）：
+
+| 分辨率 | FPS       | 积分/秒 |
+| :----- | :-------- | :------ |
+| 720P   | &lt;30fps | 3.17    |
+| 720P   | 30–60fps  | 6.33    |
+| 720P   | 60–120fps | 12.66   |
+| 720P   | ≥120fps   | 18.99   |
+| 1080P  | &lt;30fps | 5.28    |
+| 1080P  | 30–60fps  | 10.55   |
+| 1080P  | 60–120fps | 21.1    |
+| 1080P  | ≥120fps   | 31.65   |
+| 2K     | &lt;30fps | 8.02    |
+| 2K     | 30–60fps  | 15.82   |
+| 2K     | 60–120fps | 31.65   |
+| 2K     | ≥120fps   | 47.48   |
+| 4K     | &lt;30fps | 11.82   |
+| 4K     | 30–60fps  | 23.84   |
+| 4K     | 60–120fps | 47.48   |
+| 4K     | ≥120fps   | 71.32   |
+
+### 图像：HitPaw 通用图像增强
+
+**Generative Portrait**：
+
+| 百万像素 | 积分/次 |
+| :------- | :------ |
+| &lt;8MP  | 4.22    |
+| 8–12MP   | 6.33    |
+| 12–24MP  | 8.44    |
+| 24–34MP  | 12.66   |
+
+**Generative**：
+
+| 百万像素 | 积分/次 |
+| :------- | :------ |
+| &lt;8MP  | 10.55   |
+| 8–12MP   | 12.66   |
+| 12–24MP  | 16.88   |
+| 24–34MP  | 31.65   |
 
 ## Ideogram
 
-| 产品名称                                | 配置                                                                   | 积分           | 类别   |
-| :-------------------------------------- | :--------------------------------------------------------------------- | :------------- | :----- |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: DEFAULT     | 45.26 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: QUALITY     | 60.35 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit-character-ref, rendering_speed: TURBO       | 30.17 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: BALANCED                  | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: DEFAULT                   | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: QUALITY                   | 27.16 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/edit, rendering_speed: TURBO                     | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: DEFAULT | 45.26 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: QUALITY | 60.35 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate-character-ref, rendering_speed: TURBO   | 30.17 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: BALANCED              | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: DEFAULT               | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: QUALITY               | 27.16 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/generate, rendering_speed: TURBO                 | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: DEFAULT                | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: QUALITY                | 27.16 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/reframe, rendering_speed: TURBO                  | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: BALANCED                 | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: DEFAULT                  | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: QUALITY                  | 27.16 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/remix, rendering_speed: TURBO                    | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: BALANCED    | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: DEFAULT     | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: QUALITY     | 27.16 / run    | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: ideogram-v3/replace-background, rendering_speed: TURBO       | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V3 Image Generation      | endpoint: remix, rendering_speed: TURBO                                | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: TURBO                 | 9.05 / run     | 图像   |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: DEFAULT               | 18.1 / run     | 图像   |
-| prod-v1-Ideogram V4 Image Generation      | endpoint: ideogram-v4/generate, rendering_speed: QUALITY               | 30.17 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2                                             | 24.14 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: edit, model: v_2_turbo                                       | 15.09 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1                                         | 18.1 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_1_turbo                                   | 6.03 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a                                        | 12.07 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2a_turbo                                  | 7.54 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2                                         | 24.14 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: generate, model: v_2_turbo                                   | 15.09 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2                                          | 24.14 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: reframe, model: v_2_turbo                                    | 15.09 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1                                            | 18.1 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_1_turbo                                      | 6.03 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a                                           | 12.07 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2a_turbo                                     | 7.54 / run     | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2                                            | 24.14 / run    | 图像   |
-| prod-v1-Ideogram Image Generation Product | endpoint: remix, model: v_2_turbo                                      | 15.09 / run    | 图像   |
+| 节点           | turbo | 角色参考 | 渲染速度 | 积分/图像 |
+| :------------- | :---- | :------- | :------- | :-------- |
+| Ideogram V1    | 否    | —        | —        | 18.1      |
+| Ideogram V1    | 是    | —        | —        | 6.03      |
+| Ideogram V2    | 否    | —        | —        | 24.14     |
+| Ideogram V2    | 是    | —        | —        | 15.09     |
+| Ideogram V3    | —     | 否       | TURBO    | 9.05      |
+| Ideogram V3    | —     | 否       | DEFAULT  | 18.1      |
+| Ideogram V3    | —     | 否       | QUALITY  | 27.16     |
+| Ideogram V3    | —     | 是       | TURBO    | 30.17     |
+| Ideogram V3    | —     | 是       | DEFAULT  | 45.26     |
+| Ideogram V3    | —     | 是       | QUALITY  | 60.35     |
+| Ideogram V4    | —     | —        | TURBO    | 9.05      |
+| Ideogram V4    | —     | —        | DEFAULT  | 18.1      |
+| Ideogram V4    | —     | —        | QUALITY  | 30.17     |
 
 ## Krea
 
-| 产品名称 | 配置 | 积分 | 类别 |
-| :------- | :--- | :-- | :--- |
-| Krea 2 图像生成 | 模型：krea-2-medium-turbo | 3.2 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-medium-turbo，附带图像风格参考 | 3.7 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-medium-turbo，附带灵感板 | 4.2 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-medium | 6.4 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-medium，附带图像风格参考 | 7.4 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-medium，附带灵感板 | 8.5 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-large | 12.7 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-large，附带图像风格参考 | 13.8 / 次 | 图像 |
-| Krea 2 图像生成 | 模型：krea-2-large，附带灵感板 | 14.8 / 次 | 图像 |
+| 模型 | 风格参考 | 灵感板 | 积分/次 |
+| :--- | :--- | :--- | :--- |
+| Krea 2 Medium Turbo | 否 | — | 3.17 |
+| Krea 2 Medium Turbo | 是 | 否 | 3.69 |
+| Krea 2 Medium Turbo | — | 是 | 4.22 |
+| Krea 2 Medium | 否 | 否 | 6.33 |
+| Krea 2 Medium | 是 | 否 | 7.39 |
+| Krea 2 Medium | — | 是 | 8.44 |
+| Krea 2 Large | 否 | 否 | 12.66 |
+| Krea 2 Large | 是 | 否 | 13.72 |
+| Krea 2 Large | — | 是 | 14.77 |
 
 ## Kling
 
-| 产品名称                              | 配置                                                 | 积分          | 类别 |
-| :------------------------------------ | :--------------------------------------------------- | :------------ | :--- |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v1                           | 103.39 / 次   | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v1-5                         | 103.39 / 次   | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v1-6                         | 103.39 / 次   | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v2-1                         | 103.39 / 次   | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v2-1-master                  | 295.4 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v2-5-turbo                   | 73.85 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: pro, model: kling-v2-master                    | 295.4 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v1                           | 29.54 / 秒    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v1-5                         | 59.08 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v1-6                         | 59.08 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v2-1                         | 59.08 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v2-1-master                  | 295.4 / 次    | 视频 |
-| prod-v1-Kling 视频生成产品            | mode: std, model: kling-v2-master                    | 295.4 / 次    | 视频 |
-| Kling 有声视频生成产品                | mode: pro, model: kling-v2-6, sound: off             | 14.77 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: pro, model: kling-v2-6, sound: on              | 29.54 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 1080p, model: kling-v3, no_sound: true   | 23.63 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 1080p, model: kling-v3, no_sound: false  | 35.45 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 720p, model: kling-v3, no_sound: true    | 17.72 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 720p, model: kling-v3, no_sound: false   | 26.59 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: pro, model: kling-v3-omni, no_sound: true      | 23.63 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: pro, model: kling-v3-omni, no_sound: false     | 29.54 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: std, model: kling-v3-omni, no_sound: true      | 17.72 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: std, model: kling-v3-omni, no_sound: false     | 23.63 / 秒    | 视频 |
-| Kling 有声视频生成产品                | mode: pro, model: kling-v3-4k                        | 88.62 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 720p, model: kling-3.0-turbo             | 23.63 / 秒    | 视频 |
-| Kling 有声视频生成产品                | resolution: 1080p, model: kling-3.0-turbo            | 29.54 / 秒    | 视频 |
-| Kling Omni 视频产品                   | generate_with_video: false, mode: pro, model: kling-video-o1 | 23.63 / 秒 | 视频 |
-| Kling Omni 视频产品                   | generate_with_video: false, mode: std, model: kling-video-o1 | 17.72 / 秒 | 视频 |
-| Kling Omni 视频产品                   | generate_with_video: true, mode: pro, model: kling-video-o1  | 35.45 / 秒 | 视频 |
-| Kling Omni 视频产品                   | generate_with_video: true, mode: std, model: kling-video-o1  | 26.59 / 秒 | 视频 |
-| Kling 视频扩展产品                    | NA                                                           | 59.08 / 次    | 视频 |
-| Kling 唇形同步产品                    | NA                                                           | 14.77 / 次    | 图像 |
-| Kling 动作控制产品                    | mode: std, model: kling-v2-6                                 | 14.77 / 次    | 图像 |
-| Kling 动作控制产品                    | mode: pro, model: kling-v2-6                                 | 23.63 / 次    | 图像 |
-| Kling 虚拟试穿                        | model: kolors-virtual-try-on-v1                              | 14.77 / 次    | 图像 |
-| Kling 虚拟试穿                        | model: kolors-virtual-try-on-v1-5                            | 14.77 / 次    | 图像 |
-| Kling 图像生成产品                    | model: kling-v1, operation: text_to_image                    | 0.74 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v1, operation: image_to_image                   | 0.74 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v1-5, operation: text_to_image                  | 2.95 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v1-5, operation: image_to_image                 | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v2, operation: text_to_image                    | 2.95 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v2-new, operation: image_to_image_restyle       | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v2-1, operation: text_to_image                  | 2.95 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 1k, operation: text_to_image         | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 2k, operation: text_to_image         | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 1k, operation: image_to_image        | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 2k, operation: image_to_image        | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 1k, operation: image_editing         | 11.82 / 次    | 图像 |
-| Kling 图像生成产品                    | model: kling-v3, specs: 4k, operation: image_editing         | 11.82 / 次    | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 1k, operation: text_to_image    | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 2k, operation: text_to_image    | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 1k, operation: image_to_image   | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 2k, operation: image_to_image   | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 1k, operation: image_editing    | 11.82 / 次    | 图像 |
-| Kling 图像生成产品                    | model: kling-v3-omni, specs: 4k, operation: image_editing    | 11.82 / 次    | 图像 |
-| Kling 图像生成产品                    | model: kling-image-o1, operation: text_to_image               | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-image-o1, operation: image_to_image              | 5.91 / 次     | 图像 |
-| Kling 图像生成产品                    | model: kling-image-o1, operation: image_editing               | 5.91 / 次     | 图像 |
-| Kling 图像生成 (w/ N)                 | model: kling-v1, operation: text_to_image                    | 0.74 / 次     | 图像 |
-| Kling 图像生成 (w/ N)                 | model: kling-v1, operation: image_to_image                   | 0.74 / 次     | 图像 |
-| Kling 图像生成 (w/ N)                 | model: kling-v1-5, operation: text_to_image                  | 2.95 / 次     | 图像 |
-| Kling 图像生成 (w/ N)                 | model: kling-v1-5, operation: image_to_image                 | 5.91 / 次     | 图像 |
-| Kling 图像生成 (w/ N)                 | model: kling-v2, operation: text_to_image                    | 2.95 / 次     | 图像 |
-| Kling 积分                            | type: image                                                  | 0.74 / 次     | 图像 |
-| Kling 积分                            | type: video                                                  | 29.54 / 次    | 图像 |
-| Kling 相机控制产品                    | type: text-to-video                                           | 29.54 / 次    | 视频 |
-| Kling 相机控制产品                    | type: image-to-video                                          | 103.39 / 次   | 视频 |
-| Kling 头像产品                        | mode: std                                                     | 11.82 / 秒    | 视频 |
-| Kling 头像产品                        | mode: pro                                                     | 23.63 / 秒    | 视频 |
-| Kling 2.6 音频产品                    | mode: text-to-video, no_sound: true                           | 14.77 / 秒    | 视频 |
-| Kling 2.6 音频产品                    | mode: text-to-video, no_sound: false                          | 29.54 / 秒    | 视频 |
-| Kling 2.6 音频产品                    | mode: image-to-video, no_sound: true                          | 14.77 / 秒    | 视频 |
-| Kling 2.6 音频产品                    | mode: image-to-video, no_sound: false                         | 29.54 / 秒    | 视频 |
+### 视频：积分/秒
+
+总积分 = **(积分/秒) × `duration`**，**Kling 3.0 Omni 编辑视频**和**Kling 动作控制**除外（按输出秒数计费；编辑时时长跟随输入视频）。
+
+#### kling-video-o1
+
+| 任务               | 分辨率 | 积分/秒 |
+| :----------------- | :----- | :------ |
+| 生成               | 720p   | 17.72   |
+| 生成               | 1080p  | 23.63   |
+| 视频转视频，编辑   | 720p   | 26.59   |
+| 视频转视频，编辑   | 1080p  | 35.45   |
+
+#### kling-v3-omni
+
+| 任务               | 分辨率 | 生成音频 | 积分/秒 |
+| :----------------- | :----- | :------- | :------ |
+| 生成               | 720p   | 否       | 17.72   |
+| 生成               | 720p   | 是       | 23.63   |
+| 生成               | 1080p  | 否       | 23.63   |
+| 生成               | 1080p  | 是       | 29.54   |
+| 生成               | 4k     | 否，是   | 88.62   |
+| 视频转视频，编辑   | 720p   | —        | 26.59   |
+| 视频转视频，编辑   | 1080p  | —        | 35.45   |
+
+#### kling-3.0-turbo
+
+始终生成音频；音频开关被忽略。
+
+| 分辨率 | 积分/秒 |
+| :----- | :------ |
+| 720p   | 23.63   |
+| 1080p  | 29.54   |
+
+#### kling-v3
+
+| 任务 | 分辨率 | 生成音频 | 积分/秒 |
+| :--- | :----- | :------- | :------ |
+| 生成 | 720p   | 否       | 17.72   |
+| 生成 | 720p   | 是       | 26.59   |
+| 生成 | 1080p  | 否       | 23.63   |
+| 生成 | 1080p  | 是       | 35.45   |
+| 生成 | 4k     | 否，是   | 88.62   |
+
+| 任务         | 模式 | 积分/秒 |
+| :----------- | :--- | :------ |
+| 动作控制     | 标准 | 26.59   |
+| 动作控制     | 专业 | 35.45   |
+
+#### kling-v2-6
+
+| 任务         | 生成音频 | 模式 | 积分/秒 |
+| :----------- | :------- | :--- | :------ |
+| 生成         | 否       | —    | 14.77   |
+| 生成         | 是       | —    | 29.54   |
+| 动作控制     | —        | 标准 | 14.77   |
+| 动作控制     | —        | 专业 | 23.63   |
+
+#### 传统模型（v2-5-turbo、v2-master、v1.x）
+
+| 模型                                          | 模式     | 积分/秒 |
+| :-------------------------------------------- | :------- | :------ |
+| kling-v2-5-turbo                              | 专业     | 14.77   |
+| kling-v2-master、kling-v2-1-master            | 标准，专业 | 59.08   |
+| kling-v1-5、kling-v1-6、kling-v2-1           | 标准     | 11.82   |
+| kling-v1                                      | 标准     | 5.91    |
+| kling-v1、kling-v1-5、kling-v1-6、kling-v2-1 | 专业     | 20.68   |
+
+#### Kling 头像 2.0
+
+| 模式 | 积分/秒 |
+| :--- | :------ |
+| 标准 | 11.82   |
+| 专业 | 23.63   |
+
+**Kling 文本/图像转视频（相机控制）**：固定时长 **5秒**，使用 `kling-v1` 标准模式或 `kling-v1-5` 专业模式（参见传统表格）。
+
+### 视频：积分/次
+
+| 模型      | 任务                       | 积分/次 |
+| :-------- | :------------------------- | :------ |
+| kling-v1-6 | 大部分特效场景             | 59.08   |
+| kling-v1-6 | `dizzydizzy`、`bloombloom` | 103.39  |
+| —         | 视频扩展                   | 59.08   |
+| —         | 唇形同步                   | 21.1    |
+
+### 图像
+
+| 模型                                                 | 分辨率 | 图像输入 | 积分         |
+| :--------------------------------------------------- | :----- | :------- | :----------- |
+| kling-image-o1                                       | 1K、2K | —        | 5.91 / 图像  |
+| kling-image-o1                                       | 4K     | —        | 11.82 / 图像 |
+| kling-v3-omni                                        | 1K、2K | —        | 5.91 / 图像  |
+| kling-v3-omni                                        | 4K     | —        | 11.82 / 图像 |
+| kling-v3                                             | —      | 否       | 5.91 / 图像  |
+| kling-v2                                             | —      | 否，是   | 2.95 / 图像  |
+| kling-v1-5                                           | —      | 否       | 2.95 / 图像  |
+| kling-v1-5                                           | —      | 是       | 5.91 / 图像  |
+| kolors-virtual-try-on-v1、kolors-virtual-try-on-v1-5 | —      | —        | 147.7 / 次   |
+
+图像总积分 = **(积分/图像) × `n`**（**Kling 3.0 图像**）；**Kling 3.0 Omni 图像**需乘以 `series_amount`（`kling-image-o1` 始终为 ×1）。
 
 ## Lightricks
 
-| 产品名称                 | 配置                                                           | 积分          | 类别 |
-| :----------------------- | :------------------------------------------------------------- | :------------ | :--- |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-fast，分辨率：1920x1080          | 8.44 / 秒     | 视频 |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-fast，分辨率：2560x1440          | 16.88 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-fast，分辨率：3840x2160          | 33.76 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-pro，分辨率：1920x1080           | 12.66 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-pro，分辨率：2560x1440           | 25.32 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：图像转视频，模型：ltx-2-pro，分辨率：3840x2160           | 50.64 / 次    | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-fast，分辨率：1920x1080          | 8.44 / 秒     | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-fast，分辨率：2560x1440          | 16.88 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-fast，分辨率：3840x2160          | 33.76 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-pro，分辨率：1920x1080           | 12.66 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-pro，分辨率：2560x1440           | 25.32 / 秒    | 视频 |
-| Ltx 视频生成产品         | 端点：文本转视频，模型：ltx-2-pro，分辨率：3840x2160           | 50.64 / 次    | 视频 |
+### 视频：积分/秒
+
+总积分 = **(积分/秒) × `时长`**。
+
+| 模型           | 分辨率   | 积分          |
+| :------------- | :------- | :------------ |
+| LTX-2 (Pro)    | 1080p    | 12.66 / 秒    |
+| LTX-2 (Pro)    | 1440p    | 25.32 / 秒    |
+| LTX-2 (Pro)    | 4K       | 50.64 / 秒    |
+| LTX-2 (Fast)   | 1080p    | 8.44 / 秒     |
+| LTX-2 (Fast)   | 1440p    | 16.88 / 秒    |
+| LTX-2 (Fast)   | 4K       | 33.76 / 秒    |
+
+分辨率对应 `1920x1080`、`2560x1440` 和 `3840x2160`。时长超过 10 秒仅适用于 **LTX-2 (Fast)** 的 1080p 和 25 FPS 模式。
 
 ## Luma
 
-| 产品名称                                                       | 配置                                                                                               | 积分          | 类别 |
-| :------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :------------ | :--- |
-| prod-v1-Luma 视频生成产品                                      | 模型: ray-1-6                                                                                      | 0.97 / 秒     | 视频 |
-| prod-v1-Luma 视频生成产品                                      | 模型: ray-2                                                                                        | 1.93 / 秒     | 视频 |
-| prod-v1-Luma 视频生成产品                                      | 模型: ray-flash-2                                                                                  | 0.66 / 秒     | 视频 |
-| Luma 图像生成（百万像素）产品                                  | 模型: photon-1                                                                                     | 2.2 / 次      | 图像 |
-| Luma 图像生成（百万像素）产品                                  | 模型: photon-flash-1                                                                               | 0.57 / 次     | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 文生图                                                                          | 8.52 / 次     | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图生图                                                                          | 9.16 / 次     | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 1                                               | 9.16 / 次     | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 2                                               | 9.79 / 次     | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 3                                               | 10.42 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 4                                               | 11.06 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 5                                               | 11.69 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 6                                               | 12.32 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 7                                               | 12.96 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 8                                               | 13.59 / 次    | 图像 |
-| Luma Agents uni-1 图像产品                                     | 模型: uni-1, 任务: 图像参考, num_reference_images: 9                                               | 14.22 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 文生图                                                                      | 21.10 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图生图                                                                      | 21.73 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 1                                           | 21.73 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 2                                           | 22.37 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 3                                           | 23.00 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 4                                           | 23.63 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 5                                           | 24.27 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 6                                           | 24.90 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 7                                           | 25.53 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 8                                           | 26.16 / 次    | 图像 |
-| Luma Agents uni-1-max 图像产品                                 | 模型: uni-1-max, 任务: 图像参考, num_reference_images: 9                                           | 26.80 / 次    | 图像 |
+### 视频
 
-### Luma Ray 3.2 视频
+每次 **/run** 的固定价格与节点徽章上的 `duration` 选项一致。**编辑** 和 **重构** 按 **(积分 / 秒) × 视频长度** 计费。**ray-1-6** 始终 **105.50 / 次**。
 
-| 产品名称                 | 配置                       | 积分             | 类别 |
-| :----------------------- | :------------------------- | :--------------- | :--- |
-| Luma Ray 3.2 视频生成    | 分辨率: 360p, 时长: 5秒    | 12.66 / 次       | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 360p, 时长: 10秒   | 37.98 / 次       | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 540p, 时长: 5秒    | 31.65 / 次       | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 540p, 时长: 10秒   | 94.95 / 次       | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 720p, 时长: 5秒    | 63.30 / 次       | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 720p, 时长: 10秒   | 189.90 / 次      | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 1080p, 时长: 5秒   | 253.20 / 次      | 视频 |
-| Luma Ray 3.2 视频生成    | 分辨率: 1080p, 时长: 10秒  | 759.60 / 次      | 视频 |
-| Luma Ray 3.2 视频编辑    | 分辨率: 360p              | 113.94 (5秒) - 227.88 (10秒) / 次 | 视频 |
-| Luma Ray 3.2 视频编辑    | 分辨率: 540p              | 151.92 (5秒) - 303.84 (10秒) / 次 | 视频 |
-| Luma Ray 3.2 视频编辑    | 分辨率: 720p              | 227.88 (5秒) - 455.76 (10秒) / 次 | 视频 |
-| Luma Ray 3.2 视频编辑    | 分辨率: 1080p             | 455.76 (5秒) - 911.52 (10秒) / 次 | 视频 |
-| Luma Ray 3.2 视频重构   | 分辨率: 360p              | 6.33 / 秒        | 视频 |
-| Luma Ray 3.2 视频重构   | 分辨率: 540p              | 12.66 / 秒       | 视频 |
-| Luma Ray 3.2 视频重构   | 分辨率: 720p              | 25.32 / 秒       | 视频 |
-| Luma Ray 3.2 视频重构   | 分辨率: 1080p             | 75.96 / 秒       | 视频 |
+| 模型        | 任务     | 分辨率 | 积分                                                 |
+| :---------- | :------- | :----- | :--------------------------------------------------- |
+| ray-3.2     | 生成     | 360p   | 12.66 / 次（5秒）, 37.98 / 次（10秒）                |
+| ray-3.2     | 生成     | 540p   | 31.65 / 次（5秒）, 94.95 / 次（10秒）                |
+| ray-3.2     | 生成     | 720p   | 63.30 / 次（5秒）, 189.90 / 次（10秒）               |
+| ray-3.2     | 生成     | 1080p  | 253.20 / 次（5秒）, 759.60 / 次（10秒）              |
+| ray-3.2     | 编辑     | 360p   | 22.79 / 秒                                           |
+| ray-3.2     | 编辑     | 540p   | 30.38 / 秒                                           |
+| ray-3.2     | 编辑     | 720p   | 45.58 / 秒                                           |
+| ray-3.2     | 编辑     | 1080p  | 91.15 / 秒                                           |
+| ray-3.2     | 重构     | 360p   | 6.33 / 秒                                            |
+| ray-3.2     | 重构     | 540p   | 12.66 / 秒                                           |
+| ray-3.2     | 重构     | 720p   | 25.32 / 秒                                           |
+| ray-3.2     | 重构     | 1080p  | 75.96 / 秒                                           |
+| ray-2       | 生成     | 540p   | 120.27 / 次（5秒）, 217.33 / 次（9秒）               |
+| ray-2       | 生成     | 720p   | 215.22 / 次（5秒）, 386.13 / 次（9秒）               |
+| ray-2       | 生成     | 1080p  | 478.97 / 次（5秒）, 865.10 / 次（9秒）               |
+| ray-2       | 生成     | 4K     | 1922.21 / 次（5秒）, 3460.40 / 次（9秒）             |
+| ray-flash-2 | 生成     | 540p   | 42.20 / 次（5秒）, 75.96 / 次（9秒）                 |
+| ray-flash-2 | 生成     | 720p   | 71.74 / 次（5秒）, 128.71 / 次（9秒）                |
+| ray-flash-2 | 生成     | 1080p  | 166.69 / 次（5秒）, 299.62 / 次（9秒）               |
+| ray-flash-2 | 生成     | 4K     | 660.43 / 次（5秒）, 1192.15 / 次（9秒）              |
+| ray-1-6     | 生成     | —      | 105.50 / 次                                          |
+
+**Luma Ray 3.2** 的“图像转视频”和“延长视频”始终按 **5秒** 价格计费。传统“图像转视频”使用 **ray-2** / **ray-flash-2** 行中的 **5秒** 或 **9秒** 价格。
+
+### 图像
+
+| 模型          | 任务     | 积分                                                |
+| :------------ | :------- | :-------------------------------------------------- |
+| photon-flash-1 | —        | 0.57 / 次                                           |
+| photon-1      | —        | 2.19 / 次                                           |
+| uni-1         | 生成     | 8.52 / 次 + 0.63 / 参考图像（≤ 9）                  |
+| uni-1         | 编辑     | 9.16 / 次 + 0.63 / 参考图像（≤ 8）                  |
+| uni-1-max     | 生成     | 21.10 / 次 + 0.63 / 参考图像（≤ 9）                 |
+| uni-1-max     | 编辑     | 21.73 / 次 + 0.63 / 参考图像（≤ 8）                 |
+
+参考图像附加费使用四舍五入到4位小数的美元金额，然后在转换为积分。
 
 ## Meshy
 
-| 产品名称                    | 配置                                                           | 积分         | 类别   |
-| :-------------------------- | :------------------------------------------------------------- | :----------- | :----- |
-| Meshy 纹理重绘             | 不适用                                                         | 84.4 / 次    | 3D     |
-| Meshy 骨架绑定             | 不适用                                                         | 42.2 / 次    | 3D     |
-| Meshy 网格重建             | 不适用                                                         | 42.2 / 次    | 3D     |
-| Meshy 动画                 | 不适用                                                         | 25.32 / 次   | 3D     |
-| Meshy 多图转 3D            | should_texture: 否                                             | 42.2 / 次    | 图像   |
-| Meshy 多图转 3D            | should_texture: 是                                             | 126.6 / 次   | 图像   |
-| Meshy 文字转 3D            | mode: 预览, model: 最新                                        | 168.8 / 次   | 3D     |
-| Meshy 文字转 3D            | mode: 预览, model: meshy-5                                     | 42.2 / 次    | 3D     |
-| Meshy 文字转 3D            | mode: 细化, model: 最新                                        | 84.4 / 次    | 3D     |
-| Meshy 图像转 3D            | model: 最新, model_type: lowpoly, should_texture: 否           | 168.8 / 次   | 图像   |
-| Meshy 图像转 3D            | model: 最新, model_type: lowpoly, should_texture: 是           | 253.2 / 次   | 图像   |
-| Meshy 图像转 3D            | model: 最新, model_type: standard, should_texture: 否          | 168.8 / 次   | 图像   |
-| Meshy 图像转 3D            | model: 最新, model_type: standard, should_texture: 是          | 253.2 / 次   | 图像   |
-| Meshy 图像转 3D            | model: meshy-5, model_type: lowpoly, should_texture: 否        | 168.8 / 次   | 图像   |
-| Meshy 图像转 3D            | model: meshy-5, model_type: lowpoly, should_texture: 是        | 253.2 / 次   | 图像   |
-| Meshy 图像转 3D            | model: meshy-5, model_type: standard, should_texture: 否       | 42.2 / 次    | 图像   |
-| Meshy 图像转 3D            | model: meshy-5, model_type: standard, should_texture: 是       | 126.6 / 次   | 图像   |
+| 节点 | should_texture | 积分 |
+| :--- | :--- | :--- |
+| Meshy: 文本转模型 | 不适用 | 168.8 / 次 |
+| Meshy: 细化草稿模型 | 不适用 | 84.4 / 次 |
+| Meshy: 图像转模型 | 否 | 168.8 / 次 |
+| Meshy: 图像转模型 | 是 | 253.2 / 次 |
+| Meshy: 多图转模型 | 否 | 42.2 / 次 |
+| Meshy: 多图转模型 | 是 | 126.6 / 次 |
+| Meshy: 骨架绑定模型 | 不适用 | 42.2 / 次 |
+| Meshy: 动画模型 | 不适用 | 25.32 / 次 |
+| Meshy: 纹理模型 | 不适用 | 84.4 / 次 |
+
+**Meshy: 文本转模型** 生成草稿网格；对返回的 `meshy_task_id` 运行 **Meshy: 细化草稿模型** 来添加纹理。**Meshy: 图像转模型** 和 **Meshy: 多图转模型** 在启用 `should_texture` 时可以一步完成纹理处理。
 
 ## Minimax
 
-| 产品名称                                          | 配置                                                    | 积分           | 类别   |
-| :---------------------------------------------- | :------------------------------------------------------- | :----------- | :------- |
-| prod-v1-Minimax 视频产品                         | 模型: i2v-01-director                                   | 90.73 / run  | 视频    |
-| prod-v1-Minimax 视频产品                         | 模型: i2v-01-live                                       | 90.73 / run  | 视频    |
-| prod-v1-Minimax 视频产品                         | 模型: i2v-01                                            | 90.73 / run  | 视频    |
-| prod-v1-Minimax 视频产品                         | 模型: s2v-01                                            | 137.15 / run | 视频    |
-| prod-v1-Minimax 视频产品                         | 模型: t2v-01-director                                   | 90.73 / run  | 视频    |
-| prod-v1-Minimax 视频产品                         | 模型: t2v-01                                            | 90.73 / run  | 视频    |
-| Minimax 视频生成_Hailuo-02之后模型               | 时长: 10, 模型: minimax-hailuo-02, 分辨率: 768P         | 118.16 / run | 视频    |
-| Minimax 视频生成_Hailuo-02之后模型               | 时长: 6, 模型: minimax-hailuo-02, 分辨率: 1080P        | 103.39 / run | 视频    |
-| Minimax 视频生成_Hailuo-02之后模型               | 时长: 6, 模型: minimax-hailuo-02, 分辨率: 768P          | 59.08 / run  | 视频    |
+| 节点                   | 模型                                | 分辨率 | 积分                              |
+| :--------------------- | :----------------------------------- | :----- | :-------------------------------- |
+| MiniMax 文本转视频      | T2V-01, T2V-01-Director              | —      | 90.73 / 次运行                    |
+| MiniMax 图像转视频      | I2V-01, I2V-01-Director, I2V-01-live | —      | 90.73 / 次运行                    |
+| MiniMax 海螺视频        | MiniMax-Hailuo-02                    | 768P   | 59.08 / 次运行（6秒），118.16 / 次运行（10秒） |
+| MiniMax 海螺视频        | MiniMax-Hailuo-02                    | 1080P  | 103.39 / 次运行（6秒）            |
 
-## Moonvalley
-
-<Warning>
-  **服务不可用**：Moonvalley API 服务已不再可用。下面列出的节点已被弃用，可能无法按预期运行。
-</Warning>
-
-| 产品名称                          | 配置 | 积分        | 类别 |
-| :-------------------------------- | :--- | :---------- | :--- |
-| Moonvalley 图像转视频 5秒         | 无   | 316.5 / 次  | 视频 |
-| Moonvalley 图像转视频 10秒        | 无   | 633 / 次    | 视频 |
-| Moonvalley 文本转视频 5秒         | 无   | 316.5 / 次  | 视频 |
-| Moonvalley 文本转视频 10秒        | 无   | 633 / 次    | 视频 |
-| Moonvalley 视频转视频 5秒         | 无   | 474.75 / 次 | 视频 |
-| Moonvalley 视频转视频 10秒        | 无   | 844 / 次    | 视频 |
+**MiniMax 海螺视频**在1080P下仅支持**6秒**。
 
 ## OpenAI
 
-OpenAI 合作节点按照与公共 API 相同的基础美元用量计费。**积分 = 美元 × 211**（请参见页面标题）。下面的文本模型美元费率匹配 OpenAI 的 **[API 价格](https://developers.openai.com/api/docs/pricing)** **标准**级别（每百万 tokens），如该页面所示；图像 token 倍数匹配 `comfy_api_nodes/nodes_openai.py`。DALL·E 和 Sora 的固定计算匹配节点的 `price_badge` 表达式。最终费用根据计量用量（tokens、时长以及任何缓存命中）计算。
+**积分 = 美元 × 211.** DALL·E 和 Sora 使用固定每张或每秒费率。**OpenAI GPT 图像 2** 和 **OpenAI ChatGPT** 基于 API token 使用量计费。
 
-### DALL·E 2 (`OpenAIDalle2`)
+### 图像：DALL·E
 
-每张已生成的图像（当请求多张时，乘以 `n`）。
+**DALL·E 2** 支持 **256×256**、**512×512** 或 **1024×1024**；总积分 = **(积分/张) × `n`**。**DALL·E 3** 增加了 **`quality`**（`standard` / `hd`）并支持 **1024×1024** 或竖屏 **1024×1792** / **1792×1024**。
 
-| 产品名称              | 配置               | 积分/图像 | 类别 |
-| :-------------------- | :----------------- | :--------- | :--- |
-| OpenAI DALL·E 2 图像  | 尺寸：256x256      | 3.38       | 图像 |
-| OpenAI DALL·E 2 图像  | 尺寸：512x512      | 3.80       | 图像 |
-| OpenAI DALL·E 2 图像  | 尺寸：1024x1024    | 4.22       | 图像 |
+| 节点            | quality | 尺寸                 | 积分        |
+| :-------------- | :------ | :------------------- | :---------- |
+| OpenAI DALL·E 2 | —       | 256x256              | 3.38 / 张   |
+|                 | —       | 512x512              | 3.80 / 张   |
+|                 | —       | 1024x1024            | 4.22 / 张   |
+| OpenAI DALL·E 3 | standard | 1024x1024           | 8.44 / 次   |
+|                 | standard | 1024x1792, 1792x1024 | 16.88 / 次  |
+|                 | hd      | 1024x1024            | 16.88 / 次  |
+|                 | hd      | 1024x1792, 1792x1024 | 25.32 / 次  |
 
-### DALL·E 3 (`OpenAIDalle3`)
+### 图像：GPT 图像
 
-| 产品名称              | 配置                                            | 积分/次运行 | 类别 |
-| :-------------------- | :---------------------------------------------- | :---------- | :--- |
-| OpenAI DALL·E 3 图像  | 质量：standard，尺寸：1024x1024                 | 8.44        | 图像 |
-| OpenAI DALL·E 3 图像  | 质量：standard，尺寸：1024x1792 或 1792x1024    | 16.88       | 图像 |
-| OpenAI DALL·E 3 图像  | 质量：hd，尺寸：1024x1024                       | 16.88       | 图像 |
-| OpenAI DALL·E 3 图像  | 质量：hd，尺寸：1024x1792 或 1792x1024          | 25.32       | 图像 |
+生成后基于 API token 使用量计费。`quality`（`low` / `medium` / `high`）的徽章为近似值；实际费用遵循以下 token 数量。
 
-### GPT Image 1 / 1.5 / 2 (`OpenAIGPTImage1`)
+| model         | token 类型 | 积分/百万 |
+| :------------ | :--------- | :-------- |
+| gpt-image-1   | 输入       | 2110      |
+| gpt-image-1   | 输出（图像）| 8440      |
+| gpt-image-1.5 | 输入       | 1688      |
+| gpt-image-1.5 | 输出（图像）| 6752      |
+| gpt-image-2   | 输入       | 1688      |
+| gpt-image-2   | 输出（图像）| 6330      |
 
-基于 API 用量的 token。积分 = 美元 × 211 每百万 tokens（费率来自节点的 `calculate_tokens_price_image_1` / `calculate_tokens_price_image_1_5` 辅助函数）。
+弃用的 **OpenAI GPT 图像 2** 节点（旧版实现）使用相同的模型和费率。
 
-| 产品名称                                  | 配置               | 积分/百万 tokens | 类别 |
-| :---------------------------------------- | :----------------- | :---------------- | :--- |
-| OpenAI GPT Image 输入（文本/图像）        | 模型：gpt-image-1  | 2110（$10 / 百万）| 图像 |
-| OpenAI GPT Image 输出（图像）             | 模型：gpt-image-1  | 8440（$40 / 百万）| 图像 |
-| OpenAI GPT Image 输入（文本/图像）        | 模型：gpt-image-1.5| 1688（$8 / 百万） | 图像 |
-| OpenAI GPT Image 输出（图像）             | 模型：gpt-image-1.5| 6752（$32 / 百万）| 图像 |
-| OpenAI GPT Image 输入（图像）             | 模型：gpt-image-2  | 1688（$8 / 百万） | 图像 |
-| OpenAI GPT Image 缓存输入（图像）         | 模型：gpt-image-2  | 422（$2 / 百万）  | 图像 |
-| OpenAI GPT Image 输入（文本）             | 模型：gpt-image-2  | 1055（$5 / 百万） | 图像 |
-| OpenAI GPT Image 缓存输入（文本）         | 模型：gpt-image-2  | 263.75（$1.25 / 百万）| 图像 |
-| OpenAI GPT Image 输出（图像）             | 模型：gpt-image-2  | 6330（$30 / 百万）| 图像 |
+### 聊天
 
-UI 根据质量（`低` / `中` / `高`）显示每次运行的大致**美元范围**；实际费用取决于 token 数量。
+基于 token 的计费。徽章费率按 **每 1K token** 计算；表格按 **每百万 token** 计算。
 
-### Chat (`OpenAIChatNode`)
+| Model        | 输入积分/百万 | 输出积分/百万 |
+| :----------- | ------------: | :----------- |
+| gpt-5.5      |           1055 | 6330         |
+| gpt-5.5-pro  |           6330 | 37980        |
+| gpt-5        |         263.75 | 2110         |
+| gpt-5-mini   |          52.75 | 422          |
+| gpt-5-nano   |          10.55 | 84.4         |
+| gpt-4.1      |            422 | 1688         |
+| gpt-4.1-mini |           84.4 | 337.6        |
+| gpt-4.1-nano |           21.1 | 84.4         |
+| o3           |           2110 | 8440         |
+| o4-mini      |          232.1 | 928.4        |
+| o1           |           3165 | 12660        |
+| o1-pro       |          31650 | 126600       |
 
-节点中可选的模型：`gpt-5.5`、`gpt-5.5-pro`、`gpt-5`、`gpt-5-mini`、`gpt-5-nano`、`gpt-4.1`、`gpt-4.1-mini`、`gpt-4.1-nano`、`o3`、`o4-mini`、`o1`、`o1-pro`。标准级别，每百万 tokens（缓存列是 OpenAI 列出的缓存输入费率）。对于同时具有短上下文和长上下文定价的模型，一旦请求超过短上下文窗口，将应用长上下文费率。
+可选的图像和文件会按相同模型费率增加输入 token。
 
-| 模型                          | 输入积分/百万 | 缓存输入积分/百万 | 输出积分/百万 |
-| :---------------------------- | :--------------: | :-----------------: | :--------------: |
-| gpt-5.5（短上下文）           | 1055             | 105.5               | 6330             |
-| gpt-5.5（长上下文）           | 2110             | 211                 | 9495             |
-| gpt-5.5-pro（短上下文）       | 6330             | —                   | 37980            |
-| gpt-5.5-pro（长上下文）       | 12660            | —                   | 56970            |
-| gpt-5                         | 263.75           | 26.38               | 2110             |
-| gpt-5-mini                    | 52.75            | 5.28                | 422              |
-| gpt-5-nano                    | 10.55            | 1.06                | 84.4             |
-| gpt-4.1                       | 422              | 105.5               | 1688             |
-| gpt-4.1-mini                  | 84.4             | 21.1                | 337.6            |
-| gpt-4.1-nano                  | 21.1             | 5.28                | 84.4             |
-| o3                            | 422              | 105.5               | 1688             |
-| o4-mini                       | 232.1            | 58.03               | 928.4            |
-| o1                            | 3165             | 1582.5              | 12660            |
-| o1-pro                        | 31650            | —                   | 126600           |
+### 视频：Sora
 
-可选的图像和文件会增加按相同模型输入费率计费的 tokens。
+<Warning>
+  **弃用**：OpenAI 计划在 2026 年 9 月停止提供 Sora v2 API。此节点在此日期之后可能停止工作。
+</Warning>
 
-### Sora 视频 (`OpenAIVideoSora2`)
+总积分 = **（积分/秒）× `duration`**（`duration` 为 4、8 或 12）。
 
-美元 = **（每秒费率）×（时长秒数）**；时长可以是 4、8 或 12 秒。积分 = 美元 × 211。
+| model        | 尺寸                 | 积分        |
+| :----------- | :------------------- | :---------- |
+| sora-2       | 720x1280, 1280x720   | 21.10 / 秒  |
+| sora-2-pro   | 720x1280, 1280x720   | 63.30 / 秒  |
+| sora-2-pro   | 1024x1792, 1792x1024 | 105.50 / 秒 |
 
-| 产品名称                       | 配置                                           | 积分/秒 | 类别 |
-| :----------------------------- | :--------------------------------------------- | :------ | :--- |
-| OpenAI Sora 视频生成           | 模型：sora-2，尺寸：720x1280 或 1280x720       | 21.10   | 视频 |
-| OpenAI Sora 视频生成           | 模型：sora-2-pro，尺寸：720x1280 或 1280x720   | 63.30   | 视频 |
-| OpenAI Sora 视频生成           | 模型：sora-2-pro，尺寸：1024x1792 或 1792x1024 | 105.50  | 视频 |
-
-示例：`sora-2`，1280x720，8 秒 → 约 **168.8** 积分（$0.10 × 8 × 211）。
+`sora-2` 仅支持 720x1280 和 1280x720。
 
 ## OpenRouter
 
-### OpenRouter LLM (`OpenRouterLLMNode`)
+徽章费率按**每千 tokens**计算；表格为**每百万 tokens**。最终费用根据 API 用量计算。
 
-每 1M tokens。
-
-| 模型                              | 输入积分 / 1M | 输出积分 / 1M |
-| :----------------------------------- | -----------------: | ------------------: |
-| `anthropic/claude-opus-4.7`          |               1055 |                5275 |
-| `openai/gpt-5.5-pro`                 |               6330 |               37980 |
-| `openai/gpt-5.5`                     |               1055 |                6330 |
-| `google/gemini-3.5-flash`            |              316.5 |                1899 |
-| `x-ai/grok-4.20`                     |             263.75 |               527.5 |
-| `x-ai/grok-4.3`                      |             263.75 |               527.5 |
-| `deepseek/deepseek-v4-pro`           |             91.785 |              183.57 |
-| `deepseek/deepseek-v4-flash`         |             23.632 |              47.264 |
-| `deepseek/deepseek-v3.2`             |             53.172 |              79.758 |
-| `qwen/qwen3.6-max-preview`           |             219.44 |             1316.64 |
-| `qwen/qwen3.6-plus`                  |            68.575 |              411.45 |
-| `qwen/qwen3.6-flash`                 |           39.5625 |             237.375 |
-| `mistralai/mistral-large-2512`       |              105.5 |               316.5 |
-| `mistralai/mistral-medium-3-5`       |              316.5 |              1582.5 |
-| `z-ai/glm-4.6`                       |              90.73 |              367.14 |
-| `z-ai/glm-5`                         |              126.6 |              405.12 |
-| `moonshotai/kimi-k2.6`              |             154.03 |              736.39 |
-| `moonshotai/kimi-k2-thinking`        |              126.6 |               527.5 |
-| `perplexity/sonar-pro`               |                633 |                3165 |
-| `perplexity/sonar-reasoning-pro`     |                422 |                1688 |
-| `perplexity/sonar-deep-research`     |                422 |                1688 |
-
-## Pika
-
-| 产品名称                                                | 配置                                                      | 积分         | 类别 |
-| :------------------------------------------------------ | :-------------------------------------------------------- | :----------- | :--- |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/i2v, resolution: 1080p             | 211 / 次     | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/i2v, resolution: 720p              | 126.6 / 次   | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/pikaframes, resolution: 1080p      | 211 / 次     | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/pikaframes, resolution: 720p       | 52.75 / 次   | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/pikascenes, resolution: 1080p      | 316.5 / 次   | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/pikascenes, resolution: 720p       | 84.4 / 次    | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/t2v, resolution: 1080p             | 211 / 次     | 视频 |
-| prod-v1-Pika视频生成产品（10秒）                        | endpoint: generate/2.2/t2v, resolution: 720p              | 126.6 / 次   | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/i2v, resolution: 1080p             | 94.95 / 次   | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/i2v, resolution: 720p              | 42.2 / 次    | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/pikaframes, resolution: 1080p      | 63.3 / 次    | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/pikaframes, resolution: 720p       | 42.2 / 次    | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/pikascenes, resolution: 1080p      | 105.5 / 次   | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/pikascenes, resolution: 720p       | 63.3 / 次    | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/t2v, resolution: 1080p             | 94.95 / 次   | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/2.2/t2v, resolution: 720p              | 42.2 / 次    | 视频 |
-| prod-v1-Pika视频生成（5秒）                             | endpoint: generate/pikaffects, resolution: 720p           | 94.95 / 次   | 视频 |
-| Pika基础视频产品                                        | endpoint: generate/pikadditions                           | 63.3 / 次    | 视频 |
-| Pika基础视频产品                                        | endpoint: generate/pikaffects                             | 94.95 / 次   | 视频 |
-| Pika基础视频产品                                        | endpoint: generate/pikaswaps                              | 63.3 / 次    | 视频 |
+| 模型                                                          | 输入积分/百万 | 输出积分/百万 |
+| :------------------------------------------------------------- | :----------------- | :------------------ |
+| anthropic/claude-opus-4.7                                      | 1055               | 5275                |
+| openai/gpt-5.5-pro                                             | 6330               | 37980               |
+| openai/gpt-5.5                                                 | 1055               | 6330                |
+| google/gemini-3.5-flash                                        | 316.5              | 1899                |
+| x-ai/grok-4.20, x-ai/grok-4.3                                  | 263.75             | 527.5               |
+| deepseek/deepseek-v4-pro                                       | 91.785             | 183.57              |
+| deepseek/deepseek-v4-flash                                     | 23.632             | 47.264              |
+| deepseek/deepseek-v3.2                                         | 53.172             | 79.758              |
+| qwen/qwen3.6-max-preview                                       | 219.44             | 1316.64             |
+| qwen/qwen3.6-plus                                              | 68.575             | 411.45              |
+| qwen/qwen3.6-flash                                             | 39.5625            | 237.375             |
+| mistralai/mistral-large-2512                                   | 105.5              | 316.5               |
+| mistralai/mistral-medium-3-5                                   | 316.5              | 1582.5              |
+| z-ai/glm-4.6                                                   | 90.73              | 367.14              |
+| z-ai/glm-5                                                     | 126.6              | 405.12              |
+| moonshotai/kimi-k2.6                                           | 154.03             | 736.39              |
+| moonshotai/kimi-k2-thinking                                    | 126.6              | 527.5               |
+| perplexity/sonar-pro                                           | 633                | 3165                |
+| perplexity/sonar-reasoning-pro, perplexity/sonar-deep-research | 422                | 1688                |
 
 ## Pixverse
 
-| 产品名称                        | 配置                                                | 积分        | 类别 |
-| :------------------------------ | :-------------------------------------------------- | :---------- | :--- |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: fast, quality: 360p        | 189.9 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: fast, quality: 540p        | 189.9 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: fast, quality: 720p        | 253.2 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 1080p     | 253.2 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 360p      | 94.95 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 540p      | 94.95 /次   | 视频 |
-| Pixverse 5秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 720p      | 126.6 /次   | 视频 |
-| Pixverse 8秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 360p      | 189.9 /次   | 视频 |
-| Pixverse 8秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 540p      | 189.9 /次   | 视频 |
-| Pixverse 8秒视频产品            | 模型: v3.5, motion_mode: normal, quality: 720p      | 253.2 /次   | 视频 |
+模型 **v3.5**（API 中固定，不可选择）。
+
+**1080p** 仅支持 **5 秒** 且运动模式为 **正常**。**8 秒** 片段仅支持 **正常** 运动（快速模式会被强制转为正常）。
+
+| 模型   | 时长 | 运动模式 | 质量        | 积分          |
+| :----- | :--- | :------- | :---------- | :------------ |
+| v3.5   | 5s   | 快速     | 360p, 540p  | 189.9 / 次   |
+|        | 5s   | 快速     | 720p        | 253.2 / 次   |
+|        | 5s   | 正常     | 360p, 540p  | 94.95 / 次   |
+|        | 5s   | 正常     | 720p        | 126.6 / 次   |
+|        | 5s   | 正常     | 1080p       | 253.2 / 次   |
+|        | 8s   | 正常     | 360p, 540p  | 189.9 / 次   |
+|        | 8s   | 正常     | 720p        | 253.2 / 次   |
 
 ## Quiver
 
-| 产品名称              | 配置                       | 积分            | 类别 |
-| :-------------------- | :------------------------- | :-------------- | :--- |
-| Quiver 文本转SVG      | 模型: arrow-1.1            | 60.35 / 次      | 图像 |
-| Quiver 图像转SVG      | 模型: arrow-1.1            | 45.26 / 次      | 图像 |
-| Quiver 文本转SVG      | 模型: arrow-1.1-max        | 75.43 / 次      | 图像 |
-| Quiver 图像转SVG      | 模型: arrow-1.1-max        | 60.35 / 次      | 图像 |
+### 图像
+
+| 模型             | 积分         |
+| :--------------- | :----------- |
+| 箭头-1.1         | 60.35 / 次   |
+| 箭头-1.1-max     | 75.43 / 次   |
+| 箭头-预览        | 90.52 / 次   |
 
 ## Recraft
 
-| 产品名称                     | 配置                                             | 积分         | 类别 |
-| :------------------------- | :--------------------------------------------- | :----------- | :--- |
-| Recraft创建风格             | endpoint: v2/style/create                      | 8.44 / 次    | 图像 |
-| Recraft 文本转图像           | endpoint: v2/auto/text-to-image                | 8.44 / 次    | 图像 |
-| Recraft 图像转图像           | endpoint: v2/auto/image-to-image               | 8.44 / 次    | 图像 |
-| Recraft 内补绘制             | endpoint: v2/auto/inpainting                   | 8.44 / 次    | 图像 |
-| Recraft 文本转矢量           | endpoint: v2/auto/text-to-vector               | 16.88 / 次   | 图像 |
-| Recraft 矢量化图像           | endpoint: v2/auto/vectorize-image              | 2.11 / 次    | 图像 |
-| Recraft 更换背景             | endpoint: v2/image/replace-background          | 8.44 / 次    | 图像 |
-| Recraft 移除背景             | endpoint: v2/image/remove-background           | 2.11 / 次    | 图像 |
-| Recraft 清晰放大             | endpoint: v2/image/crisp-upscale               | 0.84 / 次    | 图像 |
-| Recraft 创意放大             | endpoint: v2/image/creative-upscale            | 52.75 / 次   | 图像 |
-| Recraft V4 文本转图像         | model: recraftv4                               | 8.44 / 次    | 图像 |
-| Recraft V4 文本转图像         | model: recraftv4_pro                           | 52.75 / 次   | 图像 |
-| Recraft V4 文本转矢量         | model: recraftv4                               | 16.88 / 次   | 图像 |
-| Recraft V4 文本转矢量         | model: recraftv4_pro                           | 63.30 / 次   | 图像 |
+### 图像
+
+除非另有说明，否则按次计费。带有 **`n`** 的节点按 **(积分/图像) × `n`** 计费。v3 生成节点在 API 请求中发送模型 **recraftv3**（节点中不可选择）。
+
+| 模型           | 节点                                                                          | 积分                  |
+| :------------- | :---------------------------------------------------------------------------- | :-------------------- |
+| recraftv4_pro  | Recraft V4 文本转图像                                                         | 52.75 /图像 (× `n`)   |
+| recraftv4_pro  | Recraft V4 文本转矢量                                                         | 63.30 /图像 (× `n`)   |
+| recraftv4      | Recraft V4 文本转图像                                                         | 8.44 /图像 (× `n`)    |
+| recraftv4      | Recraft V4 文本转矢量                                                         | 16.88 /图像 (× `n`)   |
+| recraftv3      | Recraft 文本转图像、Recraft 图像转图像、Recraft 图像修复                      | 8.44 /图像 (× `n`)    |
+| recraftv3      | Recraft 文本转矢量                                                            | 16.88 /图像 (× `n`)   |
+| —              | Recraft创建风格                                                               | 8.44 /次              |
+| —              | Recraft 更换背景                                                              | 8.44 /次              |
+| —              | Recraft 矢量化图像、Recraft 移除背景                                          | 2.11 /次              |
+| —              | Recraft 清晰放大图像                                                          | 0.84 /次              |
+| —              | Recraft 创意放大图像                                                          | 52.75 /次             |
 
 ## Reve
 
-> 所示价格为基准价格（test_time_scaling=1, 无后处理）。若启用图像放大或背景移除，实际费用可能更高。
+### 图像
 
-| 产品名称         | 配置                              | 积分        | 类别   |
-| :--------------- | :-------------------------------- | :---------- | :----- |
-| Reve 图像生成    | 模型: reve-create@20250915        | 7.24 / 次   | 图像   |
-| Reve 图像编辑    | 模型: reve-edit@20250915          | 12.07 / 次  | 图像   |
-| Reve 图像编辑    | 模型: reve-edit-fast@20251030     | 2.11 / 次   | 图像   |
-| Reve 图像混合    | 模型: reve-remix@20250915         | 12.07 / 次  | 图像   |
-| Reve 图像混合    | 模型: reve-remix-fast@20251030    | 2.11 / 次   | 图像   |
+以下积分为近似**基础**费率（`test_time_scaling=1`，放大关）。若 `test_time_scaling > 1`、**放大**或**移除背景**，API 实际收费可能会增加。
 
-## Rodin
+| 模型                                    | 节点                               | 放大     | 积分         |
+| :-------------------------------------- | :--------------------------------- | :------- | :----------- |
+| reve-create@20250915                    | Reve 图像生成                      | 关       | 7.24 / 次    |
+|                                         |                                    | 2x       | 9.64 / 次    |
+|                                         |                                    | 3x       | 12.47 / 次   |
+|                                         |                                    | 4x       | 16.08 / 次   |
+| reve-edit@20250915, reve-remix@20250915 | Reve 图像编辑, Reve 图像混合       | 关       | 12.07 / 次   |
+|                                         |                                    | 2x       | 14.47 / 次   |
+|                                         |                                    | 3x       | 17.28 / 次   |
+|                                         |                                    | 4x       | 20.91 / 次   |
+| reve-edit-fast@20251030                 | Reve 图像编辑                      | —        | 2.11 / 次    |
+| reve-remix-fast@20251030                | Reve 图像混合                      | —        | 2.11 / 次    |
 
-### Hyper3D Rodin (Gen-2)
+快速编辑/混合模型采用固定基础费率；放大不改变显示估算值。
 
-| 产品名称                          | 配置     | 积分         | 类别 |
-| :-------------------------------- | :------- | :----------- | :--- |
-| Rodin 3D Generation (无附加功能)  | NA       | 84.4 / 次    | 3D   |
-| Rodin 3D Generation (带附加功能)  | NA       | 253.2 / 次   | 3D   |
+## Rodin 3D
 
-### Hyper3D Rodin Gen-2.5 (`Rodin3D_Gen25_Image` / `Rodin3D_Gen25_Text`)
+| 生成版本 | 节点                                                                                               | 模式             | 高精度包附加 | 积分         |
+| :------- | :--------------------------------------------------------------------------------------------------- | :--------------- | :------------- | :----------- |
+| Gen-2.5  | Rodin 3D Gen-2.5 - 图像转3D, Rodin 3D Gen-2.5 - 文本转3D                                           | 常规, 快速        | 关闭           | 158.25 / 次  |
+| Gen-2.5  |                                                                                                    | 极致高            | 关闭           | 316.5 / 次   |
+| Gen-2.5  |                                                                                                    | 任意             | 开启           | +168.8 / 次  |
+| Gen-2    | Rodin 3D 生成 - 常规生成, 精细生成, 平滑生成, 草图生成, Gen-2 生成                                  | —                | —              | 84.4 / 次    |
 
-| 产品名称                       | 配置                      | 积分          | 类别 |
-| :----------------------------- | :------------------------ | :------------ | :--- |
-| Rodin Gen-2.5 (常规/快速)      | 模式：常规或快速           | 158.25 / 次   | 3D   |
-| Rodin Gen-2.5 (极致高)         | 模式：极致高               | 316.5 / 次    | 3D   |
-| Rodin Gen-2.5 HighPack 附加功能 | addon\_highpack: 是        | +168.8 / 次   | 3D   |
+**HighPack**（`addon_highpack`）在该模式的 Gen-2.5 基础费率上额外增加 **168.8** 积分。
 
 ## Runway
 
-| 产品名称                                   | 配置                     | 积分          | 类别   |
-| :--------------------------------------- | :----------------------- | :------------ | :----- |
-| prod-v1-Runway 视频生成产品                 | 模型：gen3a_turbo        | 15.09 / 秒    | 视频   |
-| prod-v1-Runway 视频生成产品                 | 模型：gen4_turbo         | 10.55 / 秒    | 视频   |
-| prod-v1-Runway 视频生成产品                 | 模型：aleph2             | 84.48 / 秒    | 视频   |
-| RunwayML 图像生成产品                       | 模型：gen4_image         | 24.14 / 次    | 图像   |
-| Runway 首尾帧生成产品                       | 模型：gen4_turbo         | 15.09 / 秒    | 视频   |
+### 视频
+
+Gen3a Turbo、Gen4 Turbo 以及 First-Last-Frame：**5s** 或 **10s**。总积分 = **(积分/秒) × `duration`**。
+
+| 模型         | 积分        |
+| :---------- | :---------- |
+| gen3a_turbo | 15.09 / 秒 |
+| gen4_turbo  | 15.09 / 秒 |
+| aleph2      | 84.48 / 秒 |
+
+**Runway Aleph2 Keyframe** 和 **Runway Aleph2 Prompt Image** 为辅助节点，不单独收费；费用计入 **Runway Aleph2 Video to Video**。
+
+### 图像
+
+| 模型       | 积分        |
+| :--------- | :---------- |
+| gen4_image | 23.21 / 次 |
 
 ## Sonilo
 
-| 产品名称                | 配置                              | 积分        | 类别   |
-| :-------------------- | :-------------------------------- | :---------- | :----- |
-| Sonilo Music Generate | 模型: sonilo, 类型: 视频到音频       | 1.9 / 秒    | 音频   |
-| Sonilo Music Generate | 模型: sonilo, 类型: 文本到音频       | 1.055 / 秒  | 音频   |
+文本生成音乐：总积分 = **（积分/秒） × `duration`**（1–360 秒）。
+
+| 节点                  | 积分         |
+| :-------------------- | :----------- |
+| Sonilo 视频生成音乐   | 1.9 / 秒     |
+| Sonilo 文本生成音乐   | 0.5275 / 秒 |
 
 ## Stability AI
 
-| 产品名称                                   | 配置                                                                         | 积分          | 类别   |
-| :----------------------------------------- | :--------------------------------------------------------------------------- | :------------ | :----- |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/core                                  | 6.33 / 次     | 图像   |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/generate/ultra                                 | 16.88 / 次    | 图像   |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/conservative                           | 84.4 / 次     | 图像   |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/creative                               | 126.6 / 次    | 图像   |
-| prod-v1-Stability Image Generation Product | endpoint: v2beta/stable-image/upscale/fast                                   | 4.22 / 次     | 图像   |
-| Stability AI SD3 Image Products            | model: sd3.5-large                                                           | 13.71 / 次    | 图像   |
-| Stability AI SD3 Image Products            | model: sd3.5-large-turbo                                                     | 8.44 / 次     | 图像   |
-| Stability AI SD3 Image Products            | model: sd3.5-medium                                                          | 7.39 / 次     | 图像   |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/audio-to-audio, model: stable-audio-2.5 | 42.2 / 次     | 音频   |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/inpaint, model: stable-audio-2.5        | 42.2 / 次     | 音频   |
-| Stability Audio Generation Product         | endpoint: v2beta/audio/stable-audio-2/text-to-audio, model: stable-audio-2.5  | 42.2 / 次     | 音频   |
+### 图像
+
+| 节点                                      | 模型           | 积分         |
+| :---------------------------------------- | :------------- | :----------- |
+| Stability AI Stable 图像 Ultra            |                | 16.88 / 次   |
+| Stability AI Stable Diffusion 3.5 图像    | sd3.5-large    | 13.715 / 次  |
+|                                           | sd3.5-medium   | 7.385 / 次   |
+| Stability AI 保守放大                     |                | 84.4 / 次    |
+| Stability AI 创意放大                     |                | 126.6 / 次   |
+| Stability AI 极速放大                     |                | 4.22 / 次    |
+
+### 音频
+
+| 模型             | 积分        |
+| :--------------- | :---------- |
+| stable-audio-2.5 | 42.2 / 次   |
 
 ## 腾讯
 
-| 产品名称              | 配置                                               | 积分          | 类别 |
-| :----------------- | :------------------------------------------------ | :----------- | :--- |
-| 腾讯3D生成类型       | endpoint: hunyuan/3d-pro, generate_type: Geometry | 63.3 / 次    | 3D   |
-| 腾讯3D生成类型       | endpoint: hunyuan/3d-pro, generate_type: LowPoly  | 126.6 / 次   | 3D   |
-| 腾讯3D生成类型       | endpoint: hunyuan/3d-pro, generate_type: Normal   | 105.5 / 次   | 3D   |
-| 腾讯3D生成类型       | endpoint: hunyuan/3d-pro, generate_type: Sketch   | 105.5 / 次   | 3D   |
-| 腾讯3D面部数量       | custom_face_count: true, endpoint: hunyuan/3d-pro | 42.2 / 次    | 3D   |
-| 腾讯3D PBR           | enable_pbr: true, endpoint: hunyuan/3d-pro        | 42.2 / 次    | 3D   |
-| 腾讯3D多视图图像     | endpoint: hunyuan/3d-pro, multi_view: true        | 42.2 / 次    | 图像 |
-| 腾讯3D               | endpoint: hunyuan/3d-part                         | 126.6 / 次   | 3D   |
-| 腾讯3D               | endpoint: hunyuan/3d-texture-edit                 | 126.6 / 次   | 3D   |
-| 腾讯3D               | endpoint: hunyuan/3d-uv                           | 42.2 / 次    | 3D   |
-| 腾讯3D               | endpoint: hunyuan/3d-smart-topology               | 211 / 次     | 3D   |
+**`3.1`** 使用与 **`3.0`** 相同的费率，但不支持 LowPoly。
+
+### 3D：生成
+
+| 模型 | 生成类型 | 积分        |
+| :--- | :------- | :---------- |
+| 3.0  | Geometry | 63.3 / 次   |
+|      | Normal   | 105.5 / 次  |
+|      | LowPoly  | 126.6 / 次  |
+
+附加项在基本费率基础上叠加：
+
+| 模型 | 选项                            | 积分        |
+| :--- | :------------------------------ | :---------- |
+| 3.0  | PBR（启用 `pbr`）                | +42.2 / 次  |
+|      | 自定义 `face_count`（≠ 500000） | +42.2 / 次  |
+|      | 连接了多视图图像                 | +42.2 / 次  |
+
+多视图仅适用于 **Hunyuan3D：图像到模型**，当连接了 `image_left`、`image_right` 或 `image_back` 时。
+
+### 3D：后处理
+
+| 节点                             | 积分        |
+| :------------------------------- | :---------- |
+| Hunyuan3D：模型到 UV             | 42.2 / 次   |
+| Hunyuan3D：智能拓扑              | 211 / 次    |
+
+**Hunyuan3D：3D 纹理编辑** 和 **Hunyuan3D：3D 部件** 各花费 **126.6 / 次**。
 
 ## Topaz
 
-### 图像增强
+### 图像
 
-| 产品名称                          | 配置                                  | 积分         | 类别 |
-| :-------------------------------- | :------------------------------------ | :----------- | :--- |
-| Topaz Image Enhance (Reimagine)   | 输入分辨率：720p (1280x720)           | 13.93 / 次   | 图像 |
-| Topaz Image Enhance (Reimagine)   | 输入分辨率：1080p (1920x1080)         | 27.85 / 次   | 图像 |
-| Topaz Image Enhance (Reimagine)   | 输入分辨率：1440p (2560x1440)         | 27.85 / 次   | 图像 |
-| Topaz Image Enhance (Reimagine)   | 输入分辨率：4K (3840x2160)            | 69.63 / 次   | 图像 |
+费率由 Topaz API 在轮询时返回（**API 积分 × 0.08** 美元）。按输入分辨率的典型收费：
 
-### 视频增强
+| 模型       | 输入分辨率          | 积分          |
+| :--------- | :------------------ | :------------ |
+| Reimagine  | 720p (1280×720)     | 13.93 / 次    |
+|            | 1080p (1920×1080)   | 27.85 / 次    |
+|            | 1440p (2560×1440)   | 27.85 / 次    |
+|            | 4K (3840×2160)      | 69.63 / 次    |
 
-| 产品名称              | 配置                                                                           | 积分            | 类别 |
-| :-------------------- | :----------------------------------------------------------------------------- | :-------------- | :--- |
-| Topaz Video Enhance   | 模型：Starlight Precise 2.5 (slp-2.5)，缩放分辨率：FullHD (1080p)              | 12.99 / 秒      | 视频 |
-| Topaz Video Enhance   | 模型：Starlight Precise 2.5 (slp-2.5)，缩放分辨率：4K (2160p)                  | 28.08 / 秒      | 视频 |
-| Topaz Video Enhance   | 模型：Starlight (Astra) Fast (slf-1)，缩放分辨率：FullHD (1080p)               | 6.50 / 秒       | 视频 |
-| Topaz Video Enhance   | 模型：Starlight (Astra) Fast (slf-1)，缩放分辨率：4K (2160p)                   | 14.16 / 秒      | 视频 |
-| Topaz Video Enhance   | 模型：Starlight (Astra) Creative (slc-1)，缩放分辨率：FullHD (1080p)           | 43.62 / 秒      | 视频 |
-| Topaz Video Enhance   | 模型：Starlight (Astra) Creative (slc-1)，缩放分辨率：4K (2160p)               | 77.99 / 秒      | 视频 |
-| Topaz Video Enhance   | 插值模型：apo-8，输入分辨率：720p                                             | 2.55 / 秒       | 视频 |
-| Topaz Video Enhance   | 插值模型：apo-8，输入分辨率：1080p                                            | 5.57 / 秒       | 视频 |
-| Topaz Video Enhance   | 插值模型：apo-8，输入分辨率：4K                                                | 21.59 / 秒      | 视频 |
-| Topaz Video Enhance   | 模型：Astra 2 (ast-2)，分辨率：1080p                                           | 1.688 / 帧      | 视频 |
-| Topaz Video Enhance   | 模型：Astra 2 (ast-2)，分辨率：4K                                               | 2.813 / 帧      | 视频 |
+### 视频
+
+节点中显示的近似费率为**每来源帧**（非每秒）。总积分 ≈ **(积分/来源帧) × 输入帧数**。启用 **apo-8** 插值后，每个来源帧的放大费率增加 **~0.14**（1080p）或 **~0.28**（4K）。
+
+| 放大模型                     | 放大分辨率      | 积分 / 来源帧 |
+| :--------------------------- | :-------------- | :------------ |
+| Starlight (Astra) Fast       | FullHD (1080p)  | ~0.43         |
+|                              | 4K (2160p)      | ~0.85         |
+| Starlight Precise 2.5        | FullHD (1080p)  | ~0.70         |
+|                              | 4K (2160p)      | ~1.54         |
+| Astra 2                      | FullHD (1080p)  | ~1.72         |
+|                              | 4K (2160p)      | ~2.85         |
+| Starlight (Astra) Creative   | FullHD (1080p)  | ~2.25         |
+|                              | 4K (2160p)      | ~3.99         |
+
+仅启用 **apo-8** 插值且放大设置为 **Disabled** 时：UI 显示为 **仅插值**；费用来自轮询时 API 的估算。
+
+**Topaz 视频增强（传统）** 已弃用。它没有固定预运行估算；费用来自轮询时 API 的估算。
 
 ## Tripo
 
-| 产品名称                                   | 配置                                                                          | 积分            | 类别 |
-| :--------------------------------------- | :-------------------------------------------------------------------------------  | :------------ | :------- |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: detailed, type: image_to_model              | 84.4 / 次    | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: detailed, type: multiview_to_model | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: detailed, type: text_to_model      | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: standard, type: image_to_model     | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: standard, type: multiview_to_model | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.0-20240919, texture_quality: standard, type: text_to_model      | 42.2 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: detailed, type: image_to_model     | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: detailed, type: multiview_to_model | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: detailed, type: text_to_model      | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: standard, type: image_to_model     | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: standard, type: multiview_to_model | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v2.5-20250123, texture_quality: standard, type: text_to_model      | 42.2 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: detailed, type: image_to_model     | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: detailed, type: multiview_to_model | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: detailed, type: text_to_model      | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: standard, type: image_to_model     | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: standard, type: multiview_to_model | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.0-20250812, texture_quality: standard, type: text_to_model      | 42.2 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: detailed, type: image_to_model               | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: detailed, type: multiview_to_model           | 84.4 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: detailed, type: text_to_model                | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: standard, type: image_to_model               | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: standard, type: multiview_to_model           | 63.3 / 次  | 3D       |
-| Tripo 生成（含纹理）产品 | model: v3.1, texture_quality: standard, type: text_to_model                | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.0-20240919, type: image_to_model                                | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.0-20240919, type: multiview_to_model                            | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.0-20240919, type: text_to_model                                 | 21.1 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.5-20250123, type: image_to_model                                | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.5-20250123, type: multiview_to_model                            | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v2.5-20250123, type: text_to_model                                 | 21.1 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.0-20250812, type: image_to_model                                | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.0-20250812, type: multiview_to_model                            | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.0-20250812, type: text_to_model                                 | 21.1 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.1, type: image_to_model                                         | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.1, type: multiview_to_model                                     | 42.2 / 次  | 3D       |
-| Tripo 生成（无纹理）产品   | model: v3.1, type: text_to_model                                          | 21.1 / 次  | 3D       |
-| Tripo 风格产品                      | NA                                                                        | 10.55 / 次 | 3D       |
-| Tripo 四边形产品               | NA                                                                        | 10.55 / 次 | 3D       |
-| Tripo 添加纹理产品                | texture_quality: detailed                                                 | 42.2 / 次  | 3D       |
-| Tripo 添加纹理产品                | texture_quality: standard                                                 | 21.1 / 次  | 3D       |
-| Tripo 后处理产品            | type: animate_retarget                                                    | 21.1 / 次  | 3D       |
-| Tripo 后处理产品            | type: animate_rig                                                         | 52.75 / 次 | 3D       |
-| Tripo 后处理产品            | type: stylize_model                                                       | 42.2 / 次  | 3D       |
-| Tripo 转换产品                    | convert_format: advanced                                                  | 21.1 / 次  | 3D       |
-| Tripo 转换产品                    | convert_format: basic                                                     | 10.55 / 次 | 3D       |
-| Tripo V1-4 生成产品            | type: image_to_model                                                      | 63.3 / 次  | 3D       |
-| Tripo V1-4 生成产品            | type: refine_model                                                        | 63.3 / 次  | 3D       |
-| Tripo V1-4 生成产品            | type: text_to_model                                                       | 42.2 / 次  | 3D       |
-| Tripo 几何质量产品           | geometry_quality: detailed                                                | 42.2 / 次  | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: text_to_model, output_mode: Geometry only                | 63.3 / 次    | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: standard | 84.4 / 次    | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: text_to_model, output_mode: Textured, texture_quality: detailed | 105.5 / 次   | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: image_to_model, output_mode: Geometry only               | 84.4 / 次    | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: standard | 105.5 / 次   | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: image_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / 次   | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: multiview_to_model, output_mode: Geometry only           | 84.4 / 次    | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: standard | 105.5 / 次   | 3D       |
-| Tripo P1 生成产品              | model: P1-20260311, type: multiview_to_model, output_mode: Textured, texture_quality: detailed | 126.6 / 次   | 3D       |
-| Tripo 导入 3D 产品 | NA | 免费 | 3D |
+传统生成价格仅为近似值。该节点将内部Tripo积分按**积分 × 0.01**转换为美元。
+
+### 生成：v1.4
+
+| 模型版本         | 节点                                              | 积分          |
+| :------------- | :------------------------------------------------ | :----------- |
+| v1.4-20240625  | Tripo：文本转模型                                  | 42.2 / 次    |
+|                | Tripo：图像转模型，Tripo：多视图转模型              | 63.3 / 次    |
+
+v1.4 价格为固定值；`texture`、`quad` 和质量设置不会改变估算值。
+
+**Tripo：草稿细化模型**（仅限 v1.4 草稿）：**63.3 / 次**。
+
+### 生成：v2.0 / v2.5
+
+`model_version` **v2.0-20240919** 或 **v2.5-20250123**。`texture` 或 `pbr` 视为已纹理化。在 v2.0 和 v2.5 中，**`geometry_quality：detailed` 不会改变价格**。
+
+**Tripo：文本转模型**
+
+| 纹理  | 纹理质量   | 积分          |
+| :---- | :--------- | :----------- |
+| 关闭  | 标准       | 21.1 / 次    |
+| 开启  | 标准       | 42.2 / 次    |
+| 开启  | 精细       | 63.3 / 次    |
+
+**Tripo：图像转模型** 和 **Tripo：多视图转模型**
+
+| 纹理  | 纹理质量   | 积分          |
+| :---- | :--------- | :----------- |
+| 关闭  | 标准       | 42.2 / 次    |
+| 开启  | 标准       | 63.3 / 次    |
+| 开启  | 精细       | 84.4 / 次    |
+
+| 选项   | 积分            |
+| :----- | :------------- |
+| `quad` | +10.55 / 次    |
+
+`quad` 仅适用于 **Tripo：文本转模型** 和 **Tripo：图像转模型**。
+
+### 生成：v3.0 / v3.1
+
+相同节点，`model_version` 为 **v3.0-20250812** 或 **v3.1-20260211**。**`geometry_quality：detailed`** 在下方纹理行的基础上额外增加 **+42.2 / 次**。
+
+**Tripo：文本转模型**
+
+| 纹理  | 纹理质量   | 几何质量   | 积分            |
+| :---- | :--------- | :--------- | :------------- |
+| 关闭  | 标准       | 标准       | 21.1 / 次      |
+| 关闭  | 标准       | 精细       | 63.3 / 次      |
+| 开启  | 标准       | 标准       | 42.2 / 次      |
+| 开启  | 精细       | 标准       | 63.3 / 次      |
+| 开启  | 标准       | 精细       | 84.4 / 次      |
+| 开启  | 精细       | 精细       | 105.5 / 次     |
+
+**Tripo：图像转模型** 和 **Tripo：多视图转模型**
+
+| 纹理  | 纹理质量   | 几何质量   | 积分            |
+| :---- | :--------- | :--------- | :------------- |
+| 关闭  | 标准       | 标准       | 42.2 / 次      |
+| 关闭  | 标准       | 精细       | 84.4 / 次      |
+| 开启  | 标准       | 标准       | 63.3 / 次      |
+| 开启  | 精细       | 标准       | 84.4 / 次      |
+| 开启  | 标准       | 精细       | 105.5 / 次     |
+| 开启  | 精细       | 精细       | 126.6 / 次     |
+
+`quad` 附加项（+10.55 / 次）仅适用于 **Tripo：文本转模型** 和 **Tripo：图像转模型**。
+
+### 生成：P1
+
+| 模型         | 输出模式      | 纹理质量   | 积分（文本） | 积分（图像/多视图） |
+| :----------- | :------------ | :--------- | :---------- | :---------------- |
+| P1-20260311  | 仅几何        | —          | 63.3 / 次   | 84.4 / 次         |
+|              | 带纹理        | 标准       | 84.4 / 次   | 105.5 / 次        |
+|              | 带纹理        | 精细       | 105.5 / 次  | 126.6 / 次        |
+
+### 后处理
+
+| 节点                          | 积分            |
+| :---------------------------- | :------------- |
+| Tripo：纹理模型                | 21.1 / 次（标准），42.2 / 次（精细） |
+| Tripo：骨骼绑定模型            | 52.75 / 次     |
+| Tripo：重定向绑定模型          | 21.1 / 次      |
+| Tripo：转换模型                | 10.55 / 次（基础），21.1 / 次（高级选项） |
+| Tripo：导入模型                | 免费           |
+
+**Tripo：转换模型** 在以下情况下收费 **21.1 / 次**：`quad` 开启、`face_limit` 已设置、`texture_size` ≠ 4096、`texture_format` ≠ JPEG、`flatten_bottom` 或 `pivot_to_center_bottom` 开启、`flatten_bottom_threshold` ≠ 0、或 `scale_factor` ≠ 1；否则收费 **10.55 / 次**。
 
 ## Vidu
 
-### 视频生成 — Q3
+### 视频：Q3
 
-| 产品名称                       | 配置                                     | 积分          | 类别 |
-| :----------------------------- | :--------------------------------------- | :------------ | :--- |
-| Vidu Q3 视频生成产品           | model: vidu-q3-pro, resolution: 1080P    | 33.76 / 秒    | 视频 |
-| Vidu Q3 视频生成产品           | model: vidu-q3-pro, resolution: 720P     | 31.65 / 秒    | 视频 |
-| Vidu Q3 视频生成产品           | model: vidu-q3-pro, resolution: 540P     | 14.77 / 秒    | 视频 |
-| Vidu Q3 视频生成产品           | model: vidu-q3-turbo, resolution: 1080P  | 16.88 / 秒    | 视频 |
-| Vidu Q3 视频生成产品           | model: vidu-q3-turbo, resolution: 720P   | 12.66 / 秒    | 视频 |
-| Vidu Q3 视频生成产品           | model: vidu-q3-turbo, resolution: 540P   | 8.44 / 秒     | 视频 |
+总积分 = **(积分/秒) × `duration`**。
 
-### 视频生成 — Q2
+| 模型           | 分辨率 | 积分/秒 |
+| :------------- | :----- | :------ |
+| viduq3-turbo   | 720p   | 12.66   |
+|                | 1080p  | 16.88   |
+| viduq3-pro     | 720p   | 31.65   |
+|                | 1080p  | 33.76   |
+|                | 2K     | 42.2    |
 
-> 非高峰时段价格为正常价格的一半。小数部分向上取整。
+**2K** 仅适用于 **Vidu Q3 图像转视频生成** 且使用 **viduq3-pro** 时。
 
-| 产品名称                       | 配置                                                                         | 积分                                   | 类别 |
-| :----------------------------- | :--------------------------------------------------------------------------- | :------------------------------------- | :--- |
-| Vidu Q2 视频生成产品           | model: q2-turbo, type: img2video / start-end2video, resolution: 540P         | 起价 6.33，+2.11/秒                     | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-turbo, type: img2video / start-end2video, resolution: 720P         | 起价 8.44，2 秒后 +10.55/秒             | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-turbo, type: img2video / start-end2video, resolution: 1080P        | 起价 36.92，+10.55/秒                   | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: img2video / start-end2video, resolution: 540P           | 起价 8.44，2 秒后 +5.28/秒              | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: img2video / start-end2video, resolution: 720P           | 起价 15.82，+10.55/秒                   | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: img2video / start-end2video, resolution: 1080P          | 起价 58.03，+15.82/秒                   | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro-fast, type: img2video / start-end2video, resolution: 720P      | 起价 8.44，+2.11/秒                     | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro-fast, type: img2video / start-end2video, resolution: 1080P     | 起价 16.88，+4.22/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: text2video, resolution: 540P                                | 起价 10.55，+2.11/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: text2video, resolution: 720P                                | 起价 15.82，+5.28/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: text2video, resolution: 1080P                               | 起价 21.1，+10.55/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: reference2video, resolution: 540P                           | 起价 15.82，+5.28/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: reference2video, resolution: 720P                           | 起价 26.38，+5.28/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2, type: reference2video, resolution: 1080P                          | 起价 79.12，+10.55/秒                   | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: reference2video, resolution: 540P                       | 起价 21.1，+5.28/秒                     | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: reference2video, resolution: 720P                       | 起价 31.65，+5.28/秒                    | 视频 |
-| Vidu Q2 视频生成产品           | model: q2-pro, type: reference2video, resolution: 1080P                      | 起价 89.67，+10.55/秒                   | 视频 |
+### 视频：Q2
 
-### 视频生成 — Q1
+**线性节点**（除多帧外）：**基数 + (积分/秒) × (`duration` − 1)**。
 
-| 产品名称                       | 配置                                                                                       | 积分          | 类别 |
-| :----------------------------- | :----------------------------------------------------------------------------------------- | :------------ | :--- |
-| Vidu Q1 视频生成产品           | model: vidu-q1, type: reference2video, style: general, duration: 5s, resolution: 1080P     | 84.4 / 次     | 视频 |
-| Vidu Q1 视频生成产品           | model: vidu-q1, type: img2video, style: general, duration: 5s, resolution: 1080P           | 84.4 / 次     | 视频 |
-| Vidu Q1 视频生成产品           | model: vidu-q1, type: start-end2video, style: general, duration: 5s, resolution: 1080P     | 84.4 / 次     | 视频 |
-| Vidu Q1 视频生成产品           | model: vidu-q1, type: text2video, style: general, duration: 5s, resolution: 1080P          | 84.4 / 次     | 视频 |
-| Vidu Q1 视频生成产品           | model: vidu-q1, type: text2video, style: anime, duration: 5s, resolution: 1080P            | 84.4 / 次     | 视频 |
+**多帧：** **`frames` × 基数 + (积分/秒) × 各段时长之和**（使用扩展/多帧基数列）。
 
-### 视频生成 — Vidu 2.0
+**参考**（`viduq2`）：启用 `audio` 时额外 **+15.825 / 次**。
 
-| 产品名称                        | 配置                                                                  | 积分           | 类别 |
-| :------------------------------ | :-------------------------------------------------------------------- | :------------- | :--- |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: img2video, duration: 4S, resolution: 360P      | 21.1 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: img2video, duration: 4S, resolution: 720P      | 42.2 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: img2video, duration: 4S, resolution: 1080P     | 105.5 / 次     | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: img2video, duration: 8S, resolution: 720P      | 105.5 / 次     | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 360P| 84.4 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: reference2video, duration: 4S, resolution: 720P| 84.4 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 360P| 21.1 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 720P| 42.2 / 次      | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: start-end2video, duration: 4S, resolution: 1080P| 105.5 / 次    | 视频 |
-| Vidu 2.0 视频生成产品           | model: vidu-2.0, type: start-end2video, duration: 8S, resolution: 720P| 105.5 / 次     | 视频 |
+| 模型             | 分辨率 | 1秒后积分/秒 | 基数（1秒）线性节点 | 基数（1秒）扩展/多帧 |
+| :--------------- | :----- | :----------- | :------------------ | :------------------- |
+| viduq2           | 720p   | 5.275        | 15.825              | —                    |
+|                  | 1080p  | 10.55        | 21.1                | —                    |
+| viduq2-pro-fast  | 720p   | 2.11         | 8.44                | —                    |
+|                  | 1080p  | 4.22         | 16.88               | —                    |
+| viduq2-pro       | 720p   | 10.55        | 15.825              | 31.65                |
+|                  | 1080p  | 15.825       | 58.025              | 63.3                 |
+| viduq2-turbo     | 1080p  | 10.55        | 36.925              | 42.2                 |
+|                  | 720p   | 5.275（扩展/多帧）；10.55（图生视频/首尾帧，2秒后） | — | 15.825 |
 
-### 图像生成
+上述 **viduq2** 线性基数适用于 **文生视频**。**参考生视频** 使用相同的每秒费用，但基数为 **26.375**（720p）或 **79.125**（1080p）。
 
-| 产品名称                   | 配置                                                                             | 积分           | 类别 |
-| :------------------------- | :------------------------------------------------------------------------------- | :------------- | :--- |
-| Vidu 图像生成产品          | model: viduq2, type: Text to Image, resolution: 1080P                            | 6.33 / 次      | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Text to Image, resolution: 2K                               | 8.44 / 次      | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Text to Image, resolution: 4K                               | 10.55 / 次     | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 1080P      | 8.44 / 次      | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 2K         | 12.66 / 次     | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 1–3, resolution: 4K         | 21.1 / 次      | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 1080P      | 10.55 / 次     | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 2K         | 16.88 / 次     | 图像 |
-| Vidu 图像生成产品          | model: viduq2, type: Reference to Image, ref images: 4–7, resolution: 4K         | 31.65 / 次     | 图像 |
-| Vidu 图像生成产品          | model: viduq1, type: Reference to Image, ref images: 1–7, resolution: 1080P      | 21.1 / 次      | 图像 |
+**viduq2-pro-fast**、**viduq2-pro** 和 **viduq2-turbo** 的线性基数适用于 **图生视频** 和 **首尾帧视频**。**viduq2-turbo** 在 **720p** 下的这些节点中：1秒时 **8.44**（图生视频），2秒时 **10.55**（图生视频固定；首尾帧最短时长为2秒），2秒后 **+10.55/秒**。**5.275/秒** 的速率仅适用于扩展和多帧，不适用于图生视频或首尾帧。
 
-### 视频扩展
+### 视频：Q1
 
-| 产品名称                   | 配置                               | 积分                           | 类别 |
-| :------------------------- | :--------------------------------- | :----------------------------- | :--- |
-| Vidu 视频扩展产品          | model: q2-turbo, resolution: 540P  | 起价 10.55，+2.11/秒            | 视频 |
-| Vidu 视频扩展产品          | model: q2-turbo, resolution: 720P  | 起价 15.82，+5.28/秒            | 视频 |
-| Vidu 视频扩展产品          | model: q2-turbo, resolution: 1080P | 起价 42.2，+10.55/秒            | 视频 |
-| Vidu 视频扩展产品          | model: q2-pro, resolution: 540P    | 起价 15.82，+5.28/秒            | 视频 |
-| Vidu 视频扩展产品          | model: q2-pro, resolution: 720P    | 起价 31.65，+10.55/秒           | 视频 |
-| Vidu 视频扩展产品          | model: q2-pro, resolution: 1080P   | 起价 63.3，+15.82/秒            | 视频 |
+固定 **5秒**，**1080p**。
 
-### 其他功能
-
-| 产品名称           | 配置 | 积分           | 类别 |
-| :----------------- | :--- | :------------- | :--- |
-| Vidu 唇形同步产品  | —    | 21.1 / 5秒     | 视频 |
-| Vidu 动作同步产品  | —    | 10.55 / 秒     | 视频 |
+| 模型    | 积分      |
+| :------ | :-------- |
+| viduq1  | 84.4 / 次 |
 
 ## Wan万相
 
-| 产品名称                     | 配置                                          | 积分          | 类别   |
-| :--------------------------- | :-------------------------------------------- | :------------ | :----- |
-| Wan万相图像生成产品          | model: wan2.5-i2i-preview                     | 6.33 / 次     | 图像   |
-| Wan万相图像生成产品          | model: wan2.5-t2i-preview                     | 6.33 / 次     | 图像   |
-| Wan万相图像生成产品          | model: wan2.6-t2i                             | 6.33 / 次     | 图像   |
-| Wan万相视频生成产品          | model: wan2.5-i2v-preview, resolution: 1080P  | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.5-i2v-preview, resolution: 480P   | 10.55 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.5-i2v-preview, resolution: 720P   | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.5-t2v-preview, resolution: 1080P  | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.5-t2v-preview, resolution: 480P   | 10.55 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.5-t2v-preview, resolution: 720P   | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-i2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-i2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-r2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-r2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-t2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.6-t2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-i2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-i2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-r2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-r2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-t2v, resolution: 1080P          | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-t2v, resolution: 720P           | 21.1 / 秒     | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-videoedit, resolution: 1080P    | 31.65 / 秒    | 视频   |
-| Wan万相视频生成产品          | model: wan2.7-videoedit, resolution: 720P     | 21.1 / 秒     | 视频   |
+| 模型                                                          | 分辨率 | 积分                |
+| :------------------------------------------------------------- | :--------- | :--------------------- |
+| wan2.5-t2i-preview, wan2.5-i2i-preview                         | —          | 6.33 / 次             |
+| wan2.7-t2v, wan2.7-i2v                                         | 720P       | 21.1 / 秒             |
+|                                                                | 1080P      | 31.65 / 秒            |
+| wan2.7-i2v (续作)                                      | 720P       | 21.1 / 秒 (范围)     |
+|                                                                | 1080P      | 31.65 / 秒 (范围)    |
+| wan2.7-videoedit                                               | 720P       | 21.1 / 秒 (输入+输出)  |
+|                                                                | 1080P      | 31.65 / 秒 (输入+输出) |
+| wan2.7-r2v                                                     | 720P       | 21.1 / 秒 (范围)     |
+|                                                                | 1080P      | 31.65 / 秒 (范围)    |
+| wan2.5-t2v-preview, wan2.5-i2v-preview                         | 480p       | 10.55 / 秒            |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 720p       | 21.1 / 秒             |
+| wan2.5-t2v-preview, wan2.5-i2v-preview, wan2.6-t2v, wan2.6-i2v | 1080p      | 31.65 / 秒            |
+| wan2.6-r2v                                                     | 720p       | 21.1 / 秒 (范围)     |
+|                                                                | 1080p      | 31.65 / 秒 (范围)    |
 
-## Wavespeed
+## WaveSpeed
 
-| 产品名称            | 配置                               | 积分           | 类别   |
-| :------------------ | :---------------------------------- | :------------- | :----- |
-| Wavespeed Flashvsr  | 分辨率：1080p                       | 18.99 / 次运行 | 图像   |
-| Wavespeed Flashvsr  | 分辨率：2k                          | 25.32 / 次运行 | 图像   |
-| Wavespeed Flashvsr  | 分辨率：4k                          | 33.76 / 次运行 | 图像   |
-| Wavespeed Flashvsr  | 分辨率：720p                        | 12.66 / 次运行 | 图像   |
-| Wavespeed Image     | 端点：seedvr2                       | 2.11 / 次运行  | 图像   |
-| Wavespeed Image     | 端点：ultimate-image-upscaler       | 12.66 / 次运行 | 图像   |
+| 模型      | 分辨率       | 积分          |
+| :---------| :----------- | :------------ |
+| flashvsr  | 720p         | 2.532 / 秒    |
+|           | 1080p        | 3.798 / 秒    |
+|           | 2K           | 5.064 / 秒    |
+|           | 4K           | 6.752 / 秒    |
+| SeedVR2   | —            | 2.11 / 次     |
+| Ultimate  | —            | 12.66 / 次    |
 
 ## xAI
 
 <Note>
-视频端点对经过审核的内容收费。
+视频端点会对经过审核的内容收费。
 </Note>
-| 产品名称                                   | 配置                                                                                                      | 积分          | 类别   |
-| :--------------------------------------- | :------------------------------------------------------------------------------------------------------- | :------------ | :----- |
-| xAI 图像生成                              | endpoint: v1/images/generations, model: grok-imagine-image-beta, resolution: 1k                         | 6.96 / 次     | 图像   |
-| xAI 图像生成                              | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 1k                      | 10.55 / 次    | 图像   |
-| xAI 图像生成                              | endpoint: v1/images/generations, model: grok-imagine-image-quality, resolution: 2k                      | 14.77 / 次    | 图像   |
-| xAI 图像编辑输出                          | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 6.96 / 次     | 图像   |
-| xAI 图像编辑输出                          | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 1k                            | 10.55 / 次    | 图像   |
-| xAI 图像编辑输出                          | endpoint: v1/images/edits, model: grok-imagine-image-quality, resolution: 2k                            | 14.77 / 次    | 图像   |
-| xAI 图像编辑输入                          | endpoint: v1/images/edits, model: grok-imagine-image-beta, resolution: 1k                               | 0.42 / 次     | 图像   |
-| xAI 图像编辑输入                          | endpoint: v1/images/edits, model: grok-imagine-image-quality                                            | 2.11 / 次     | 图像   |
-| xAI 视频生成输出视频（每秒）              | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 38.19 / 秒    | 视频   |
-| xAI 视频生成输出视频（每秒）              | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p                       | 38.19 / 秒    | 视频   |
-| xAI 视频生成输出视频（每秒）              | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 480p                        | 24.14 / 秒    | 视频   |
-| xAI 视频生成输出视频（每秒）              | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 720p                        | 42.24 / 秒    | 视频   |
-| xAI 视频生成输出视频（每秒）              | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, resolution: 1080p                       | 75.43 / 秒    | 视频   |
-| xAI 视频生成输入图像                      | endpoint: v1/videos/generations, model: grok-imagine-video-1.5, type: image-to-video                    | 3.02 / 秒     | 视频   |
-| xAI 视频生成输入图像                      | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p, type: image-to-video | 0.42 / 秒     | 视频   |
-| xAI 视频生成输入图像                      | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 720p, type: image-to-video | 0.42 / 秒     | 视频   |
-| xAI 视频编辑输入+输出视频（每秒）          | endpoint: v1/videos/edits, model: grok-imagine-video-beta, resolution: 480p                             | 40.3 / 秒     | 视频   |
-| xAI 图像编辑输入                          | endpoint: v1/images/edits, model: v1/images/edits, resolution: 1k                                      | 0.42 / 次     | 图像   |
-| xAI 视频编辑输入+输出视频（每秒）          | endpoint: v1/videos/generations, model: grok-imagine-video-beta, resolution: 480p                       | 40.3 / 秒     | 视频   |
-| xAI 积分                                  | 不适用                                                                                                  | 2.11 / 次     | 图像   |
 
-## 其他（云端）
+### 图像
 
-| 产品名称        | 配置                    | 积分         | 类别 |
-| :-------------- | :---------------------- | :----------- | :--- |
-| GPU 小时产品    | gpu_type: rtx_pro_6000  | 0.27 / 秒    | 图像 |
+| 模型                          | 分辨率   | 任务   | 积分                                                |
+| :---------------------------- | :------- | :----- | :------------------------------------------------- |
+| grok-imagine-image-quality    | 1K       | 生成   | 10.55 / 输出图像                                   |
+|                               | 2K       | 生成   | 14.77 / 输出图像                                   |
+| grok-imagine-image-pro        | —        | 生成   | 14.77 / 输出图像                                   |
+| grok-imagine-image            | —        | 生成   | 4.22 / 输出图像                                    |
+| grok-imagine-image-quality    | 1K       | 编辑   | 2.11 输入 + 10.55 / 输出图像                       |
+|                               | 2K       | 编辑   | 2.11 输入 + 14.77 / 输出图像                       |
+| grok-imagine-image-pro        | —        | 编辑   | 0.422 输入 + 14.77 / 输出图像                      |
+| grok-imagine-image            | —        | 编辑   | 0.422–1.266 输入 + 4.22 / 输出图像                 |
+
+### 视频
+
+| 模型                                 | 分辨率   | 积分                                                             |
+| :----------------------------------- | :------- | :--------------------------------------------------------------- |
+| grok-imagine-video                   | 480p     | 10.55 / 秒 输出（+0.422 输入图像）                               |
+|                                      | 720p     | 14.77 / 秒 输出（+0.422 输入图像）                               |
+| grok-imagine-video-1.5               | 480p     | 24.14 / 秒 输出（+3.02 输入图像）                                |
+|                                      | 720p     | 42.24 / 秒 输出（+3.02 输入图像）                                |
+|                                      | 1080p    | 75.43 / 秒 输出（+3.02 输入图像）                                |
+| grok-imagine-video（编辑）           | —        | 12.66 / 秒（输入 + 输出视频）                                    |
+| grok-imagine-video（参考）           | 480p     | 15.09 / 秒 输出 + 0.603 / 参考图像                               |
+|                                      | 720p     | 21.12 / 秒 输出 + 0.603 / 参考图像                               |
+| grok-imagine-video（扩展）           | —        | 6.03–45.26 输入 + 15.09 × 扩展秒数 输出 / 次                     |
+
+## 云端 GPU
+
+| GPU 类型       | 积分        |
+| :------------- | :---------- |
+| rtx_pro_6000   | 0.27 / 秒   |


### PR DESCRIPTION
## Summary

- Rewrites `tutorials/partner-nodes/pricing.mdx` to align credits with ComfyUI partner node badges (211 credits = $1 USD), using model-first tables and per-provider sections.
- Removes phantom models, verbose "Used by …" node lists, and provider pricing links; keeps only pricing-relevant notes.
- Adds/updates coverage for Wan, WaveSpeed, xAI (input/output labeling), and Cloud GPU (`rtx_pro_6000`).
- Regenerates ja/zh/ko translations and fixes locale unit consistency (`/ 次`/`/ 秒`, `/ 回`/`/ 秒`, `/ 실행`/`/ 초`).

## Test plan

- [ ] Review English pricing tables against ComfyUI `comfy_api_nodes` price badges for key providers (BFL, ByteDance, Kling, xAI, Wan).
- [ ] Spot-check ja/zh/ko `pricing.mdx` for mixed-language unit leaks in Credits columns.
- [ ] Confirm Mintlify preview renders wide tables without truncation.
- [ ] Verify Cloud GPU section appears in all four locales.