### PR TITLE
docs: redirect /cloud/mcp to /agent-tools/mcp

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11136,6 +11136,22 @@
       "destination": "/ko/agent-tools/mcp"
     },
     {
+      "source": "/cloud/mcp",
+      "destination": "/agent-tools/mcp"
+    },
+    {
+      "source": "/zh/cloud/mcp",
+      "destination": "/zh/agent-tools/mcp"
+    },
+    {
+      "source": "/ja/cloud/mcp",
+      "destination": "/ja/agent-tools/mcp"
+    },
+    {
+      "source": "/ko/cloud/mcp",
+      "destination": "/ko/agent-tools/mcp"
+    },
+    {
       "source": "/cli",
       "destination": "/agent-tools/cli"
     },


### PR DESCRIPTION
## Summary
- Add Mintlify redirects from `/cloud/mcp` → `/agent-tools/mcp`
- Same for locale prefixes: `/zh/cloud/mcp`, `/ja/cloud/mcp`, `/ko/cloud/mcp`

External links (e.g. ClawHub skill notes) still advertise `docs.comfy.org/cloud/mcp`; this keeps those URLs working.

## Test plan
- [ ] After deploy, open https://docs.comfy.org/cloud/mcp and confirm redirect to `/agent-tools/mcp`
- [ ] Spot-check `/zh/cloud/mcp`, `/ja/cloud/mcp`, `/ko/cloud/mcp`