### PR TITLE
fix(seo): add redirect coverage for legacy api-node routes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11280,7 +11280,23 @@
       "destination": "/built-in-nodes/partner-node/:slug*"
     },
     {
+      "source": "/built-in-nodes/api-node/:slug*",
+      "destination": "/built-in-nodes/partner-node/:slug*"
+    },
+    {
       "source": "/zh-CN/built-in-nodes/api-nodes/:slug*",
+      "destination": "/zh/built-in-nodes/partner-node/:slug*"
+    },
+    {
+      "source": "/zh-CN/built-in-nodes/api-node/:slug*",
+      "destination": "/zh/built-in-nodes/partner-node/:slug*"
+    },
+    {
+      "source": "/zh/built-in-nodes/api-nodes/:slug*",
+      "destination": "/zh/built-in-nodes/partner-node/:slug*"
+    },
+    {
+      "source": "/zh/built-in-nodes/api-node/:slug*",
       "destination": "/zh/built-in-nodes/partner-node/:slug*"
     },
     {


### PR DESCRIPTION
## Summary

Add redirect coverage for legacy `api-node` documentation routes by redirecting them to the canonical `partner-node` paths, including missing Chinese locale variants.

## Changes

- Added redirects for legacy `api-node` routes to the canonical `partner-node` routes.
- Added redirect coverage for missing `zh` and legacy `zh-CN` route variants.
- Preserved canonical documentation URLs while improving compatibility with legacy route structures.
- Validated the updated `docs.json` configuration.

## Why

The reported failing URL referenced the deprecated `api-node` route, while the current documentation uses `partner-node`. Existing redirects covered the plural `api-nodes` variant but not the singular `api-node` path, leaving legacy URLs unresolved. These redirects ensure requests are routed to the canonical documentation pages.