### PR TITLE
docs(changelog): add v0.27.1 release notes and publish CMS popup

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -301,6 +301,34 @@
         "zh"
       ],
       "published_at": "2026-07-02T02:41:30.407Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.27.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-09T10:35:50.835Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.27.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-09T10:35:36.845Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="July 8, 2026">
+
+**Partner Node Updates**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance image generation model support added.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Speech, music, sound effects, multi-speaker dialogue.
+* [**Ideogram V1/V2 deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Legacy Ideogram partner nodes deprecated.
+* [**StabilityAI temporarily removed**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI partner nodes temporarily removed.
+
+</Update>
+
 <Update label="v0.27.0" description="June 30, 2026">
 
 **Int8 Support**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="July 8, 2026">
+
+**Actualizaciones de nodos asociados**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Soporte para modelo de generación de imágenes de ByteDance añadido.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Voz, música, efectos de sonido, diálogo multi-orador.
+* [**Ideogram V1/V2 obsoleto**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Nodos asociados heredados de Ideogram obsoletos.
+* [**StabilityAI eliminado temporalmente**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Nodos asociados de StabilityAI eliminados temporalmente.
+
+</Update>
+
 <Update label="v0.27.0" description="30 de junio de 2026">
 
 **Soporte Int8**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="8 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Ajout de la prise en charge du modèle de génération d'images ByteDance.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Parole, musique, effets sonores, dialogue multi-locuteur.
+* [**Ideogram V1/V2 obsolète**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Les nœuds partenaires Ideogram hérités sont obsolètes.
+* [**StabilityAI temporairement retiré**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Les nœuds partenaires StabilityAI ont été temporairement retirés.
+
+</Update>
+
 <Update label="v0.27.0" description="30 juin 2026">
 
 **Support Int8**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026年7月8日">
+
+**パートナーノードの更新**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance画像生成モデルのサポートを追加。
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 音声、音楽、効果音、マルチスピーカーダイアログ。
+* [**Ideogram V1/V2 非推奨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): レガシーIdeogramパートナーノードを非推奨化。
+* [**StabilityAI 一時的に削除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAIパートナーノードを一時的に削除。
+
+</Update>
+
 <Update label="v0.27.0" description="2026年6月30日">
 
 **Int8サポート**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026년 7월 8일">
+
+**파트너 노드 업데이트**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance 이미지 생성 모델 지원 추가.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 음성, 음악, 음향 효과, 다중 화자 대화.
+* [**Ideogram V1/V2 지원 중단됨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 레거시 Ideogram 파트너 노드 지원 중단.
+* [**StabilityAI 일시 제거**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI 파트너 노드가 일시적으로 제거됨.
+
+</Update>
+
 <Update label="v0.27.0" description="2026년 6월 30일">
 
 **Int8 지원**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="8 июля 2026 года">
+
+**Обновления партнёрских узлов**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Добавлена поддержка модели генерации изображений ByteDance.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Речь, музыка, звуковые эффекты, многоголосый диалог.
+* [**Ideogram V1/V2 устарели**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Устаревшие партнёрские узлы Ideogram объявлены устаревшими.
+* [**StabilityAI временно удалены**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Партнёрские узлы StabilityAI временно удалены.
+
+</Update>
+
 <Update label="v0.27.0" description="30 июня 2026 г.">
 
 **Поддержка Int8**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026年7月8日">
+
+**合作节点更新**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): 已添加字节跳动图片生成模型支持。
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 语音、音乐、音效、多说话人对话。
+* [**Ideogram V1/V2 已弃用**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 传统Ideogram合作节点已弃用。
+* [**StabilityAI 暂时移除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI合作节点暂时移除。
+
+</Update>
+
 <Update label="v0.27.0" description="2026年6月30日">
 
 **新模型支持**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="July 8, 2026">
+
+**Partner Node Updates**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance image generation model support added.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Speech, music, sound effects, multi-speaker dialogue.
+* [**Ideogram V1/V2 deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Legacy Ideogram partner nodes deprecated.
+* [**StabilityAI temporarily removed**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI partner nodes temporarily removed.
+
+</Update>
+
 <Update label="v0.27.0" description="June 30, 2026">
 
 **Int8 Support**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="July 8, 2026">
+
+**Actualizaciones de nodos asociados**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Soporte para modelo de generación de imágenes de ByteDance añadido.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Voz, música, efectos de sonido, diálogo multi-orador.
+* [**Ideogram V1/V2 obsoleto**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Nodos asociados heredados de Ideogram obsoletos.
+* [**StabilityAI eliminado temporalmente**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Nodos asociados de StabilityAI eliminados temporalmente.
+
+</Update>
+
 <Update label="v0.27.0" description="30 de junio de 2026">
 
 **Soporte Int8**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="8 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Ajout de la prise en charge du modèle de génération d'images ByteDance.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Parole, musique, effets sonores, dialogue multi-locuteur.
+* [**Ideogram V1/V2 obsolète**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Les nœuds partenaires Ideogram hérités sont obsolètes.
+* [**StabilityAI temporairement retiré**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Les nœuds partenaires StabilityAI ont été temporairement retirés.
+
+</Update>
+
 <Update label="v0.27.0" description="30 juin 2026">
 
 **Support Int8**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026年7月8日">
+
+**パートナーノードの更新**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance画像生成モデルのサポートを追加。
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 音声、音楽、効果音、マルチスピーカーダイアログ。
+* [**Ideogram V1/V2 非推奨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): レガシーIdeogramパートナーノードを非推奨化。
+* [**StabilityAI 一時的に削除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAIパートナーノードを一時的に削除。
+
+</Update>
+
 <Update label="v0.27.0" description="2026年6月30日">
 
 **Int8サポート**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026년 7월 8일">
+
+**파트너 노드 업데이트**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance 이미지 생성 모델 지원 추가.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 음성, 음악, 음향 효과, 다중 화자 대화.
+* [**Ideogram V1/V2 지원 중단됨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 레거시 Ideogram 파트너 노드 지원 중단.
+* [**StabilityAI 일시 제거**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI 파트너 노드가 일시적으로 제거됨.
+
+</Update>
+
 <Update label="v0.27.0" description="2026년 6월 30일">
 
 **Int8 지원**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="8 июля 2026 года">
+
+**Обновления партнёрских узлов**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Добавлена поддержка модели генерации изображений ByteDance.
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Речь, музыка, звуковые эффекты, многоголосый диалог.
+* [**Ideogram V1/V2 устарели**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Устаревшие партнёрские узлы Ideogram объявлены устаревшими.
+* [**StabilityAI временно удалены**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Партнёрские узлы StabilityAI временно удалены.
+
+</Update>
+
 <Update label="v0.27.0" description="30 июня 2026 г.">
 
 **Поддержка Int8**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,16 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.27.1" description="2026年7月8日">
+
+**合作节点更新**
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): 已添加字节跳动图片生成模型支持。
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 语音、音乐、音效、多说话人对话。
+* [**Ideogram V1/V2 已弃用**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 传统Ideogram合作节点已弃用。
+* [**StabilityAI 暂时移除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI合作节点暂时移除。
+
+</Update>
+
 <Update label="v0.27.0" description="2026年6月30日">
 
 **新模型支持**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,19 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.27.1" description="July 8, 2026">
+
+**Partner Node Updates**
+* [**Seedream 5 Pro**](https://links.comfy.org/3R12fXw): ByteDance Seedream 5 Pro image generation model support
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): ByteDance Seed Audio 1.0 for speech, music, sound effects, and multi-speaker dialogue
+* [**Ideogram V1/V2 deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Deprecated legacy Ideogram V1 and V2 partner nodes
+* [**StabilityAI temporarily removed**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI partner nodes temporarily removed
+
+**Bug Fixes**
+* [**Video decode**](https://github.com/Comfy-Org/ComfyUI/pull/14746): Fixed crash on videos with undecodable audio streams
+
+</Update>
+
 <Update label="v0.27.0" description="June 30, 2026">
 
 **int8 Model Support**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: eb04ad8e
+translationSourceHash: f490e5fa
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
   "v0.26.1": 9e645618
@@ -103,6 +104,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.27.1" description="2026年7月8日">
+
+**パートナーノードの更新**
+* [**Seedream 5 Pro**](https://links.comfy.org/3R12fXw): ByteDance Seedream 5 Pro 画像生成モデルのサポート
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): ByteDance Seed Audio 1.0：音声、音楽、効果音、マルチスピーカーダイアログ用
+* [**Ideogram V1/V2 非推奨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): レガシーIdeogram V1およびV2パートナーノードを非推奨に
+* [**StabilityAI 一時的に削除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAIパートナーノードを一時的に削除
+
+**バグ修正**
+* [**ビデオデコード**](https://github.com/Comfy-Org/ComfyUI/pull/14746): デコードできないオーディオストリームを含む動画のクラッシュを修正
+
+</Update>
 
 <Update label="v0.27.0" description="2026年6月30日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: eb04ad8e
+translationSourceHash: f490e5fa
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
   "v0.26.1": 9e645618
@@ -103,6 +104,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.27.1" description="2026년 7월 8일">
+
+**파트너 노드 업데이트**
+* [**Seedream 5 Pro**](https://links.comfy.org/3R12fXw): ByteDance Seedream 5 Pro 이미지 생성 모델 지원
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): ByteDance Seed Audio 1.0 - 음성, 음악, 효과음 및 다중 화자 대화 지원
+* [**Ideogram V1/V2 지원 중단**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 레거시 Ideogram V1 및 V2 파트너 노드 지원 중단
+* [**StabilityAI 임시 제거**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI 파트너 노드 임시 제거
+
+**버그 수정**
+* [**비디오 디코딩**](https://github.com/Comfy-Org/ComfyUI/pull/14746): 디코딩할 수 없는 오디오 스트림이 있는 비디오에서 발생하는 충돌 수정
+
+</Update>
 
 <Update label="v0.27.0" description="2026년 6월 30일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: eb04ad8e
+translationSourceHash: f490e5fa
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
   "v0.26.1": 9e645618
@@ -103,6 +104,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.27.1" description="2026年7月8日">
+
+**合作节点更新**
+* [**Seedream 5 Pro**](https://links.comfy.org/3R12fXw)：支持字节跳动 Seedream 5 Pro 图像生成模型
+* [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731)：字节跳动 Seed Audio 1.0，支持语音、音乐、音效及多说话人对话
+* [**Ideogram V1/V2 弃用**](https://github.com/Comfy-Org/ComfyUI/pull/14712)：弃用传统 Ideogram V1 和 V2 合作节点
+* [**StabilityAI 暂时移除**](https://github.com/Comfy-Org/ComfyUI/pull/14737)：暂时移除 StabilityAI 合作节点
+
+**错误修复**
+* [**视频解码**](https://github.com/Comfy-Org/ComfyUI/pull/14746)：修复了视频中含有无法解码的音频流时崩溃的问题
+
+</Update>
 
 <Update label="v0.27.0" description="2026年6月30日">
 


### PR DESCRIPTION
## Summary
- Add **v0.27.1** to docs changelog (EN + ja/zh/ko): Seedream 5 Pro, Seed Audio 1.0, Ideogram V1/V2 deprecated, StabilityAI temporarily removed, video decode fix.
- Add CMS popup staging for v0.27.1 (en/zh/ja/ko/fr/ru/es) for **comfyui** and **cloud** projects.
- Seedream links differ by surface: docs use `links.comfy.org/3R12fXw`; CMS comfyui uses `4ydIJYi`; CMS cloud uses `4vTG0BN`.
- **CMS published live** for both projects (7 locales each); `published-versions.json` updated.

## Test plan
- [x] `pnpm cms:preview -- --project comfyui v0.27.1`
- [x] `pnpm cms:sync -- --project comfyui v0.27.1`
- [x] `pnpm cms:publish -- --project comfyui v0.27.1`
- [x] `pnpm cms:preview -- --project cloud v0.27.1`
- [x] `pnpm cms:sync -- --project cloud v0.27.1`
- [x] `pnpm cms:publish -- --project cloud v0.27.1`
- [ ] Verify in-app popup shows v0.27.1 for comfyui and cloud
- [ ] Spot-check docs changelog on Mintlify (EN/zh)