### PR TITLE
docs: add ComfyUI v0.28.1 and v0.28.2 changelog

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -342,7 +342,7 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-07-15T12:33:08.856Z"
+      "published_at": "2026-07-19T03:17:47.351Z"
     },
     {
       "project": "comfyui",
@@ -356,7 +356,63 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-07-15T12:32:50.377Z"
+      "published_at": "2026-07-19T03:18:09.883Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.28.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-19T03:16:36.888Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.28.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-19T03:16:16.245Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.28.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-19T03:16:41.802Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.28.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-19T03:16:21.011Z"
     }
   ]
 }

--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -342,7 +342,7 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-07-19T03:17:47.351Z"
+      "published_at": "2026-07-19T03:28:34.601Z"
     },
     {
       "project": "comfyui",
@@ -356,7 +356,7 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-07-19T03:18:09.883Z"
+      "published_at": "2026-07-19T03:28:21.301Z"
     },
     {
       "project": "cloud",

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="July 18, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Switched Omni model to the Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="July 17, 2026">
+
+**Partner Node Updates**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Added GPT-5.6 Sol, Terra, and Luna models
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Added Gemini 3.5 Flash to the Gemini LLM node
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech nodes
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="July 18, 2026">
+
+**Actualizaciones de nodos asociados**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Cambió el modelo Omni a la API de Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 de julio de 2026">
+
+**Actualizaciones de nodos asociados**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Se añadieron los modelos GPT-5.6 Sol, Terra y Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Se añadió Gemini 3.5 Flash al nodo Gemini LLM
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Nodos de Video de Avatar, Foto Parlante, Crear Avatar, Traducir Video y Texto a Voz
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="18 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984) : Passage du modèle Omni à l'API Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957) : Ajout des modèles GPT-5.6 Sol, Terra et Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972) : Ajout de Gemini 3.5 Flash au nœud LLM Gemini
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958) : Nœuds Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026年7月18日">
+
+**パートナーノード更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): OmniモデルをInteractions APIに切り替えました
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**パートナーノードの更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol、Terra、Luna モデルを追加
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini LLM ノードに Gemini 3.5 Flash を追加
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): アバタービデオ、トーキングフォト、アバター作成、ビデオ翻訳、テキスト読み上げノード
+
+</Update>
+
 <Update label="v0.28.0" description="2026年7月15日">
 
 **新しいオープンソースモデルのサポート**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026년 7월 18일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Omni 모델을 Interactions API로 전환했습니다.
+
+</Update>
+
+<Update label="v0.28.1" description="2026년 7월 17일">
+
+**파트너 노드 업데이트**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol, Terra, Luna 모델 추가
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini 3.5 Flash를 Gemini LLM 노드에 추가
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech 노드
+
+</Update>
+
 <Update label="v0.28.0" description="2026년 7월 15일">
 
 **새로운 오픈 소스 모델 지원**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="18 июля 2026 г.">
+
+**Обновления партнерских узлов**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Переключена модель Omni на API Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 июля 2026 года">
+
+**Обновления партнёрских узлов**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Добавлены модели GPT-5.6 Sol, Terra и Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Добавлен Gemini 3.5 Flash в узел Gemini LLM
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): узлы Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech
+
+</Update>
+
 <Update label="v0.28.0" description="15 июля 2026">
 
 **Поддержка новых моделей с открытым исходным кодом**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026年7月18日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): 将Omni模型切换到Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**合作伙伴节点更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957)：新增GPT-5.6 Sol、Terra和Luna模型
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972)：在Gemini LLM节点中新增Gemini 3.5 Flash
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958)：头像视频、会说话的照片、创建头像、视频翻译、文本转语音节点
+
+</Update>
+
 <Update label="v0.28.0" description="2026年7月15日">
 
 **新增开源模型支持**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -35,7 +35,7 @@ cmsStaging: true
 
 **合作伙伴节点更新**
 * [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 唇形同步与说话图像支持
-* [**Seedream 思维控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思维过程的选项
+* [**Seedream 思考链 COT**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思考链 COT 的选项
 * [**Gemini 图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini 图像预览模型移至发布版本
 
 </Update>

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="July 18, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Switched Omni model to the Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="July 17, 2026">
+
+**Partner Node Updates**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Added GPT-5.6 Sol, Terra, and Luna models
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Added Gemini 3.5 Flash to the Gemini LLM node
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech nodes
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="July 18, 2026">
+
+**Actualizaciones de nodos asociados**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Cambió el modelo Omni a la API de Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 de julio de 2026">
+
+**Actualizaciones de nodos asociados**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Se añadieron los modelos GPT-5.6 Sol, Terra y Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Se añadió Gemini 3.5 Flash al nodo Gemini LLM
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Nodos de Video de Avatar, Foto Parlante, Crear Avatar, Traducir Video y Texto a Voz
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="18 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984) : Passage du modèle Omni à l'API Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957) : Ajout des modèles GPT-5.6 Sol, Terra et Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972) : Ajout de Gemini 3.5 Flash au nœud LLM Gemini
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958) : Nœuds Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026年7月18日">
+
+**パートナーノード更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): OmniモデルをInteractions APIに切り替えました
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**パートナーノードの更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol、Terra、Luna モデルを追加
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini LLM ノードに Gemini 3.5 Flash を追加
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): アバタービデオ、トーキングフォト、アバター作成、ビデオ翻訳、テキスト読み上げノード
+
+</Update>
+
 <Update label="v0.28.0" description="2026年7月15日">
 
 **新しいオープンソースモデルのサポート**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026년 7월 18일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Omni 모델을 Interactions API로 전환했습니다.
+
+</Update>
+
+<Update label="v0.28.1" description="2026년 7월 17일">
+
+**파트너 노드 업데이트**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol, Terra, Luna 모델 추가
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini 3.5 Flash를 Gemini LLM 노드에 추가
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech 노드
+
+</Update>
+
 <Update label="v0.28.0" description="2026년 7월 15일">
 
 **새로운 오픈 소스 모델 지원**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="18 июля 2026 г.">
+
+**Обновления партнерских узлов**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Переключена модель Omni на API Interactions
+
+</Update>
+
+<Update label="v0.28.1" description="17 июля 2026 года">
+
+**Обновления партнёрских узлов**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Добавлены модели GPT-5.6 Sol, Terra и Luna
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Добавлен Gemini 3.5 Flash в узел Gemini LLM
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): узлы Avatar Video, Talking Photo, Create Avatar, Video Translate, Text to Speech
+
+</Update>
+
 <Update label="v0.28.0" description="15 июля 2026">
 
 **Поддержка новых моделей с открытым исходным кодом**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,22 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.28.2" description="2026年7月18日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): 将Omni模型切换到Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**合作伙伴节点更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957)：新增GPT-5.6 Sol、Terra和Luna模型
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972)：在Gemini LLM节点中新增Gemini 3.5 Flash
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958)：头像视频、会说话的照片、创建头像、视频翻译、文本转语音节点
+
+</Update>
+
 <Update label="v0.28.0" description="2026年7月15日">
 
 **新增开源模型支持**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -35,7 +35,7 @@ cmsStaging: true
 
 **合作伙伴节点更新**
 * [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928): sync.so sync-3 唇形同步与说话图像支持
-* [**Seedream 思维控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思维过程的选项
+* [**Seedream 思考链 COT**](https://github.com/Comfy-Org/ComfyUI/pull/14853): 在 Seedream 节点上禁用思考链 COT 的选项
 * [**Gemini 图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917): Gemini 图像预览模型移至发布版本
 
 </Update>

--- a/.mintignore
+++ b/.mintignore
@@ -1,7 +1,10 @@
 # Dependencies (pnpm nests packages under node_modules/.pnpm)
 node_modules/
 **/node_modules/
+
+# Agent instruction shims (not Mintlify pages; HTML comments / @imports break MDX parse)
 AGENTS.md
+CLAUDE.md
 
 # Local tooling / logs — not part of the docs site
 .github/

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,22 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.28.2" description="July 18, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Switched Omni model to the Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="July 17, 2026">
+
+**Partner Node Updates**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): Added GPT-5.6 Sol, Terra, and Luna models
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Added Gemini 3.5 Flash to the Gemini LLM node
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): Avatar Video, Talking Photo, Create Avatar, Video Translate, and Text to Speech nodes
+
+</Update>
+
 <Update label="v0.28.0" description="July 15, 2026">
 
 **New Open-Source Model Support**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 23fea43f
+translationSourceHash: 7082b633
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.2": 27b88b8c
+  "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
@@ -106,6 +108,23 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
+
+<Update label="v0.28.2" description="2026年7月18日">
+
+**パートナーノード更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): OmniモデルをInteractions APIに切り替えました。
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**パートナーノード更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol、Terra、Lunaモデルを追加
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini 3.5 FlashをGemini LLMノードに追加
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): アバタービデオ、トーキングフォト、アバター作成、ビデオ翻訳、テキスト読み上げノード
+
+</Update>
 
 <Update label="v0.28.0" description="2026年7月15日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 23fea43f
+translationSourceHash: 7082b633
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.2": 27b88b8c
+  "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
@@ -106,6 +108,23 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
+
+<Update label="v0.28.2" description="2026년 7월 18일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984): Omni 모델을 Interactions API로 전환했습니다
+
+</Update>
+
+<Update label="v0.28.1" description="2026년 7월 17일">
+
+**파트너 노드 업데이트**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957): GPT-5.6 Sol, Terra, Luna 모델이 추가되었습니다
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972): Gemini LLM 노드에 Gemini 3.5 Flash가 추가되었습니다
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958): 아바타 비디오, 토킹 포토, 아바타 생성, 비디오 번역, 텍스트 음성 변환 노드
+
+</Update>
 
 <Update label="v0.28.0" description="2026년 7월 15일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -110,6 +110,7 @@ translationBlockHashes:
 
 
 
+
 <Update label="v0.28.2" description="2026年7月18日">
 
 **合作伙伴节点更新**
@@ -142,7 +143,7 @@ translationBlockHashes:
 
 **合作伙伴节点更新**
 * [**sync.so sync-3**](https://github.com/Comfy-Org/ComfyUI/pull/14928)：sync.so sync-3 唇形同步与说话图像支持
-* [**Seedream 思考控制**](https://github.com/Comfy-Org/ComfyUI/pull/14853)：Seedream节点可禁用思考过程
+* [**Seedream 思考链 COT**](https://github.com/Comfy-Org/ComfyUI/pull/14853)：Seedream 节点可禁用思考链 COT
 * [**Gemini图像**](https://github.com/Comfy-Org/ComfyUI/pull/14917)：Gemini图像预览模型已移至发布版本
 
 **性能与稳定性**

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 23fea43f
+translationSourceHash: 7082b633
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.28.2": 27b88b8c
+  "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
   "v0.27.1": 429baf35
   "v0.27.0": cc42c9a3
@@ -106,6 +108,23 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
+
+<Update label="v0.28.2" description="2026年7月18日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/14984)：已将 Omni 模型切换至 Interactions API
+
+</Update>
+
+<Update label="v0.28.1" description="2026年7月17日">
+
+**合作伙伴节点更新**
+* [**GPT-5.6**](https://github.com/Comfy-Org/ComfyUI/pull/14957)：新增 GPT-5.6 Sol、Terra 和 Luna 模型
+* [**Gemini 3.5 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/14972)：为 Gemini LLM 节点新增 Gemini 3.5 Flash
+* [**HeyGen**](https://github.com/Comfy-Org/ComfyUI/pull/14958)：新增 Avatar 视频、说话照片、创建 Avatar、视频翻译和文本转语音节点
+
+</Update>
 
 <Update label="v0.28.0" description="2026年7月15日">
 


### PR DESCRIPTION
## Summary
- Add docs changelog entries for **v0.28.1** (GPT-5.6, Gemini 3.5 Flash, HeyGen partner nodes) and **v0.28.2** (Gemini Video Omni Interactions API)
- Translate changelog blocks to zh / ja / ko
- Update CMS staging and `published-versions.json` after publishing release notes to both **comfyui** and **cloud** (including republished cloud v0.28.0)

## Test plan
- [ ] Preview changelog pages (EN / zh / ja / ko) for v0.28.1 and v0.28.2
- [ ] Confirm CMS in-app release notes show for comfyui and cloud on 0.28.0–0.28.2