### PR TITLE
fix(i18n): sub-chunk oversized H2 blocks to prevent truncation

### DIFF
--- a/.cursor/skills/docs-i18n-translate/SKILL.md
+++ b/.cursor/skills/docs-i18n-translate/SKILL.md
@@ -115,6 +115,10 @@ pnpm translate -- changelog/index.mdx --lang zh
 | `heading_sections` | Long reference pages | `chunked_files` or `auto_chunk` (≥3k chars, ≥2 `##`) |
 | `update_blocks` | Changelog | `chunked_files` entry for `changelog/index.mdx` |
 
+Oversized individual `##` blocks (e.g. many Mintlify Tabs) are sub-chunked when
+they exceed `auto_chunk.max_block_chars` (default 6000): Tabs → `###` → fence-safe
+size splits. Invalid/truncated blocks stay pending (hash not updated).
+
 Checkpoints per block — safe to resume after interrupt.
 
 ```bash

--- a/.github/scripts/i18n/README.md
+++ b/.github/scripts/i18n/README.md
@@ -80,6 +80,27 @@ Configure explicit paths in `translation-config.json` → `chunked_files`, or re
 on `auto_chunk` (default: body ≥ 3k chars and ≥ 2 `##` sections) to auto-enable
 `heading_sections`.
 
+**Oversized H2 blocks:** a single `##` section can still be too large for one API
+call (e.g. Install tabs with many Mintlify `<Tab>` children). When an English
+block exceeds `auto_chunk.max_block_chars` (default **6000**), the translator
+sub-chunks it for the API only:
+
+1. Mintlify `<Tab title="…">…</Tab>` pieces (preferred)
+2. Else `###` subheadings
+3. Else fence-safe soft splits by character budget
+
+Pieces are translated separately and concatenated. Sync hashes stay keyed by the
+H2 label (no frontmatter schema change).
+
+API calls use `max_tokens: 16384` and inspect `finish_reason`. Truncated or
+structurally invalid block output (wrong Tab count, unclosed fences, short line
+ratio, `finish_reason === "length"`) is **rejected**: previous target content is
+kept and that block’s hash is left pending so the next run retries. A file with
+failed blocks is reported as failed, not silently marked up-to-date.
+
+Truncation scan also flags per-block problems (`truncated_block`) when whole-file
+line count still looks acceptable but a Tab-heavy section is cut.
+
 Changelog `<Update description="…">` dates are **derived from English** and
 localized automatically (`ja`/`zh`: `YYYY年M月D日`, `ko`: `YYYY년 M월 D일`) after
 each block is translated or re-serialized — English month names should not
@@ -89,7 +110,7 @@ During a chunked run the script:
 
 1. Parses English into blocks (intro + each `##` section).
 2. Compares each block’s hash to `translationBlockHashes` in the target frontmatter.
-3. Translates only pending blocks (plus frontmatter when needed).
+3. Translates only pending blocks (plus frontmatter when needed), sub-chunking oversized blocks.
 4. Checkpoints after every block so a failed run can resume.
 
 `translationBlockHashes` keys are written in **descending semver order** for

--- a/.github/scripts/i18n/check-translation-truncation.ts
+++ b/.github/scripts/i18n/check-translation-truncation.ts
@@ -25,8 +25,13 @@ import {
   TRUNCATION_ISSUES_TXT,
 } from "./i18n-config.mjs";
 import {
+  countNonEmptyLines,
+  countTagCloses,
+  countTagOpens,
   missingSectionLabels,
   parseFrontmatterAndBody,
+  parseHeadingSections,
+  parseTargetSectionsByIndex,
   resolveChunkStrategy,
   type ChunkedFileConfig,
 } from "./chunked-translate.ts";
@@ -46,7 +51,7 @@ interface LangConfig {
 interface TranslationConfig {
   skip_paths: string[];
   chunked_files?: ChunkedFileConfig[];
-  auto_chunk?: { min_body_chars?: number; min_sections?: number };
+  auto_chunk?: { min_body_chars?: number; min_sections?: number; max_block_chars?: number };
   languages: LangConfig[];
 }
 
@@ -187,6 +192,42 @@ async function collectEnglishFiles(snippetsMode: boolean): Promise<string[]> {
     .filter((f) => isEnglishPagePath(f, pathFilterOpts));
 }
 
+function findTruncatedHeadingBlocks(
+  enBody: string,
+  targetBody: string
+): string[] {
+  const enBlocks = parseHeadingSections(enBody);
+  const targetSections = parseTargetSectionsByIndex(targetBody, enBlocks.length);
+  const bad: string[] = [];
+
+  for (let i = 0; i < enBlocks.length; i++) {
+    const en = enBlocks[i]!;
+    const tr = targetSections[i] ?? "";
+    if (!tr.trim()) continue;
+
+    const enTabs = countTagOpens(en.content, "Tab");
+    const trTabs = countTagOpens(tr, "Tab");
+    if (enTabs >= 2 && trTabs !== enTabs) {
+      bad.push(en.label);
+      continue;
+    }
+
+    const enWrappers = countTagOpens(en.content, "Tabs");
+    if (enWrappers > 0 && countTagCloses(tr, "Tabs") < enWrappers) {
+      bad.push(en.label);
+      continue;
+    }
+
+    const enLines = countNonEmptyLines(en.content);
+    const trLines = countNonEmptyLines(tr);
+    if (enLines >= 80 && trLines < enLines * 0.6) {
+      bad.push(en.label);
+    }
+  }
+
+  return bad;
+}
+
 export function detectTruncation(
   enContent: string,
   targetContent: string,
@@ -233,6 +274,10 @@ export function detectTruncation(
     if (missingSections.length > 0) {
       reasons.push("missing_sections");
     }
+    const truncatedBlocks = findTruncatedHeadingBlocks(enBody, targetBody);
+    if (truncatedBlocks.length > 0) {
+      reasons.push("truncated_block");
+    }
   }
 
   return reasons;
@@ -277,6 +322,12 @@ function formatDetail(
     const missing = missingSectionLabels(enBody, targetBody, "heading_sections");
     parts.push(
       `missing sections: ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? "..." : ""}`
+    );
+  }
+  if (reasons.includes("truncated_block")) {
+    const bad = findTruncatedHeadingBlocks(enBody, targetBody);
+    parts.push(
+      `truncated block(s): ${bad.slice(0, 5).join(", ")}${bad.length > 5 ? "..." : ""}`
     );
   }
   return parts.join("; ");

--- a/.github/scripts/i18n/chunked-translate.test.ts
+++ b/.github/scripts/i18n/chunked-translate.test.ts
@@ -4,6 +4,11 @@ import {
   documentBlockHashes,
   getSectionSyncStatus,
   parseDocument,
+  softSplitByBudget,
+  splitByH3Subheadings,
+  splitByMintlifyTabs,
+  splitOversizedBlock,
+  validateTranslatedBlock,
 } from "./chunked-translate.ts";
 
 const FM = `---
@@ -72,7 +77,6 @@ describe("getSectionSyncStatus update_blocks", () => {
     );
     const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
     expect(status.pendingBlocks).toEqual(["v0.26.0"]);
-    expect(status.upToDate).toBe(false);
   });
 
   test("re-translates when block exists but hash entry is missing", () => {
@@ -87,5 +91,115 @@ describe("getSectionSyncStatus update_blocks", () => {
     );
     const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
     expect(status.pendingBlocks).toEqual(["v0.26.0"]);
+  });
+});
+
+describe("splitOversizedBlock", () => {
+  test("returns single piece when under budget", () => {
+    expect(splitOversizedBlock("## Small\n\nHello", 6000)).toEqual(["## Small\n\nHello"]);
+  });
+
+  test("splits Mintlify Tabs and concatenates to original", () => {
+    const content = `## Install
+
+Intro text.
+
+<Tabs>
+  <Tab title="A">
+    Alpha content here.
+  </Tab>
+  <Tab title="B">
+    Bravo content here.
+  </Tab>
+</Tabs>
+`;
+    const pieces = splitByMintlifyTabs(content);
+    expect(pieces).not.toBeNull();
+    expect(pieces!.length).toBeGreaterThanOrEqual(3);
+    expect(pieces!.join("")).toBe(content);
+
+    const oversized = splitOversizedBlock(content, 40);
+    expect(oversized.length).toBeGreaterThan(1);
+    expect(oversized.join("")).toBe(content);
+  });
+
+  test("splits on ### subheadings", () => {
+    const content = `## Advanced
+
+Prefix.
+
+### One
+aaaa
+
+### Two
+bbbb
+`;
+    const pieces = splitByH3Subheadings(content);
+    expect(pieces).not.toBeNull();
+    expect(pieces!.length).toBe(2);
+    expect(pieces!.join("")).toBe(content);
+  });
+
+  test("soft-split does not leave an open fence", () => {
+    const fenceBody = Array.from({ length: 20 }, (_, i) => `line-${i}`).join("\n");
+    const content = `## Code\n\nBefore\n\n\`\`\`\n${fenceBody}\n\`\`\`\n\nAfter paragraph text\n`;
+    const pieces = softSplitByBudget(content, 80);
+    expect(pieces.join("")).toBe(content);
+    for (const p of pieces) {
+      let inFence = false;
+      for (const line of p.split("\n")) {
+        if (/^(```|~~~)/.test(line.trim())) inFence = !inFence;
+      }
+      expect(inFence).toBe(false);
+    }
+  });
+});
+
+describe("validateTranslatedBlock heading_sections", () => {
+  const installBlock = {
+    label: "Install Comfy Cloud MCP",
+    content: `## Install Comfy Cloud MCP
+
+<Tabs>
+  <Tab title="A">
+    one
+  </Tab>
+  <Tab title="B">
+    two
+  </Tab>
+</Tabs>
+`,
+  };
+
+  test("accepts complete Tab set", () => {
+    const tr = `## 安装
+
+<Tabs>
+  <Tab title="A">
+    一
+  </Tab>
+  <Tab title="B">
+    二
+  </Tab>
+</Tabs>
+`;
+    expect(validateTranslatedBlock("heading_sections", installBlock, tr)).toBe(true);
+  });
+
+  test("rejects truncated Tab set", () => {
+    const tr = `## 安装
+
+<Tabs>
+  <Tab title="A">
+    一
+`;
+    expect(validateTranslatedBlock("heading_sections", installBlock, tr)).toBe(false);
+  });
+
+  test("rejects finish_reason length", () => {
+    const tr = installBlock.content;
+    expect(
+      validateTranslatedBlock("heading_sections", installBlock, tr, { finishReason: "length" })
+    ).toBe(false);
   });
 });

--- a/.github/scripts/i18n/chunked-translate.ts
+++ b/.github/scripts/i18n/chunked-translate.ts
@@ -28,7 +28,15 @@ export interface AutoChunkConfig {
   min_body_chars?: number;
   /** Minimum number of `##` sections required for auto-chunking. */
   min_sections?: number;
+  /**
+   * Max English chars per API call when translating a heading_sections block.
+   * Oversized blocks are sub-chunked (Tabs → ### → fence-safe size).
+   */
+  max_block_chars?: number;
 }
+
+/** Default max English chars sent in one translation API call for a H2 block. */
+export const DEFAULT_MAX_BLOCK_CHARS = 6000;
 
 export interface ContentBlock {
   /** Stable sync key from English (section title or `_intro`). */
@@ -675,23 +683,210 @@ export function resolveChunkStrategy(
   return null;
 }
 
+export function countTagOpens(content: string, tag: string): number {
+  const re = new RegExp(`<${tag}\\b`, "g");
+  return (content.match(re) ?? []).length;
+}
+
+export function countTagCloses(content: string, tag: string): number {
+  const re = new RegExp(`</${tag}>`, "g");
+  return (content.match(re) ?? []).length;
+}
+
+export function hasUnclosedCodeFence(content: string): boolean {
+  let inFence = false;
+  for (const line of content.split("\n")) {
+    inFence = toggleFence(line, inFence);
+  }
+  return inFence;
+}
+
+export function countNonEmptyLines(content: string): number {
+  return content.split("\n").filter((l) => l.trim().length > 0).length;
+}
+
+/**
+ * Split a Mintlify `<Tabs>` region into pieces that concatenate to `content`.
+ * Returns null when fewer than two `<Tab>` children are present.
+ */
+export function splitByMintlifyTabs(content: string): string[] | null {
+  const openMatch = content.match(/<Tabs\b[^>]*>/);
+  if (!openMatch || openMatch.index === undefined) return null;
+  const openEnd = openMatch.index + openMatch[0].length;
+  const closeIdx = content.indexOf("</Tabs>", openEnd);
+  if (closeIdx < 0) return null;
+
+  const prefix = content.slice(0, openEnd);
+  const inner = content.slice(openEnd, closeIdx);
+  const suffix = content.slice(closeIdx);
+
+  const tabRe = /[ \t]*<Tab\b[^>]*>[\s\S]*?<\/Tab>/g;
+  const matches = [...inner.matchAll(tabRe)];
+  if (matches.length < 2) return null;
+
+  const firstIdx = matches[0]!.index!;
+  const pieces: string[] = [prefix + inner.slice(0, firstIdx)];
+
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i]!;
+    const start = m.index!;
+    const nextStart = i + 1 < matches.length ? matches[i + 1]!.index! : inner.length;
+    pieces.push(inner.slice(start, nextStart));
+  }
+
+  pieces[pieces.length - 1] = pieces[pieces.length - 1]! + suffix;
+
+  if (pieces.join("") !== content) return null;
+  return pieces;
+}
+
+const H3_HEADING_RE = /^### (?![#])/;
+
+function isH3SectionLine(line: string, inFence: boolean): boolean {
+  return !inFence && H3_HEADING_RE.test(line);
+}
+
+/**
+ * Split on `###` subheadings. First piece keeps everything before the first `###`
+ * (including a leading `##`). Returns null when fewer than two `###` exist.
+ * Pieces concatenate with `""` back to `content`.
+ */
+export function splitByH3Subheadings(content: string): string[] | null {
+  const lines = content.split("\n");
+  let h3Count = 0;
+  let inFence = false;
+  for (const line of lines) {
+    inFence = toggleFence(line, inFence);
+    if (isH3SectionLine(line, inFence)) h3Count++;
+  }
+  if (h3Count < 2) return null;
+
+  const pieces: string[] = [];
+  let current: string[] = [];
+  inFence = false;
+  let seenH3 = false;
+
+  for (const line of lines) {
+    inFence = toggleFence(line, inFence);
+    if (isH3SectionLine(line, inFence) && seenH3) {
+      // Keep the newline that separated the previous last line from this heading.
+      pieces.push(current.join("\n") + "\n");
+      current = [line];
+    } else {
+      if (isH3SectionLine(line, inFence)) seenH3 = true;
+      current.push(line);
+    }
+  }
+  if (current.length > 0) pieces.push(current.join("\n"));
+  if (pieces.length < 2) return null;
+  if (pieces.join("") !== content) return null;
+  return pieces;
+}
+
+/**
+ * Soft-split without cutting inside fenced code. Prefer blank-line boundaries.
+ * Pieces concatenate with `""` back to `content`.
+ */
+export function softSplitByBudget(content: string, maxChars: number): string[] {
+  if (content.length <= maxChars) return [content];
+
+  const lines = content.split("\n");
+  const pieces: string[] = [];
+  let current: string[] = [];
+  let currentLen = 0;
+  let inFence = false;
+
+  const flush = (withTrailingNewline: boolean) => {
+    if (current.length === 0) return;
+    const joined = current.join("\n");
+    pieces.push(withTrailingNewline ? `${joined}\n` : joined);
+    current = [];
+    currentLen = 0;
+  };
+
+  for (const line of lines) {
+    const extra = current.length > 0 ? 1 : 0;
+    const lineLen = line.length + extra;
+    if (!inFence && currentLen > 0 && currentLen + lineLen > maxChars) {
+      flush(true);
+    }
+    current.push(line);
+    currentLen = current.length === 1 ? line.length : currentLen + 1 + line.length;
+    inFence = toggleFence(line, inFence);
+  }
+  flush(false);
+  if (pieces.length === 0) return [content];
+  if (pieces.join("") !== content) {
+    // Fallback: avoid corrupting content if accounting drifts.
+    return [content];
+  }
+  return pieces;
+}
+
+function splitOversizedWithoutTabs(content: string, maxChars: number): string[] {
+  const byH3 = splitByH3Subheadings(content);
+  if (byH3 && byH3.length > 1) {
+    return byH3.flatMap((p) =>
+      p.length > maxChars ? softSplitByBudget(p, maxChars) : [p]
+    );
+  }
+  return softSplitByBudget(content, maxChars);
+}
+
+/**
+ * Split an oversized H2 block for API calls only. Pieces concatenate to `content`.
+ * Prefer Mintlify Tabs, then `###`, then fence-safe size splits.
+ */
+export function splitOversizedBlock(
+  content: string,
+  maxChars: number = DEFAULT_MAX_BLOCK_CHARS
+): string[] {
+  if (content.length <= maxChars) return [content];
+
+  const byTabs = splitByMintlifyTabs(content);
+  if (byTabs && byTabs.length > 1) {
+    return byTabs.flatMap((p) =>
+      p.length > maxChars ? splitOversizedWithoutTabs(p, maxChars) : [p]
+    );
+  }
+  return splitOversizedWithoutTabs(content, maxChars);
+}
+
 export function validateTranslatedBlock(
   strategy: ChunkStrategy,
   enBlock: ContentBlock,
-  translated: string
+  translated: string,
+  options?: { finishReason?: string | null }
 ): boolean {
   if (!translated.trim()) return false;
+  if (options?.finishReason === "length") return false;
 
   if (strategy === "update_blocks") {
     return translated.includes("<Update");
   }
 
-  if (enBlock.label === "_intro") {
-    return true;
+  if (enBlock.label !== "_intro") {
+    // Section blocks must remain level-2 headings (text may be localized).
+    if (!/^## (?![#])/.test(translated.trimStart())) return false;
   }
 
-  // Section blocks must remain level-2 headings (text may be translated).
-  return /^## (?![#])/.test(translated.trimStart());
+  if (hasUnclosedCodeFence(translated)) return false;
+
+  const enTabs = countTagOpens(enBlock.content, "Tab");
+  const trTabs = countTagOpens(translated, "Tab");
+  if (enTabs >= 2 && trTabs !== enTabs) return false;
+
+  const enTabsWrappers = countTagOpens(enBlock.content, "Tabs");
+  if (enTabsWrappers > 0 && countTagCloses(translated, "Tabs") < enTabsWrappers) {
+    return false;
+  }
+  if (enTabs > 0 && countTagCloses(translated, "Tab") !== trTabs) return false;
+
+  const enLines = countNonEmptyLines(enBlock.content);
+  const trLines = countNonEmptyLines(translated);
+  if (enLines >= 80 && trLines < enLines * 0.6) return false;
+
+  return true;
 }
 
 export function missingSectionLabels(

--- a/.github/scripts/i18n/translate-i18n.ts
+++ b/.github/scripts/i18n/translate-i18n.ts
@@ -73,16 +73,20 @@ import {
   type BlockSlot,
   type ChunkedFileConfig,
   type ChunkStrategy,
+  type ContentBlock,
+  DEFAULT_MAX_BLOCK_CHARS,
   aggregateDocumentHash,
   applyChangelogBlockLocalizations,
   changelogLabelHash,
   documentBlockHashes,
   getSectionSyncStatus,
+  parseBlockHashesFromFrontmatter,
   parseDocument,
   parseFrontmatterAndBody,
   parseTargetSectionsByIndex,
   resolveChunkStrategy,
   serializeChunkedDocument,
+  splitOversizedBlock,
   stripTranslationMetaFromFrontmatter,
   syncUpdateBlockDescription,
   validateTranslatedBlock,
@@ -368,6 +372,12 @@ function parseLangArg(args: string[]): LangConfig[] {
 interface TranslationResult {
   content: string;
   mismatches: string[];
+  finishReason: string | null;
+}
+
+interface ApiCallResult {
+  content: string;
+  finishReason: string | null;
 }
 
 function extractMismatches(text: string): { clean: string; mismatches: string[] } {
@@ -392,7 +402,7 @@ function extractMismatches(text: string): { clean: string; mismatches: string[] 
 async function callApi(
   messages: { role: string; content: string }[],
   extraBody: Record<string, unknown> = {}
-): Promise<string> {
+): Promise<ApiCallResult> {
   const response = await fetch(`${BASE_URL}/chat/completions`, {
     method: "POST",
     headers: {
@@ -403,7 +413,7 @@ async function callApi(
       model: MODEL,
       messages,
       temperature: 0.3,
-      max_tokens: 8192,
+      max_tokens: 16384,
       ...extraBody,
     }),
   });
@@ -411,8 +421,14 @@ async function callApi(
     const err = await response.text();
     throw new Error(`API ${response.status}: ${err}`);
   }
-  const data = (await response.json()) as { choices?: { message?: { content?: string } }[] };
-  return data.choices?.[0]?.message?.content ?? "";
+  const data = (await response.json()) as {
+    choices?: { message?: { content?: string }; finish_reason?: string }[];
+  };
+  const choice = data.choices?.[0];
+  return {
+    content: choice?.message?.content ?? "",
+    finishReason: choice?.finish_reason ?? null,
+  };
 }
 
 function buildTranslationInstructions(lang: LangConfig): string {
@@ -456,12 +472,12 @@ async function translateWithQwenMT(
     );
   }
 
-  const translated = await callApi(
+  const apiResult = await callApi(
     [{ role: "user", content: parts.join("\n") }],
     { translation_options: { source_lang: "English", target_lang: lang.name } }
   );
-  const { clean, mismatches } = extractMismatches(translated);
-  return { content: clean, mismatches };
+  const { clean, mismatches } = extractMismatches(apiResult.content);
+  return { content: clean, mismatches, finishReason: apiResult.finishReason };
 }
 
 async function translateWithLLM(
@@ -493,12 +509,72 @@ Output ONLY the translated MDX content.`;
   }
   userParts.push("", `Translate/update to ${lang.name}. Output only the translated MDX.`);
 
-  const translated = await callApi([
+  const apiResult = await callApi([
     { role: "system", content: systemPrompt },
     { role: "user", content: userParts.join("\n") },
   ]);
-  const { clean, mismatches } = extractMismatches(translated);
-  return { content: clean, mismatches };
+  const { clean, mismatches } = extractMismatches(apiResult.content);
+  return { content: clean, mismatches, finishReason: apiResult.finishReason };
+}
+
+/**
+ * Translate one English block, sub-chunking oversized content (Tabs / ### / size)
+ * so each API call stays under max_block_chars.
+ */
+async function translateBlockContent(
+  enText: string,
+  existingText: string,
+  lang: LangConfig,
+  relPath: string
+): Promise<TranslationResult> {
+  const maxChars = AUTO_CHUNK?.max_block_chars ?? DEFAULT_MAX_BLOCK_CHARS;
+  const enPieces = splitOversizedBlock(enText, maxChars);
+
+  const translateOne = (en: string, existing: string, piecePath: string) =>
+    IS_QWEN_MT
+      ? translateWithQwenMT(en, existing, lang)
+      : translateWithLLM(en, existing, lang, piecePath);
+
+  if (enPieces.length === 1) {
+    return translateOne(enText, existingText, relPath);
+  }
+
+  console.log(
+    `      sub-chunked into ${enPieces.length} pieces (max ${maxChars} chars)`
+  );
+  const existingPieces = existingText.trim()
+    ? splitOversizedBlock(existingText, maxChars)
+    : [];
+  const aligned = existingPieces.length === enPieces.length;
+  if (existingText.trim() && !aligned) {
+    console.log(
+      `      existing piece count ${existingPieces.length} ≠ ${enPieces.length}; translating pieces without aligned context`
+    );
+  }
+
+  const outs: string[] = [];
+  const mismatches: string[] = [];
+  let finishReason: string | null = "stop";
+
+  for (let i = 0; i < enPieces.length; i++) {
+    const piece = enPieces[i]!;
+    const ex = aligned ? existingPieces[i]! : "";
+    console.log(`      piece ${i + 1}/${enPieces.length} (${piece.length} chars)`);
+    const result = await translateOne(piece, ex, `${relPath}#piece${i + 1}`);
+    mismatches.push(...result.mismatches);
+    outs.push(result.content);
+    if (result.finishReason === "length") {
+      finishReason = "length";
+      break;
+    }
+    if (result.finishReason) finishReason = result.finishReason;
+  }
+
+  return {
+    content: outs.join(""),
+    mismatches,
+    finishReason,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -573,7 +649,7 @@ async function translateChunkedFile(
   targetPath: string
 ): Promise<{
   mismatches: string[];
-  status: "translated" | "skipped" | "up-to-date";
+  status: "translated" | "skipped" | "up-to-date" | "failed";
   blocksTranslated: number;
   output: string | null;
 }> {
@@ -589,6 +665,15 @@ async function translateChunkedFile(
     strategy === "update_blocks"
       ? changelogLabelHash(enDoc.blocks)
       : aggregateDocumentHash(enBlockHashes);
+
+  const existingFmBody = existingContent
+    ? parseFrontmatterAndBody(existingContent)
+        .frontmatter.replace(/^---\n/, "")
+        .replace(/\n---$/, "")
+    : "";
+  const oldBlockHashes = existingFmBody
+    ? parseBlockHashesFromFrontmatter(existingFmBody)
+    : {};
 
   const existingByLabel = new Map(
     (existingDoc?.blocks ?? []).map((b) => [b.label, b.content])
@@ -640,6 +725,8 @@ async function translateChunkedFile(
   const allMismatches: string[] = [];
   let blocksTranslated = 0;
   let frontmatterDirty = false;
+  const hashesForMeta: Record<string, string> = { ...enBlockHashes };
+  const failedLabels: string[] = [];
 
   let translatedFrontmatter = existingDoc?.frontmatter ?? "";
   if (force || status.needsFrontmatter) {
@@ -664,7 +751,7 @@ async function translateChunkedFile(
       slots,
       fileHash,
       enRel,
-      enBlockHashes,
+      hashesForMeta,
       strategy,
     );
   } else {
@@ -689,9 +776,12 @@ async function translateChunkedFile(
         : slot.label;
 
     console.log(`    Translating block: ${blockTag}...`);
-    const blockResult = IS_QWEN_MT
-      ? await translateWithQwenMT(enBlock.content, existingBlock, lang)
-      : await translateWithLLM(enBlock.content, existingBlock, lang, `${relPath}#${blockTag}`);
+    const blockResult = await translateBlockContent(
+      enBlock.content,
+      existingBlock,
+      lang,
+      `${relPath}#${blockTag}`
+    );
 
     let translatedBlock = cleanModelOutput(blockResult.content);
     translatedBlock = localizeMdxPaths(translatedBlock, lang, config.languages);
@@ -699,22 +789,35 @@ async function translateChunkedFile(
       translatedBlock = syncUpdateBlockDescription(translatedBlock, enBlock, lang.code);
     }
 
-    if (!validateTranslatedBlock(strategy, enBlock, translatedBlock)) {
-      console.log(`    [WARN] Block ${blockTag}: invalid output, keeping existing`);
-      translatedBlock = existingBlock.trim() ? existingBlock : enBlock.content;
+    const valid = validateTranslatedBlock(strategy, enBlock, translatedBlock, {
+      finishReason: blockResult.finishReason,
+    });
+
+    if (!valid) {
+      console.log(
+        `    [FAIL] Block ${blockTag}: truncated or invalid (finish_reason=${blockResult.finishReason ?? "n/a"}); leaving pending`
+      );
+      slot.content = existingBlock.trim() ? existingBlock : enBlock.content;
+      if (oldBlockHashes[slot.label]) {
+        hashesForMeta[slot.label] = oldBlockHashes[slot.label]!;
+      } else {
+        delete hashesForMeta[slot.label];
+      }
+      failedLabels.push(slot.label);
     } else {
+      slot.content = translatedBlock;
       blocksTranslated++;
     }
 
-    slot.content = translatedBlock;
     allMismatches.push(...blockResult.mismatches);
     await writeChunkedCheckpoint(
       targetPath,
       translatedFrontmatter,
       slots,
-      fileHash,
+      // Keep source hash as full EN aggregate only when nothing failed.
+      failedLabels.length === 0 ? fileHash : aggregateDocumentHash(hashesForMeta),
       enRel,
-      enBlockHashes,
+      hashesForMeta,
       strategy,
       blockTag
     );
@@ -723,13 +826,25 @@ async function translateChunkedFile(
   const output = serializeChunkedDocument(
     translatedFrontmatter,
     applyChangelogBlockLocalizations(slots, enDoc.blocks, lang.code),
-    fileHash,
+    failedLabels.length === 0 ? fileHash : aggregateDocumentHash(hashesForMeta),
     enRel,
-    enBlockHashes,
+    hashesForMeta,
     strategy
   );
   const didWork =
     blocksTranslated > 0 || frontmatterDirty || status.needsFrontmatter || status.needsReserialize;
+
+  if (failedLabels.length > 0) {
+    console.log(
+      `    [FAIL] ${failedLabels.length} block(s) still pending: ${failedLabels.join(", ")}`
+    );
+    return {
+      mismatches: allMismatches,
+      status: "failed",
+      blocksTranslated,
+      output,
+    };
+  }
 
   return {
     mismatches: allMismatches,
@@ -748,7 +863,7 @@ async function translateFile(
   lang: LangConfig,
   force: boolean,
   snippetsMode: boolean
-): Promise<{ mismatches: string[]; status: "translated" | "skipped" | "up-to-date"; blocksTranslated?: number }> {
+): Promise<{ mismatches: string[]; status: "translated" | "skipped" | "up-to-date" | "failed"; blocksTranslated?: number }> {
   const { enPath, targetPath, enRel } = makeMapping(lang, relPath, snippetsMode);
 
   const enContent = await readFileOr(enPath);
@@ -784,6 +899,15 @@ async function translateFile(
         mismatches: [],
         status: "up-to-date",
         blocksTranslated: 0,
+      };
+    }
+    if (chunked.status === "failed") {
+      await mkdir(dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, chunked.output);
+      return {
+        mismatches: chunked.mismatches,
+        status: "failed",
+        blocksTranslated: chunked.blocksTranslated,
       };
     }
     return {
@@ -1066,6 +1190,18 @@ async function runTranslatePhase(options: {
         const mismatchNote =
           result.mismatches.length > 0 ? ` (${result.mismatches.length} mismatches)` : "";
         console.log(`${tag} OK   ${label}${blockNote}${mismatchNote}`);
+        if (result.mismatches.length > 0) {
+          runMismatches.push({ enRel: relPath, lang: lang.code, issues: result.mismatches });
+        }
+      } else if (result.status === "failed") {
+        failed++;
+        translatedJobs.push({ relPath, lang });
+        console.error(
+          `${tag} FAIL ${label}: truncated/invalid block(s); left pending for retry` +
+            (result.blocksTranslated != null
+              ? ` (${result.blocksTranslated} block(s) ok)`
+              : "")
+        );
         if (result.mismatches.length > 0) {
           runMismatches.push({ enRel: relPath, lang: lang.code, issues: result.mismatches });
         }

--- a/.github/scripts/i18n/translation-config.json
+++ b/.github/scripts/i18n/translation-config.json
@@ -13,7 +13,8 @@
   ],
   "auto_chunk": {
     "min_body_chars": 3000,
-    "min_sections": 2
+    "min_sections": 2,
+    "max_block_chars": 6000
   },
   "languages": [
     {


### PR DESCRIPTION
## Summary
Root cause: page-level `##` chunking still left single sections larger than model output. Example: `agent-tools/mcp.mdx` **Install** is ~14k EN chars / 6 Tabs, but went out as **one** API call with `max_tokens: 8192`. Output stopped mid-Tab; weak validation (`starts with ##`) accepted it; the new EN block hash was written so the next run skipped the broken block.

### Fixes
- Sub-chunk oversized H2 blocks before API (`auto_chunk.max_block_chars`, default 6000): Mintlify Tabs → `###` → fence-safe size splits
- Bump `max_tokens` to 16384; surface `finish_reason` and reject `length`
- Strengthen block validation (Tab count, `</Tabs>`, unclosed fences, line-ratio floor)
- On failure: keep prior content and **leave the block hash pending** so retries work; mark the file failed
- Truncation scan: per-block `truncated_block` heuristic
- Unit tests + README / skill notes

## Test plan
- [x] `bun test ./.github/scripts/i18n/` (15 pass)
- [x] `pnpm translate:check-truncation -- agent-tools/mcp.mdx` → 0 issues
- [ ] Optional: force-retranslate `agent-tools/mcp.mdx` Install for `ko` and confirm logs show `sub-chunked into N pieces`