### PR TITLE
fix(seo): add redirects for legacy Chinese locale variants

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11300,7 +11300,15 @@
       "destination": "/zh/custom-nodes/backend/expansion"
     },
     {
+      "source": "/zh-CN/zh-cn/:slug*",
+      "destination": "/zh/:slug*"
+    },
+    {
       "source": "/zh-CN/:slug*",
+      "destination": "/zh/:slug*"
+    },
+    {
+      "source": "/zh-cn/:slug*",
       "destination": "/zh/:slug*"
     },
     {


### PR DESCRIPTION
## Summary

Add redirect coverage for legacy Chinese locale variants to resolve uncovered documentation routes.

## What was happening?

The repository already redirected legacy `/zh-CN/*` URLs to the canonical `/zh/*` paths. However, redirect coverage was missing for the lowercase `/zh-cn/*` variant and duplicated `/zh-CN/zh-cn/*` paths. Requests to these legacy URLs therefore resulted in 404 responses instead of resolving to the canonical documentation.

## Solution

Added redirect rules for the missing legacy locale variants:

- `/zh-cn/:slug*` → `/zh/:slug*`
- `/zh-CN/zh-cn/:slug*` → `/zh/:slug*`

These redirects ensure outdated Chinese locale URLs resolve to the canonical `/zh/` documentation instead of returning 404 errors.

## Validation

- Verified `/zh/` is the canonical Chinese locale used by the repository.
- Confirmed `:slug*` entries are valid redirect wildcard syntax.
- Validated the updated `docs.json` configuration.