### PR TITLE
docs: add ComfyUI v0.28.0 changelog and CMS release notes

### DIFF
--- a/.cursor/skills/docs-i18n-translate/SKILL.md
+++ b/.cursor/skills/docs-i18n-translate/SKILL.md
@@ -18,14 +18,13 @@ Translate **Mintlify docs** (not CMS). English is source of truth; ja / zh / ko 
 ```
 index.mdx, changelog/index.mdx, …   ← English (edit here)
         │
-        ▼  pnpm translate
+        ▼  pnpm translate            ← MDX only (does NOT touch docs.json)
 {ja,zh,ko}/…                        ← translated MDX (commit to git)
 snippets/{ja,zh,ko}/…
         │
-        ▼  optional
-pnpm translate:sync-docs-json       ← mirror nav paths in docs.json
+        ▼  only if EN nav changed
+pnpm translate:sync-docs-json       ← mirror nav paths in docs.json (opt-in)
 ```
-
 Incremental: each file stores `translationSourceHash` in frontmatter. Unchanged English → skip.
 
 ## Environment (`.env.local`)
@@ -55,7 +54,8 @@ Requires **Bun**.
 | `pnpm translate:repair-fences` | Append missing closing ``` (no API) |
 | `pnpm translate:repair-truncated -- --lang ko` | Re-translate flagged files |
 | `pnpm translate:sync-hash` | Refresh hashes after manual zh/ja/ko edits (no API) |
-| `pnpm translate:sync-docs-json` | Sync `docs.json` nav paths (labels preserved) |
+| `pnpm translate -- --with-docs-json` | Translate then sync `docs.json` nav (opt-in) |
+| `pnpm translate:sync-docs-json` | Sync `docs.json` nav paths only (labels preserved) |
 | `pnpm translate:sync-docs-json -- --translate-nav-labels` | Also translate new EN nav labels |
 | `pnpm glossary:sync` | Rebuild glossary from ComfyUI frontend |
 | `pnpm glossary:sync:dry-run` | Preview glossary sync |
@@ -160,7 +160,7 @@ When user updates English docs and needs translations:
 - [ ] After long pages, run `pnpm translate:check-truncation`
 - [ ] Commit translated MDX + updated `translationSourceHash` / `translationBlockHashes`
 - [ ] Do not commit `.github/i18n-logs/`
-- [ ] If nav structure changed, run `pnpm translate:sync-docs-json`
+- [ ] Do **not** expect `pnpm translate` to edit `docs.json`; if EN nav structure changed, run `pnpm translate:sync-docs-json` (or `--with-docs-json`) separately
 - [ ] Optional quality pass: skill `docs-i18n-review`
 
 ## Key files

--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -329,6 +329,34 @@
         "zh"
       ],
       "published_at": "2026-07-09T10:35:36.845Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.28.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-15T12:33:08.856Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.28.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-15T12:32:50.377Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**New Open-Source Model Support**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Native SeedVR2 image and video upscaling
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Added PixelDiT PID 1.5 model support
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 support and Turing int8/int4 optimizations
+
+**New Node Updates**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (Advanced), Save Splat, and Save Point Cloud nodes
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Save text outputs to .txt, .md, or .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Text overlay for images and video
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Built-in Text node re-enabled after undeprecation
+
+**Partner Node Updates**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 lip-sync and talking-image support
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Option to disable thinking on Seedream nodes
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image preview models moved to release versions
+
+</Update>
+
 <Update label="v0.27.1" description="July 8, 2026">
 
 **Partner Node Updates**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance image generation model support added.
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance image generation model support added.
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Speech, music, sound effects, multi-speaker dialogue.
 * [**Ideogram V1/V2 deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Legacy Ideogram partner nodes deprecated.
 * [**StabilityAI temporarily removed**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI partner nodes temporarily removed.

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Escalado nativo de imágenes y vídeos con SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Se añadió soporte para el modelo PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): Soporte para convrot int4 y optimizaciones Turing int8/int4
+
+**Nuevas actualizaciones de nodos**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Nodos Guardar 3D (Avanzado), Guardar Splat y Guardar Nube de Puntos
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Guardar salidas de texto en .txt, .md o .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Superposición de texto para imágenes y vídeo
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Nodo Text integrado rehabilitado
+
+**Actualizaciones de nodos asociados**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): Soporte para sincronización de labios y talking-image con sync.so sync-3
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Opción para desactivar el pensamiento en nodos Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Modelos de previsualización de Gemini Image trasladados a versiones de lanzamiento
+
+</Update>
+
 <Update label="v0.27.1" description="July 8, 2026">
 
 **Actualizaciones de nodos asociados**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Soporte para modelo de generación de imágenes de ByteDance añadido.
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Soporte para modelo de generación de imágenes de ByteDance añadido.
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Voz, música, efectos de sonido, diálogo multi-orador.
 * [**Ideogram V1/V2 obsoleto**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Nodos asociados heredados de Ideogram obsoletos.
 * [**StabilityAI eliminado temporalmente**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Nodos asociados de StabilityAI eliminados temporalmente.

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**Nouveau support de modèles open-source**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json) : Mise à l'échelle native d'images et de vidéos SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894) : Ajout du support du modèle PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859) : Support convrot int4 et optimisations Turing int8/int4
+
+**Nouvelles mises à jour de nœuds**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701) : Nœuds Save 3D (Advanced), Save Splat et Save Point Cloud
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102) : Enregistrement des sorties texte en .txt, .md ou .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610) : Superposition de texte pour images et vidéos
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870) : Nœud Text intégré réactivé
+
+**Mises à jour des nœuds partenaires**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928) : Support sync.so sync-3 lip-sync et talking-image
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853) : Option pour désactiver le raisonnement sur les nœuds Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917) : Les modèles d'aperçu Gemini Image sont passés aux versions de publication
+
+</Update>
+
 <Update label="v0.27.1" description="8 juillet 2026">
 
 **Mises à jour des nœuds partenaires**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Ajout de la prise en charge du modèle de génération d'images ByteDance.
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Ajout de la prise en charge du modèle de génération d'images ByteDance.
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Parole, musique, effets sonores, dialogue multi-locuteur.
 * [**Ideogram V1/V2 obsolète**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Les nœuds partenaires Ideogram hérités sont obsolètes.
 * [**StabilityAI temporairement retiré**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Les nœuds partenaires StabilityAI ont été temporairement retirés.

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新しいオープンソースモデルのサポート**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): ネイティブSeedVR2画像・ビデオアップスケーリング
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5モデルのサポートを追加
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4サポートとTuring int8/int4最適化
+
+**新しいノードの更新**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D（高度な機能）、Save Splat、Save Point Cloudノード
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): テキスト出力を.txt、.md、.jsonに保存
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 画像とビデオ向けテキストオーバーレイ
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 組み込み Text ノードを再有効化
+
+**パートナーノードの更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 リップシンクおよびトーキングイメージサポート
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedreamノードでthinkingを無効にするオプション
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image プレビューモデルをリリースバージョンに移行
+
+</Update>
+
 <Update label="v0.27.1" description="2026年7月8日">
 
 **パートナーノードの更新**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance画像生成モデルのサポートを追加。
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance画像生成モデルのサポートを追加。
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 音声、音楽、効果音、マルチスピーカーダイアログ。
 * [**Ideogram V1/V2 非推奨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): レガシーIdeogramパートナーノードを非推奨化。
 * [**StabilityAI 一時的に削除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAIパートナーノードを一時的に削除。

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026년 7월 15일">
+
+**새로운 오픈 소스 모델 지원**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): 기본 SeedVR2 이미지 및 비디오 업스케일링
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5 모델 지원 추가
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 지원 및 Turing int8/int4 최적화
+
+**새 노드 업데이트**
+* [**Save 3D (고급)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (고급), Save Splat, Save Point Cloud 노드
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): 텍스트 출력을 .txt, .md, .json으로 저장
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 이미지 및 비디오용 텍스트 오버레이
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 내장 Text 노드를 다시 활성화
+
+**파트너 노드 업데이트**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 립싱크 및 토킹 이미지 지원
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedream 노드에서 생각 비활성화 옵션
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image 미리보기 모델을 릴리스 버전으로 이동
+
+</Update>
+
 <Update label="v0.27.1" description="2026년 7월 8일">
 
 **파트너 노드 업데이트**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): ByteDance 이미지 생성 모델 지원 추가.
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): ByteDance 이미지 생성 모델 지원 추가.
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 음성, 음악, 음향 효과, 다중 화자 대화.
 * [**Ideogram V1/V2 지원 중단됨**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 레거시 Ideogram 파트너 노드 지원 중단.
 * [**StabilityAI 일시 제거**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI 파트너 노드가 일시적으로 제거됨.

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="15 июля 2026">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Нативное масштабирование изображений и видео SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Добавлена поддержка модели PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): Поддержка convrot int4 и оптимизации Turing int8/int4
+
+**Обновления новых узлов**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Узлы Save 3D (Advanced), Save Splat и Save Point Cloud
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Сохранение текстовых результатов в .txt, .md или .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Текстовое наложение для изображений и видео
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Встроенный узел Text снова включён
+
+**Обновления партнерских узлов**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 поддержка синхронизации губ и говорящих изображений
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Опция отключения мышления в узлах Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Модели предварительного просмотра Gemini Image перенесены в релизные версии
+
+</Update>
+
 <Update label="v0.27.1" description="8 июля 2026 года">
 
 **Обновления партнёрских узлов**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): Добавлена поддержка модели генерации изображений ByteDance.
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): Добавлена поддержка модели генерации изображений ByteDance.
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): Речь, музыка, звуковые эффекты, многоголосый диалог.
 * [**Ideogram V1/V2 устарели**](https://github.com/Comfy-Org/ComfyUI/pull/14712): Устаревшие партнёрские узлы Ideogram объявлены устаревшими.
 * [**StabilityAI временно удалены**](https://github.com/Comfy-Org/ComfyUI/pull/14737): Партнёрские узлы StabilityAI временно удалены.

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,10 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新增开源模型支持**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): 原生 SeedVR2 图像和视频放大
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): 新增 PixelDiT PID 1.5 模型支持
+* [**int4 模型**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 支持及 Turing int8/int4 优化
+
+**新增节点更新**
+* [**保存 3D（高级）**](https://github.com/Comfy-Org/ComfyUI/pull/14701): 保存 3D（高级）、保存 Splat 和保存点云节点
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): 将文本输出保存为 .txt、.md 或 .json
+* [**文本叠加**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 用于图像和视频的文本叠加
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 已重新启用内置 Text 节点
+
+**合作伙伴节点更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 唇形同步与说话图像支持
+* [**Seedream 思维控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思维过程的选项
+* [**Gemini 图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini 图像预览模型移至发布版本
+
+</Update>
+
 <Update label="v0.27.1" description="2026年7月8日">
 
 **合作节点更新**
-* [**Seedream 5.0 Pro**](https://links.comfy.org/4vTG0BN): 已添加字节跳动图片生成模型支持。
+* [**Seedream 5.0 Pro**](https://links.comfy.org/4ydIJYi): 已添加字节跳动图片生成模型支持。
 * [**Seed Audio 1.0**](https://github.com/Comfy-Org/ComfyUI/pull/14731): 语音、音乐、音效、多说话人对话。
 * [**Ideogram V1/V2 已弃用**](https://github.com/Comfy-Org/ComfyUI/pull/14712): 传统Ideogram合作节点已弃用。
 * [**StabilityAI 暂时移除**](https://github.com/Comfy-Org/ComfyUI/pull/14737): StabilityAI合作节点暂时移除。

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**New Open-Source Model Support**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Native SeedVR2 image and video upscaling
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Added PixelDiT PID 1.5 model support
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 support and Turing int8/int4 optimizations
+
+**New Node Updates**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (Advanced), Save Splat, and Save Point Cloud nodes
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Save text outputs to .txt, .md, or .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Text overlay for images and video
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Built-in Text node re-enabled after undeprecation
+
+**Partner Node Updates**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 lip-sync and talking-image support
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Option to disable thinking on Seedream nodes
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image preview models moved to release versions
+
+</Update>
+
 <Update label="v0.27.1" description="July 8, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Escalado nativo de imágenes y vídeos con SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Se añadió soporte para el modelo PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): Soporte para convrot int4 y optimizaciones Turing int8/int4
+
+**Nuevas actualizaciones de nodos**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Nodos Guardar 3D (Avanzado), Guardar Splat y Guardar Nube de Puntos
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Guardar salidas de texto en .txt, .md o .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Superposición de texto para imágenes y vídeo
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Nodo Text integrado rehabilitado
+
+**Actualizaciones de nodos asociados**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): Soporte para sincronización de labios y talking-image con sync.so sync-3
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Opción para desactivar el pensamiento en nodos Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Modelos de previsualización de Gemini Image trasladados a versiones de lanzamiento
+
+</Update>
+
 <Update label="v0.27.1" description="July 8, 2026">
 
 **Actualizaciones de nodos asociados**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**Nouveau support de modèles open-source**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json) : Mise à l'échelle native d'images et de vidéos SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894) : Ajout du support du modèle PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859) : Support convrot int4 et optimisations Turing int8/int4
+
+**Nouvelles mises à jour de nœuds**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701) : Nœuds Save 3D (Advanced), Save Splat et Save Point Cloud
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102) : Enregistrement des sorties texte en .txt, .md ou .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610) : Superposition de texte pour images et vidéos
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870) : Nœud Text intégré réactivé
+
+**Mises à jour des nœuds partenaires**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928) : Support sync.so sync-3 lip-sync et talking-image
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853) : Option pour désactiver le raisonnement sur les nœuds Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917) : Les modèles d'aperçu Gemini Image sont passés aux versions de publication
+
+</Update>
+
 <Update label="v0.27.1" description="8 juillet 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新しいオープンソースモデルのサポート**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): ネイティブSeedVR2画像・ビデオアップスケーリング
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5モデルのサポートを追加
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4サポートとTuring int8/int4最適化
+
+**新しいノードの更新**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D（高度な機能）、Save Splat、Save Point Cloudノード
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): テキスト出力を.txt、.md、.jsonに保存
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 画像とビデオ向けテキストオーバーレイ
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 組み込み Text ノードを再有効化
+
+**パートナーノードの更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 リップシンクおよびトーキングイメージサポート
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedreamノードでthinkingを無効にするオプション
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image プレビューモデルをリリースバージョンに移行
+
+</Update>
+
 <Update label="v0.27.1" description="2026年7月8日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026년 7월 15일">
+
+**새로운 오픈 소스 모델 지원**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): 기본 SeedVR2 이미지 및 비디오 업스케일링
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5 모델 지원 추가
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 지원 및 Turing int8/int4 최적화
+
+**새 노드 업데이트**
+* [**Save 3D (고급)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (고급), Save Splat, Save Point Cloud 노드
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): 텍스트 출력을 .txt, .md, .json으로 저장
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 이미지 및 비디오용 텍스트 오버레이
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 내장 Text 노드를 다시 활성화
+
+**파트너 노드 업데이트**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 립싱크 및 토킹 이미지 지원
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedream 노드에서 생각 비활성화 옵션
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image 미리보기 모델을 릴리스 버전으로 이동
+
+</Update>
+
 <Update label="v0.27.1" description="2026년 7월 8일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="15 июля 2026">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Нативное масштабирование изображений и видео SeedVR2
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): Добавлена поддержка модели PixelDiT PID 1.5
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): Поддержка convrot int4 и оптимизации Turing int8/int4
+
+**Обновления новых узлов**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Узлы Save 3D (Advanced), Save Splat и Save Point Cloud
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Сохранение текстовых результатов в .txt, .md или .json
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Текстовое наложение для изображений и видео
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Встроенный узел Text снова включён
+
+**Обновления партнерских узлов**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 поддержка синхронизации губ и говорящих изображений
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Опция отключения мышления в узлах Seedream
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Модели предварительного просмотра Gemini Image перенесены в релизные версии
+
+</Update>
+
 <Update label="v0.27.1" description="8 июля 2026 года">
 
 **Обновления партнёрских узлов**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,26 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新增开源模型支持**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): 原生 SeedVR2 图像和视频放大
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): 新增 PixelDiT PID 1.5 模型支持
+* [**int4 模型**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 支持及 Turing int8/int4 优化
+
+**新增节点更新**
+* [**保存 3D（高级）**](https://github.com/Comfy-Org/ComfyUI/pull/14701): 保存 3D（高级）、保存 Splat 和保存点云节点
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): 将文本输出保存为 .txt、.md 或 .json
+* [**文本叠加**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 用于图像和视频的文本叠加
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 已重新启用内置 Text 节点
+
+**合作伙伴节点更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 唇形同步与说话图像支持
+* [**Seedream 思维控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思维过程的选项
+* [**Gemini 图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini 图像预览模型移至发布版本
+
+</Update>
+
 <Update label="v0.27.1" description="2026年7月8日">
 
 **合作节点更新**

--- a/.github/scripts/i18n/README.md
+++ b/.github/scripts/i18n/README.md
@@ -39,13 +39,20 @@ pnpm translate:dry-run               # list what would be translated
 pnpm translate:force                 # re-translate everything
 pnpm translate -- --lang zh,ja       # specific languages
 pnpm translate -- installation/x.mdx # specific files
+pnpm translate -- --with-docs-json   # also sync docs.json nav after translate (opt-in)
 pnpm translate:snippets              # snippets only
 pnpm translate:check-truncation      # scan for truncated output
 pnpm translate:repair-fences         # append missing closing ```
 pnpm translate:repair-truncated -- --lang ko
 pnpm translate:sync-hash             # update hashes after manual translation edits
-pnpm translate:sync-docs-json        # sync docs.json navigation paths
+pnpm translate:sync-docs-json        # sync docs.json navigation paths (standalone)
 ```
+
+**`docs.json` is not rewritten by `pnpm translate` by default.** Nav sync used to run
+after every page translate and would also normalize EN path casing against on-disk
+MDX filenames, so a changelog-only run could produce a large unrelated `docs.json`
+diff. When you add, move, or rename pages in the English nav, run
+`pnpm translate:sync-docs-json` (or `pnpm translate -- --with-docs-json`) separately.
 
 Quality controls during/after a run write to `.github/i18n-logs/translate/`
 (gitignored): semantic mismatches reported by the model, and a truncation scan

--- a/.github/scripts/i18n/translate-i18n.ts
+++ b/.github/scripts/i18n/translate-i18n.ts
@@ -19,10 +19,16 @@
  *   npm run translate:snippets                     # snippets only
  *   npm run translate -- --pages-only              # pages only, skip snippets
  *   npm run translate -- installation/foo.mdx      # specific files
+ *   npm run translate -- --with-docs-json          # also sync docs.json nav paths after translate
  *   npm run translate:check-truncation             # scan for truncated translations
  *   npm run translate:repair-truncated -- --lang ko  # re-translate files from truncation log
  *   npm run translate:sync-docs-json -- --lang ko    # sync docs.json paths only (labels preserved)
  *   npm run translate:sync-docs-json -- --translate-nav-labels  # also translate new English nav labels
+ *
+ * docs.json is NOT synced after translate by default. Path/label navigation sync
+ * is a separate concern (new pages, renames, casing). Use
+ * `pnpm translate:sync-docs-json` or pass `--with-docs-json` when the EN nav tree
+ * actually changed. `--no-sync-docs-json` is kept as a no-op for older scripts.
  *
  * Requires Bun: https://bun.sh
  *
@@ -1265,6 +1271,10 @@ async function main() {
   const checkTruncation = args.includes("--check-truncation");
   const repairTruncated = args.includes("--repair-truncated");
   const syncDocsJsonOnly = args.includes("--sync-docs-json");
+  // Opt-in: translate used to always rewrite docs.json (path casing + locale
+  // nav mirror), which mixed unrelated nav diffs into single-file translate PRs
+  // (e.g. changelog-only). Sync only when explicitly requested.
+  const withDocsJsonSync = args.includes("--with-docs-json");
   const skipDocsJsonSync = args.includes("--no-sync-docs-json");
   const translateNavLabels = args.includes("--translate-nav-labels");
   const force = args.includes("--force") || repairTruncated;
@@ -1275,7 +1285,8 @@ async function main() {
     (a, i) => !a.startsWith("--") && args[i - 1] !== "--lang"
   );
   const phases = resolveTranslatePhases(snippetsOnly, pagesOnly, fileArgs);
-  const runDocsJsonAfter = !snippetsOnly && !skipDocsJsonSync;
+  const runDocsJsonAfter =
+    withDocsJsonSync && !snippetsOnly && !skipDocsJsonSync;
 
   if (syncDocsJsonOnly) {
     if (translateNavLabels && !API_KEY) {

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,41 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.28.0" description="July 15, 2026">
+
+**New Open-Source Model Support**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): Native SeedVR2 image and video upscaling ([#14424](https://github.com/Comfy-Org/ComfyUI/pull/14424))
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5 model support
+* [**int4 Models**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 support, plus [Turing int8/int4 optimizations](https://github.com/Comfy-Org/ComfyUI/pull/14927)
+
+**New Nodes**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (Advanced), Save Splat, and Save Point Cloud nodes
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): Save text outputs to `.txt`, `.md`, or `.json`
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): Text overlay for images and video
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): Restored the core Text node
+* [**Create Bounding Boxes**](https://github.com/Comfy-Org/ComfyUI/pull/14724): Added `bboxes` input for upstream wiring
+
+**Partner Node Updates**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 lip-sync and talking-image support
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Option to disable thinking on Seedream nodes
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image preview models moved to release versions
+
+**Performance & Stability**
+* [**`--models-directory`**](https://github.com/Comfy-Org/ComfyUI/pull/9113): Launch argument for a default models directory
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/14772): GQA on all attention backends; dropped PyTorch 2.4
+* [**int8 on 16xx**](https://github.com/Comfy-Org/ComfyUI/pull/14941): Fixed int8 regression on GTX 16xx
+* [**ROCm / AMD Triton**](https://github.com/Comfy-Org/ComfyUI/pull/14869): Triton auto-enable limited to matrix-core GPUs
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/14944): Bumped comfyui-frontend-package to 1.45.21
+
+**Bug Fixes**
+* [**Cached job outputs**](https://github.com/Comfy-Org/ComfyUI/pull/14939): Fixed missing cached outputs when the prompt has no `client_id`
+* [**3D Advanced (API mode)**](https://github.com/Comfy-Org/ComfyUI/pull/14930): Fixed Advanced 3D nodes crashing with no UI
+* [**int4 Turing**](https://github.com/Comfy-Org/ComfyUI/pull/14864): Fixed black images on Turing with int4 models
+* [**Qwen3-VL**](https://github.com/Comfy-Org/ComfyUI/pull/14845): Fixed reference images used as text encode models
+* [**Save Image (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14761): Support for single-channel images
+* [**HiDream O1**](https://github.com/Comfy-Org/ComfyUI/pull/14923): Fixed HiDream O1 regression
+</Update>
+
 <Update label="v0.27.1" description="July 8, 2026">
 
 **Partner Node Updates**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: f490e5fa
+translationSourceHash: 23fea43f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
@@ -104,6 +105,42 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新オープンソースモデルサポート**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): ネイティブ SeedVR2 画像およびビデオのアップスケーリング ([#14424](https://github.com/Comfy-Org/ComfyUI/pull/14424))
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5 モデルサポート
+* [**int4モデル**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 サポート、および [Turing int8/int4最適化](https://github.com/Comfy-Org/ComfyUI/pull/14927)
+
+**新ノード**
+* [**3D保存（高度な機能）**](https://github.com/Comfy-Org/ComfyUI/pull/14701): 3D保存（高度な機能）、スプラット保存、ポイントクラウド保存ノード
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): テキスト出力を `.txt`、`.md`、または `.json` に保存
+* [**テキストオーバーレイ**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 画像とビデオ向けテキストオーバーレイ
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 組み込み Text ノードの非推奨を解除して再有効化
+* [**バウンディングボックスを作成**](https://github.com/Comfy-Org/ComfyUI/pull/14724): 上流配線用の `bboxes` 入力を追加
+
+**パートナーノードの更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 リップシンクおよびトーキングイメージのサポート
+* [**Seedream 思考制御**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedream ノードで思考を無効にするオプション
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image 画像プレビューモデルをリリースバージョンに移動
+
+**パフォーマンスと安定性**
+* [**`--models-directory`**](https://github.com/Comfy-Org/ComfyUI/pull/9113): デフォルトのモデルディレクトリ用の起動引数
+* [**GQAアテンション**](https://github.com/Comfy-Org/ComfyUI/pull/14772): すべてのアテンションバックエンドでの GQA、PyTorch 2.4 のサポート終了
+* [**16xxでのint8**](https://github.com/Comfy-Org/ComfyUI/pull/14941): GTX 16xx でのint8リグレッションを修正
+* [**ROCm / AMD Triton**](https://github.com/Comfy-Org/ComfyUI/pull/14869): Tritonの自動有効化をマトリックスコアGPUに限定
+* [**フロントエンド**](https://github.com/Comfy-Org/ComfyUI/pull/14944): comfyui-frontend-package を 1.45.21 にアップデート
+
+**バグ修正**
+* [**キャッシュされたジョブ出力**](https://github.com/Comfy-Org/ComfyUI/pull/14939): プロンプトに `client_id` がない場合の不足しているキャッシュ出力を修正
+* [**3D高度な機能（APIモード）**](https://github.com/Comfy-Org/ComfyUI/pull/14930): UIなしで高度な3Dノードがクラッシュする問題を修正
+* [**int4 Turing**](https://github.com/Comfy-Org/ComfyUI/pull/14864): Turing で int4 モデル使用時の黒画像を修正
+* [**Qwen3-VL**](https://github.com/Comfy-Org/ComfyUI/pull/14845): 参照画像がテキストエンコードモデルとして使用される問題を修正
+* [**画像を保存（高度な機能）**](https://github.com/Comfy-Org/ComfyUI/pull/14761): シングルチャンネル画像のサポート
+* [**HiDream O1**](https://github.com/Comfy-Org/ComfyUI/pull/14923): HiDream O1 のリグレッションを修正
+</Update>
 
 <Update label="v0.27.1" description="2026年7月8日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: f490e5fa
+translationSourceHash: 23fea43f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
@@ -104,6 +105,43 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+
+<Update label="v0.28.0" description="2026년 7월 15일">
+
+**새로운 오픈소스 모델 지원**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json): 기본 SeedVR2 이미지 및 비디오 업스케일링 ([#14424](https://github.com/Comfy-Org/ComfyUI/pull/14424))
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894): PixelDiT PID 1.5 모델 지원
+* [**int4 모델**](https://github.com/Comfy-Org/ComfyUI/pull/14859): convrot int4 지원 및 [Turing int8/int4 최적화](https://github.com/Comfy-Org/ComfyUI/pull/14927)
+
+**새로운 노드**
+* [**Save 3D (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14701): Save 3D (Advanced), Save Splat, Save Point Cloud 노드
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102): 텍스트 출력을 `.txt`, `.md`, 또는 `.json` 파일로 저장
+* [**Text Overlay**](https://github.com/Comfy-Org/ComfyUI/pull/14610): 이미지 및 비디오용 텍스트 오버레이
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870): 내장 Text 노드를 다시 활성화
+* [**Create Bounding Boxes**](https://github.com/Comfy-Org/ComfyUI/pull/14724): 업스트림 연결을 위한 `bboxes` 입력 추가
+
+**파트너 노드 업데이트**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 립싱크 및 토킹 이미지 지원
+* [**Seedream thinking control**](https://github.com/Comfy-Org/ComfyUI/pull/14853): Seedream 노드에서 thinking 비활성화 옵션
+* [**Gemini Image**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini Image 미리보기 모델이 릴리스 버전으로 이동됨
+
+**성능 및 안정성**
+* [**`--models-directory`**](https://github.com/Comfy-Org/ComfyUI/pull/9113): 기본 모델 디렉터리 설정을 위한 런치 인수
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/14772): 모든 어텐션 백엔드에 GQA 지원; PyTorch 2.4 지원 중단
+* [**int8 on 16xx**](https://github.com/Comfy-Org/ComfyUI/pull/14941): GTX 16xx에서 int8 회귀 버그 수정
+* [**ROCm / AMD Triton**](https://github.com/Comfy-Org/ComfyUI/pull/14869): Triton 자동 활성화가 matrix-core GPU로 제한됨
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/14944): comfyui-frontend-package를 1.45.21로 업데이트
+
+**버그 수정**
+* [**Cached job outputs**](https://github.com/Comfy-Org/ComfyUI/pull/14939): `client_id`가 없는 프롬프트에서 캐시된 출력 누락 문제 수정
+* [**3D Advanced (API mode)**](https://github.com/Comfy-Org/ComfyUI/pull/14930): UI 없이 고급 3D 노드가 충돌하는 문제 수정
+* [**int4 Turing**](https://github.com/Comfy-Org/ComfyUI/pull/14864): Turing에서 int4 모델 사용 시 검정색 이미지 문제 수정
+* [**Qwen3-VL**](https://github.com/Comfy-Org/ComfyUI/pull/14845): 참조 이미지가 텍스트 인코드 모델로 사용되는 문제 수정
+* [**Save Image (Advanced)**](https://github.com/Comfy-Org/ComfyUI/pull/14761): 단일 채널 이미지 지원
+* [**HiDream O1**](https://github.com/Comfy-Org/ComfyUI/pull/14923): HiDream O1 회귀 버그 수정
+
+</Update>
 
 <Update label="v0.27.1" description="2026년 7월 8일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: f490e5fa
+translationSourceHash: 23fea43f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
   "v0.26.2": 26439f22
@@ -104,6 +105,42 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+
+<Update label="v0.28.0" description="2026年7月15日">
+
+**新型开源模型支持**
+* [**SeedVR2**](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/utility_seedvr2_3b_int8_upscale_image.json)：原生SeedVR2图像与视频放大（[#14424](https://github.com/Comfy-Org/ComfyUI/pull/14424)）
+* [**PID 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/14894)：PixelDiT PID 1.5模型支持
+* [**int4模型**](https://github.com/Comfy-Org/ComfyUI/pull/14859)：convrot int4支持，以及[Turing int8/int4优化](https://github.com/Comfy-Org/ComfyUI/pull/14927)
+
+**新增节点**
+* [**保存3D（高级）**](https://github.com/Comfy-Org/ComfyUI/pull/14701)：保存3D（高级）、保存Splat和保存点云节点
+* [**SaveText**](https://github.com/Comfy-Org/ComfyUI/pull/14102)：将文本输出保存为`.txt`、`.md`或`.json`
+* [**文本叠加**](https://github.com/Comfy-Org/ComfyUI/pull/14610)：图像与视频的文本叠加
+* [**Text**](https://github.com/Comfy-Org/ComfyUI/pull/14870)：已重新启用内置 Text 节点
+* [**创建边界框**](https://github.com/Comfy-Org/ComfyUI/pull/14724)：增加了`bboxes`输入，用于上游连线
+
+**合作伙伴节点更新**
+* [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928)：sync.so sync-3 唇形同步与说话图像支持
+* [**Seedream 思考控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853)：Seedream节点可禁用思考过程
+* [**Gemini图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917)：Gemini图像预览模型已移至发布版本
+
+**性能与稳定性**
+* [**`--models-directory`**](https://github.com/Comfy-Org/ComfyUI/pull/9113)：用于设置默认模型目录的启动参数
+* [**GQA注意力**](https://github.com/Comfy-Org/ComfyUI/pull/14772)：所有注意力后端均支持GQA；已放弃PyTorch 2.4
+* [**16xx上的int8**](https://github.com/Comfy-Org/ComfyUI/pull/14941)：修复了GTX 16xx上的int8回归问题
+* [**ROCm / AMD Triton**](https://github.com/Comfy-Org/ComfyUI/pull/14869)：Triton自动启用仅限于矩阵核心GPU
+* [**前端**](https://github.com/Comfy-Org/ComfyUI/pull/14944)：comfyui-frontend-package 更新至1.45.21
+
+**错误修复**
+* [**缓存的任务输出**](https://github.com/Comfy-Org/ComfyUI/pull/14939)：修复了当提示中没有`client_id`时缓存输出缺失的问题
+* [**3D高级（API模式）**](https://github.com/Comfy-Org/ComfyUI/pull/14930)：修复了高级3D节点在无UI情况下崩溃的问题
+* [**int4 Turing**](https://github.com/Comfy-Org/ComfyUI/pull/14864)：修复了Turing显卡上int4模型输出黑色图像的问题
+* [**Qwen3-VL**](https://github.com/Comfy-Org/ComfyUI/pull/14845)：修复将参考图像用于文本编码模型时的问题
+* [**保存图像（高级）**](https://github.com/Comfy-Org/ComfyUI/pull/14761)：支持单通道图像
+* [**HiDream O1**](https://github.com/Comfy-Org/ComfyUI/pull/14923)：修复了HiDream O1回归问题
+</Update>
 
 <Update label="v0.27.1" description="2026年7月8日">
 


### PR DESCRIPTION
## Summary
- Add full docs changelog for ComfyUI **v0.28.0** (EN) with zh/ja/ko translations: SeedVR2, PID 1.5, int4, Save 3D Advanced / SaveText / Text Overlay, partner updates, and related fixes.
- Publish CMS popup staging for **comfyui** and **cloud** (en/zh/ja/ko/fr/ru/es) and refresh `published-versions.json`.
- Stop `pnpm translate` from auto-rewriting `docs.json` (opt-in via `--with-docs-json` or `pnpm translate:sync-docs-json`) so single-file translate runs no longer mix unrelated nav casing diffs.

## Test plan
- [ ] Preview EN `changelog/index.mdx` v0.28.0 block on Mintlify (links to SeedVR2 template + PR)
- [ ] Spot-check zh/ja/ko changelog headings and Text undeprecation wording
- [ ] Confirm in-app / Strapi release notes show `# ComfyUI v0.28.0` and `# Cloud v0.28.0` for published locales
- [ ] Run `pnpm translate:dry-run -- changelog/index.mdx` and confirm it does **not** propose `docs.json` changes unless `--with-docs-json` is passed