### PR TITLE
docs: add CLAUDE.md shim (BE-3540)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Agent instructions live in AGENTS.md (the cross-agent standard). This is a Claude Code shim: Claude reads only CLAUDE.md, so the import below pulls AGENTS.md in. Don't add content here — edit AGENTS.md. -->
+@AGENTS.md


### PR DESCRIPTION
## ELI-5

Claude Code only reads `CLAUDE.md` — it never falls back to `AGENTS.md`. This repo keeps its agent instructions in `AGENTS.md` (the cross-agent standard). This PR adds a tiny `CLAUDE.md` at the root that imports `AGENTS.md` so Claude Code picks up the same instructions as every other tool. Nothing else changes.

## What

Adds a root `CLAUDE.md` containing exactly the org-standard shim (per the 2026-07-15 "Pillar 1: Agentic Engineering" guide, audited in BE-3241):

```markdown
<!-- Agent instructions live in AGENTS.md (the cross-agent standard). This is a Claude Code shim: Claude reads only CLAUDE.md, so the import below pulls AGENTS.md in. Don't add content here — edit AGENTS.md. -->
@AGENTS.md
```

`AGENTS.md` (36 lines, already compliant) is unchanged. `@AGENTS.md` resolves relative to the shim's directory (repo root), so it pulls in the existing root `AGENTS.md`.

## Why

Standardizes agent instructions: `AGENTS.md` is the single source of truth; `CLAUDE.md` exists only as a Claude Code shim.

## Testing / CI notes

- The file contains **no links** (the `<!-- -->` HTML comment and `@AGENTS.md` import are not markdown/HTML link syntax), so `link-validation` (runs on `**/*.md`) and `mint broken-links` have nothing to flag.
- `i18n-sync-check` triggers only on `**/*.mdx` / `docs.json`, so a `.md` shim requires no translations.
- Verified byte-for-byte against the canonical shim (incl. the `—` em-dash); `git diff` confirms `AGENTS.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
