### PR TITLE
fix(seo): localize Registry API reference routes and normalize zh loc…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2726,7 +2726,10 @@
           },
           {
             "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
+            "openapi": {
+              "source": "https://api.comfy.org/openapi",
+              "directory": "api-reference/registry"
+            }
           },
           {
             "tab": "Cloud API Reference",
@@ -5465,7 +5468,10 @@
           },
           {
             "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
+            "openapi": {
+              "source": "https://api.comfy.org/openapi",
+              "directory": "zh/api-reference/registry"
+            }
           },
           {
             "tab": "Cloud API 参考文档",
@@ -8211,7 +8217,10 @@
           },
           {
             "tab": "Registry APIリファレンス",
-            "openapi": "https://api.comfy.org/openapi"
+            "openapi": {
+              "source": "https://api.comfy.org/openapi",
+              "directory": "ja/api-reference/registry"
+            }
           },
           {
             "tab": "Cloud APIリファレンス",
@@ -10901,7 +10910,10 @@
           },
           {
             "tab": "Registry API 참조",
-            "openapi": "https://api.comfy.org/openapi"
+            "openapi": {
+              "source": "https://api.comfy.org/openapi",
+              "directory": "ko/api-reference/registry"
+            }
           },
           {
             "tab": "Cloud API 참조",
@@ -11300,7 +11312,15 @@
       "destination": "/zh/custom-nodes/backend/expansion"
     },
     {
+      "source": "/zh-CN/zh-cn/:slug*",
+      "destination": "/zh/:slug*"
+    },
+    {
       "source": "/zh-CN/:slug*",
+      "destination": "/zh/:slug*"
+    },
+    {
+      "source": "/zh-cn/:slug*",
       "destination": "/zh/:slug*"
     },
     {


### PR DESCRIPTION
# Summary

* Add locale-specific output directories for Registry API Reference pages.
* Normalize legacy Chinese locale variants with redirects to the canonical `/zh` path.

# Motivation

The Registry API Reference shared the same OpenAPI configuration across locales, causing localized routing collisions. This change aligns Registry API generation with the existing Cloud API implementation to ensure each locale generates independently.

# Testing

* Verified localized routing using the Mintlify development preview.
* Confirmed locale-specific Registry API routes resolve correctly.
* Validated `docs.json` syntax.
