### PR TITLE
Chore: ignore local Codex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp/
 __pycache__/
 *.py[cod]
 .work/
+.codex/


### PR DESCRIPTION
## Summary

- ignore the repository-local `.codex/` directory
- prevent local Codex workspace files from being committed accidentally
