### PR TITLE
Fix duplicate outbound Card navigation with Syft

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "mint": "^4.2.459",
+    "mint": "^4.2.700",
     "sharp": "^0.33.3"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       mint:
-        specifier: ^4.2.459
-        version: 4.2.585(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
+        specifier: ^4.2.700
+        version: 4.2.700(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
       sharp:
         specifier: ^0.33.3
         version: 0.33.5
     devDependencies:
       '@executeautomation/playwright-mcp-server':
         specifier: ^1.0.5
-        version: 1.0.12(react@19.2.3)(ws@8.21.0)(zod@4.3.6)
+        version: 1.0.12(react@19.2.3)(ws@8.21.0)(zod@3.25.76)
 
 packages:
 
@@ -603,16 +603,16 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mintlify/cli@4.0.1188':
-    resolution: {integrity: sha512-TOFqM1AWf0MPPmB7jOs+wmprnkRAGUdh0l6uCruPkDwI6CgwTYztGiRwrg0DnSFzh5ZjgNfa2KMyUzsUEFGP1Q==}
+  '@mintlify/cli@4.0.1303':
+    resolution: {integrity: sha512-+bssdCzu2SgSpuAAXn+wAxmyZjkn23YxGk28nSN7sKEXPJyKO91Vy6IXXRTsux2MPr5jbQmeg6k0w2It+Pen5A==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@mintlify/common@1.0.916':
-    resolution: {integrity: sha512-fc3KnfFOHs4/b1kRQe0ax1CG8zUEsWGB/NtSjpvFTSX+CPpHBqLVb7AyBMy3TkdP1Zef11/0XKwEvNCB1OZv/g==}
+  '@mintlify/common@1.0.1014':
+    resolution: {integrity: sha512-ILOxAVg7Fj4eD6G9HwNd/RHYhXW95OVPYvX28Fu8X5OaymMf6vYgnsu3NMcAgnQ/3E86zEXNRrgvlhJ9DcvQbg==}
 
-  '@mintlify/link-rot@3.0.1096':
-    resolution: {integrity: sha512-fcdjrRI94oSpTMvt0WzmK6dJJIj/DLvJvBzYh6n/rMZXzCAYYZMy9ysPOlB33VZiNimfI1RB07ZTesjJf2JjQw==}
+  '@mintlify/link-rot@3.0.1206':
+    resolution: {integrity: sha512-FInBfdSn0GWA6FEqQ5Kqi5FopaRaOxg3F3kNU58EkxChpmiCWX/YlPRJgJ30l/WGpJ5XkrRghJJC8pCuKhaKNw==}
     engines: {node: '>=18.0.0'}
 
   '@mintlify/mdx@3.0.4':
@@ -622,28 +622,28 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@mintlify/models@0.0.314':
-    resolution: {integrity: sha512-ts3AU94pgrC3kOFCtdeyzxKZjiRojYvXMoyY7uGzm1dQurbZFvAc3BfedlRcgUGvxaCUOgJZFgq/wYgb1+rBGQ==}
+  '@mintlify/models@0.0.338':
+    resolution: {integrity: sha512-j7ZGlKPl+rgA/wd0rBqodpYPDDXo8NrP3CIAlcPbhUw39DFwAl1S0NUeDuaKSEIORMIX1r8wvobhDGmCDHA9wQ==}
     engines: {node: '>=18.0.0'}
 
   '@mintlify/openapi-parser@0.0.8':
     resolution: {integrity: sha512-9MBRq9lS4l4HITYCrqCL7T61MOb20q9IdU7HWhqYMNMM1jGO1nHjXasFy61yZ8V6gMZyyKQARGVoZ0ZrYN48Og==}
     engines: {node: '>=18'}
 
-  '@mintlify/prebuild@1.0.1060':
-    resolution: {integrity: sha512-yrIqhT2pEccR9T9b4bE0JdrO76VFeiQYYj732UyG7WX77gIfSgqu9r8kht8sbe5pGk3sAWH3xvE0xVHzvZbwLg==}
+  '@mintlify/prebuild@1.0.1162':
+    resolution: {integrity: sha512-UPEwhLAonzgkWpC6ZBcsP4ANtr0dw13AJ9oopj//Malk8Hg9tIlXmcASDyBMMVds0U6jp28IYH6I5yGEg1GhvQ==}
 
-  '@mintlify/previewing@4.0.1121':
-    resolution: {integrity: sha512-dKC5G7DKf630iqppvoihCaHt8U4yu5tSq4zXNAeNP62y6QJzkC4KA+p1QDGeAhaLLEQ2iK/nGMGF+5ftUm4+9w==}
+  '@mintlify/previewing@4.0.1231':
+    resolution: {integrity: sha512-3SH3ZU9ZhC5eEX9XkzsC068deZoYSZjkFETIL+36/46tRwGf/lULX2Hrsp4pA1XMM9coEdKdppAnl1f2cKZdMQ==}
     engines: {node: '>=18.0.0'}
 
-  '@mintlify/scraping@4.0.780':
-    resolution: {integrity: sha512-eBfHeYOq/+mJUZGJPjHDK9hx70H/In66TbAEIGI/AveODmQNCt6H2jRHRq5cb6UJ4YwiSta3gcOJ1qhcRjaOvA==}
+  '@mintlify/scraping@4.0.879':
+    resolution: {integrity: sha512-DWp2xFEvoRQhbXdto4rk1/Q8CiFD6NSnl6czmXaegJMeqxrsNK7ma2L9LhzNP01kBVX8FvbCXHcTly8/hoLMzA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@mintlify/validation@0.1.714':
-    resolution: {integrity: sha512-Wda8JWogJ4n38T6NUcUxM6wiUJh0hwov9/AEqNmNxw+/R00AxAWdnNKQEbK+EV10yW/sJsaGd1AfSnZLEh5mIg==}
+  '@mintlify/validation@0.1.786':
+    resolution: {integrity: sha512-/BBVqbOT9vbWR3JDKEkYHcWoVVIoI0b85Juur+DutnfQPNMthW1R1Yu+MbyZMzD7KR+0qccfk9QcqW0w2OOttQ==}
 
   '@modelcontextprotocol/sdk@1.24.3':
     resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
@@ -904,8 +904,8 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
-  '@puppeteer/browsers@2.3.0':
-    resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
+  '@puppeteer/browsers@2.7.1':
+    resolution: {integrity: sha512-MK7rtm8JjaxPN7Mf1JdZIZKPD2Z+W7osvrC1vjpvfOX1K0awDIHYbNi89f7eotp7eMUn2shWnt03HwVbriXtKQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1719,8 +1719,8 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromium-bidi@0.6.2:
-    resolution: {integrity: sha512-4WVBa6ijmUTVr9cZD4eicQD8Mdy/HCX3bzEIYYpmk0glqYLoWH+LqQEvV9RpDRzoQSbY1KJHloYXbDMXMbDPhg==}
+  chromium-bidi@2.1.2:
+    resolution: {integrity: sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -1978,8 +1978,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  devtools-protocol@0.0.1312386:
-    resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
+  devtools-protocol@0.0.1402036:
+    resolution: {integrity: sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2282,6 +2282,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -3165,8 +3169,8 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mint@4.2.585:
-    resolution: {integrity: sha512-W/yqwcsAz04fiOmfSUQqkvzLw2t8G+Plf9AVYMvpKqRrckaTvXTZiM/H6T+tfIyAKtmruBfIpjCcji0RHHKuHQ==}
+  mint@4.2.700:
+    resolution: {integrity: sha512-0xmAyUqJlqFhFbOYj8Oje+mgXD/FIhvAShcWiljpMLBZdeTPZV6KIcy/54r08rvE3zvl+kCbDUFZ516SNHSdMA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -3549,12 +3553,12 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  puppeteer-core@22.14.0:
-    resolution: {integrity: sha512-rl4tOY5LcA3e374GAlsGGHc05HL3eGNf5rZ+uxkl6id9zVZKcwcp1Z+Nd6byb6WPiPeecT/dwz8f/iUm+AZQSw==}
+  puppeteer-core@24.3.1:
+    resolution: {integrity: sha512-585ccfcTav4KmlSmYbwwOSeC8VdutQHn2Fuk0id/y/9OoeO7Gg5PK1aUGdZjEmos0TAq+pCpChqFurFbpNd3wA==}
     engines: {node: '>=18'}
 
-  puppeteer@22.14.0:
-    resolution: {integrity: sha512-MGTR6/pM8zmWbTdazb6FKnwIihzsSEXBPH49mFFU96DNZpQOevCAZMnjBZGlZRGRzRK6aADCavR6SQtrbv5dQw==}
+  puppeteer@24.3.1:
+    resolution: {integrity: sha512-k0OJ7itRwkr06owp0CP3f/PsRD7Pdw4DjoCUZvjGr+aNgS1z6n/61VajIp0uBjl+V5XAQO1v/3k9bzeZLWs9OQ==}
     engines: {node: '>=18'}
     deprecated: < 24.15.0 is no longer supported
     hasBin: true
@@ -4099,9 +4103,6 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -4194,6 +4195,9 @@ packages:
     resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
 
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -4202,9 +4206,6 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
-
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -4280,9 +4281,6 @@ packages:
 
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-
-  urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4483,11 +4481,11 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.24.0:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -4513,45 +4511,45 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@ai-sdk/anthropic@1.2.12(zod@4.3.6)':
+  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/openai@1.3.24(zod@4.3.6)':
+  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.12
       secure-json-parse: 2.7.0
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.12(react@19.2.3)(zod@4.3.6)':
+  '@ai-sdk/react@1.2.12(react@19.2.3)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
       react: 19.2.3
       swr: 2.4.1(react@19.2.3)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 4.3.6
+      zod: 3.25.76
 
-  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
@@ -4707,16 +4705,16 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@executeautomation/playwright-mcp-server@1.0.12(react@19.2.3)(ws@8.21.0)(zod@4.3.6)':
+  '@executeautomation/playwright-mcp-server@1.0.12(react@19.2.3)(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       '@playwright/browser-chromium': 1.57.0
       '@playwright/browser-firefox': 1.57.0
       '@playwright/browser-webkit': 1.57.0
       '@playwright/test': 1.60.0
       cors: 2.8.6
       express: 4.22.2
-      mcp-evals: 2.0.1(react@19.2.3)(ws@8.21.0)(zod@4.3.6)
+      mcp-evals: 2.0.1(react@19.2.3)(ws@8.21.0)(zod@3.25.76)
       playwright: 1.57.0
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -4998,7 +4996,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
-      acorn: 8.11.2
+      acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -5007,7 +5005,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.11.2)
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -5028,15 +5026,15 @@ snapshots:
       '@types/react': 19.2.15
       react: 19.2.3
 
-  '@mintlify/cli@4.0.1188(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)':
+  '@mintlify/cli@4.0.1303(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)':
     dependencies:
       '@inquirer/prompts': 7.9.0(@types/node@25.9.1)
-      '@mintlify/common': 1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/link-rot': 3.0.1096(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/models': 0.0.314
-      '@mintlify/prebuild': 1.0.1060(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1121(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
-      '@mintlify/validation': 0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/common': 1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/link-rot': 3.0.1206(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/models': 0.0.338
+      '@mintlify/prebuild': 1.0.1162(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1231(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
+      '@mintlify/validation': 0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
       color: 4.2.3
@@ -5074,14 +5072,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/common@1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+  '@mintlify/common@1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
       '@asyncapi/parser': 3.4.0
       '@asyncapi/specs': 6.8.1
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/models': 0.0.314
+      '@mintlify/models': 0.0.338
       '@mintlify/openapi-parser': 0.0.8
-      '@mintlify/validation': 0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/validation': 0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       '@sindresorhus/slugify': 2.2.0
       '@types/mdast': 4.0.4
       acorn: 8.11.2
@@ -5116,7 +5114,7 @@ snapshots:
       remark-rehype: 11.1.1
       remark-stringify: 11.0.0
       sucrase: 3.34.0
-      tailwindcss: 3.4.17
+      tailwindcss-v3: tailwindcss@3.4.17
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -5137,14 +5135,14 @@ snapshots:
       - ts-node
       - typescript
 
-  '@mintlify/link-rot@3.0.1096(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+  '@mintlify/link-rot@3.0.1206(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/models': 0.0.314
-      '@mintlify/prebuild': 1.0.1060(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/previewing': 4.0.1121(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
-      '@mintlify/scraping': 4.0.780(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/validation': 0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/common': 1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/models': 0.0.338
+      '@mintlify/prebuild': 1.0.1162(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/previewing': 4.0.1231(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.879(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/validation': 0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       fs-extra: 11.1.0
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
@@ -5171,7 +5169,7 @@ snapshots:
       '@shikijs/twoslash': 3.23.0(typescript@6.0.3)
       arktype: 2.2.0
       hast-util-to-string: 3.0.1
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-to-hast: 13.2.1
@@ -5190,7 +5188,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@mintlify/models@0.0.314':
+  '@mintlify/models@0.0.338':
     dependencies:
       axios: 1.16.1
       openapi-types: 12.1.3
@@ -5207,12 +5205,12 @@ snapshots:
       leven: 4.1.0
       yaml: 2.9.0
 
-  '@mintlify/prebuild@1.0.1060(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+  '@mintlify/prebuild@1.0.1162(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/common': 1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
-      '@mintlify/scraping': 4.0.780(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/validation': 0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/scraping': 4.0.879(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/validation': 0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       chalk: 5.3.0
       favicons: 7.2.0
       front-matter: 4.0.2
@@ -5239,11 +5237,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/previewing@4.0.1121(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)':
+  '@mintlify/previewing@4.0.1231(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/prebuild': 1.0.1060(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/validation': 0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/common': 1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/prebuild': 1.0.1162(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/validation': 0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       better-opn: 3.0.2
       chalk: 5.2.0
@@ -5278,16 +5276,16 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/scraping@4.0.780(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+  '@mintlify/scraping@4.0.879(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
-      '@mintlify/common': 1.0.916(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      '@mintlify/common': 1.0.1014(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.1.1
       hast-util-to-mdast: 10.1.0
       js-yaml: 4.1.1
       mdast-util-mdx-jsx: 3.1.3
       neotraverse: 0.6.18
-      puppeteer: 22.14.0(typescript@6.0.3)
+      puppeteer: 24.3.1(typescript@6.0.3)
       rehype-parse: 9.0.1
       remark-gfm: 4.0.0
       remark-mdx: 3.0.1
@@ -5313,11 +5311,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mintlify/validation@0.1.714(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
+  '@mintlify/validation@0.1.786(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)':
     dependencies:
       '@mintlify/mdx': 3.0.4(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-      '@mintlify/models': 0.0.314
+      '@mintlify/models': 0.0.338
       arktype: 2.1.27
+      fractional-indexing: 3.2.0
       js-yaml: 4.1.1
       lcm: 0.0.3
       lodash: 4.18.1
@@ -5336,7 +5335,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@modelcontextprotocol/sdk@1.24.3(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.24.3(zod@3.25.76)':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -5350,8 +5349,8 @@ snapshots:
       jose: 6.2.3
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -5662,15 +5661,14 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@puppeteer/browsers@2.3.0':
+  '@puppeteer/browsers@2.7.1':
     dependencies:
       debug: 4.4.3
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.8.1
       tar-fs: 3.1.2
-      unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -5925,7 +5923,7 @@ snapshots:
 
   '@stoplight/json-ref-readers@1.2.2':
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       tslib: 1.14.1
     transitivePeerDependencies:
       - encoding
@@ -6179,6 +6177,10 @@ snapshots:
     dependencies:
       acorn: 8.11.2
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.11.2: {}
 
   acorn@8.16.0: {}
@@ -6204,15 +6206,15 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@4.3.19(react@19.2.3)(zod@4.3.6):
+  ai@4.3.19(react@19.2.3)(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      '@ai-sdk/react': 1.2.12(react@19.2.3)(zod@4.3.6)
-      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@19.2.3)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 4.3.6
+      zod: 3.25.76
     optionalDependencies:
       react: 19.2.3
 
@@ -6383,7 +6385,8 @@ snapshots:
 
   base-64@0.1.0: {}
 
-  base64-js@1.5.1: {}
+  base64-js@1.5.1:
+    optional: true
 
   base64id@2.0.0: {}
 
@@ -6450,6 +6453,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bytes@3.1.2: {}
 
@@ -6540,12 +6544,11 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromium-bidi@0.6.2(devtools-protocol@0.0.1312386):
+  chromium-bidi@2.1.2(devtools-protocol@0.0.1402036):
     dependencies:
-      devtools-protocol: 0.0.1312386
+      devtools-protocol: 0.0.1402036
       mitt: 3.0.1
-      urlpattern-polyfill: 10.0.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   cjs-module-lexer@1.4.3: {}
 
@@ -6759,7 +6762,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  devtools-protocol@0.0.1312386: {}
+  devtools-protocol@0.0.1402036: {}
 
   didyoumean@1.2.2: {}
 
@@ -6930,7 +6933,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.11.2
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -7251,6 +7254,8 @@ snapshots:
       web-streams-polyfill: 4.0.0-beta.3
 
   forwarded@0.2.0: {}
+
+  fractional-indexing@3.2.0: {}
 
   fresh@0.5.2: {}
 
@@ -7662,7 +7667,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   ignore@7.0.5: {}
 
@@ -8016,13 +8022,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-evals@2.0.1(react@19.2.3)(ws@8.21.0)(zod@4.3.6):
+  mcp-evals@2.0.1(react@19.2.3)(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@actions/core': 1.11.1
-      '@ai-sdk/anthropic': 1.2.12(zod@4.3.6)
-      '@ai-sdk/openai': 1.3.24(zod@4.3.6)
+      '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
+      '@ai-sdk/openai': 1.3.24(zod@3.25.76)
       '@anthropic-ai/sdk': 0.8.1
-      '@modelcontextprotocol/sdk': 1.24.3(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-http': 0.200.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
@@ -8030,12 +8036,12 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@types/js-yaml': 4.0.9
-      ai: 4.3.19(react@19.2.3)(zod@4.3.6)
+      ai: 4.3.19(react@19.2.3)(zod@3.25.76)
       chalk: 4.1.2
       dotenv: 16.6.1
       express: 5.2.1
       js-yaml: 4.1.1
-      openai: 4.104.0(ws@8.21.0)(zod@4.3.6)
+      openai: 4.104.0(ws@8.21.0)(zod@3.25.76)
       prom-client: 15.1.3
       react: 19.2.3
       tsx: 4.22.3
@@ -8057,7 +8063,7 @@ snapshots:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
       unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -8098,7 +8104,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -8116,7 +8122,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -8125,7 +8131,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8135,7 +8141,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8144,14 +8150,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -8163,7 +8169,7 @@ snapshots:
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -8179,7 +8185,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -8191,7 +8197,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8204,7 +8210,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -8232,7 +8238,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -8246,7 +8252,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8433,8 +8439,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.1
       micromark-extension-mdx-md: 2.0.0
@@ -8616,9 +8622,9 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mint@4.2.585(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3):
+  mint@4.2.700(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3):
     dependencies:
-      '@mintlify/cli': 4.0.1188(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
+      '@mintlify/cli': 4.0.1303(@radix-ui/react-popover@1.1.15(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.1)(@types/react@19.2.15)(react-dom@18.3.1(react@19.2.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -8701,7 +8707,7 @@ snapshots:
 
   node-abi@3.92.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.1
     optional: true
 
   node-addon-api@4.3.0:
@@ -8768,7 +8774,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@8.21.0)(zod@4.3.6):
+  openai@4.104.0(ws@8.21.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -8779,7 +8785,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.21.0
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
@@ -9026,12 +9032,13 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  puppeteer-core@22.14.0:
+  puppeteer-core@24.3.1:
     dependencies:
-      '@puppeteer/browsers': 2.3.0
-      chromium-bidi: 0.6.2(devtools-protocol@0.0.1312386)
+      '@puppeteer/browsers': 2.7.1
+      chromium-bidi: 2.1.2(devtools-protocol@0.0.1402036)
       debug: 4.4.3
-      devtools-protocol: 0.0.1312386
+      devtools-protocol: 0.0.1402036
+      typed-query-selector: 2.12.2
       ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -9041,12 +9048,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@22.14.0(typescript@6.0.3):
+  puppeteer@24.3.1(typescript@6.0.3):
     dependencies:
-      '@puppeteer/browsers': 2.3.0
+      '@puppeteer/browsers': 2.7.1
+      chromium-bidi: 2.1.2(devtools-protocol@0.0.1402036)
       cosmiconfig: 9.0.1(typescript@6.0.3)
-      devtools-protocol: 0.0.1312386
-      puppeteer-core: 22.14.0
+      devtools-protocol: 0.0.1402036
+      puppeteer-core: 24.3.1
+      typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -9153,10 +9162,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.11.2):
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -9213,7 +9222,7 @@ snapshots:
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
       katex: 0.16.47
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
 
   rehype-minify-whitespace@6.0.2:
@@ -9238,7 +9247,7 @@ snapshots:
   rehype-stringify@10.0.1:
     dependencies:
       '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.4
+      hast-util-to-html: 9.0.5
       unified: 11.0.5
 
   remark-frontmatter@5.0.0:
@@ -9253,7 +9262,7 @@ snapshots:
   remark-gfm@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.0.0
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9293,7 +9302,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9911,8 +9920,6 @@ snapshots:
 
   throttleit@2.1.0: {}
 
-  through@2.3.8: {}
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10015,6 +10022,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-query-selector@2.12.2: {}
+
   typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
@@ -10023,11 +10032,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
 
   undici-types@5.26.5: {}
 
@@ -10090,7 +10094,7 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -10132,8 +10136,6 @@ snapshots:
   unpipe@1.0.0: {}
 
   urijs@1.19.11: {}
-
-  urlpattern-polyfill@10.0.0: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.15)(react@19.2.3):
     dependencies:
@@ -10325,13 +10327,13 @@ snapshots:
     dependencies:
       zod: 3.24.0
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
-      zod: 4.3.6
-
-  zod@3.23.8: {}
+      zod: 3.25.76
 
   zod@3.24.0: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/syft.js
+++ b/syft.js
@@ -1,1 +1,9 @@
-!function(t,e,c){if(t.syftc=c,!t.syft){t.syft={q:[],fi:[],fetchID:function(){var e=Array.prototype.slice.call(arguments);return new Promise(function(c,f){t.syft.fi.push({args:e,resolve:c,reject:f})})}},["identify","track","page","signup"].forEach(function(e){t.syft[e]=function(){var c=Array.prototype.slice.call(arguments);c.unshift(e),t.syft.q.push(c)}});var f=e.createElement("script");f.async=!0,f.setAttribute("src","https://cdn.sy-d.io/syftnext/syft.umd.js"),(e.body||e.head).appendChild(f)}}(window,document,{sourceId:"cmo1xgq4o000804jr5jlj5dtn"});
+!function(t,e,c){if(t.syftc=c,!t.syft){t.syft={q:[],fi:[],fetchID:function(){var e=Array.prototype.slice.call(arguments);return new Promise(function(c,f){t.syft.fi.push({args:e,resolve:c,reject:f})})}},["identify","track","page","signup"].forEach(function(e){t.syft[e]=function(){var c=Array.prototype.slice.call(arguments);c.unshift(e),t.syft.q.push(c)}});var f=e.createElement("script");f.async=!0,f.setAttribute("src","https://cdn.sy-d.io/syftnext/syft.umd.js"),(e.body||e.head).appendChild(f)}}(window,document,{sourceId:"cmo1xgq4o000804jr5jlj5dtn",trackOutboundLinks:!1});
+
+// Syft's built-in outbound link tracking prevents and replays clicks. That
+// conflicts with Mintlify cards, which handle navigation on the card itself.
+// Track the same event without changing the browser's navigation behavior.
+document.addEventListener("click",function(event){
+  var target=event.target instanceof Element?event.target.closest("a"):null;
+  target&&target.host!==location.host&&target.href!==""&&target.href!=="#"&&window.syft.track("OutboundLink Clicked",{href:target.href});
+},{capture:!0});


### PR DESCRIPTION
## Summary

- upgrade Mint CLI from 4.2.459 to 4.2.700
- disable Syft built-in outbound-link replay, which conflicts with Mintlify Card navigation
- preserve the existing `OutboundLink Clicked` analytics event using a non-blocking click listener

## Root cause

Syft prevents clicks on external anchors and replays them after tracking. Mintlify Cards also handle navigation on the card container, so external Card clicks can open two tabs. Internal links are unaffected.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec mint version` (CLI 4.2.700, client 0.0.3252)
- `git diff --check`
- clicked the full model-download Card in the local LTX-2.3 page and confirmed exactly one Hugging Face tab opened
- confirmed `Place in` paths remain visible
