### PR TITLE
ci: add AGENTS.md integrity check (thin caller of shared workflow)

### DIFF
--- a/.github/workflows/agents-md-integrity.yml
+++ b/.github/workflows/agents-md-integrity.yml
@@ -1,0 +1,21 @@
+name: AGENTS.md Integrity
+
+# Thin caller for the shared reusable AGENTS.md integrity check. The checker
+# lives in Comfy-Org/github-workflows (single source of truth), loaded from
+# the pinned workflows_ref — never from this repo's checkout. Bump the SHA to
+# pick up upstream changes and keep `workflows_ref` matching so the check
+# script loads from the same commit; the upstream bump dispatcher
+# (AGENTS_MD_CALLERS) opens SHA-bump PRs automatically once registered.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  agents-md:
+    permissions:
+      contents: read
+    uses: Comfy-Org/github-workflows/.github/workflows/agents-md-integrity.yml@fe6b08e278c27ceacf2651cf441d0752ca2e78ee # github-workflows main (fe6b08e)
+    with:
+      workflows_ref: fe6b08e278c27ceacf2651cf441d0752ca2e78ee


### PR DESCRIPTION
## ELI-5

This repo has an `AGENTS.md` (the house rules for AI coding agents). This PR adds
a small CI check that makes sure that file stays healthy on every pull request —
it's short enough, has a `CLAUDE.md` shim pointing at it, no stray `.cursorrules`,
and so on. The actual checking logic doesn't live here; it lives once in
`Comfy-Org/github-workflows` and every repo calls it. This file is just the thin
"call that shared check" wire-up.

## What & why

- Adds `.github/workflows/agents-md-integrity.yml`, a thin caller of the reusable
  `AGENTS.md Integrity` workflow maintained centrally in `Comfy-Org/github-workflows`
  (single source of truth for the check logic).
- The checker is loaded from a **full-SHA-pinned** ref (`fe6b08e2…`) rather than
  this repo's checkout, so the check is reproducible and can't be rewritten by a PR.
  The pin follows the `github-workflows` README convention (full SHA, not the `v1`
  tag — `v1` predates this workflow).
- All inputs stay at defaults; no secrets required.
- This repo has been registered in the upstream `AGENTS_MD_CALLERS` variable, so the
  workflows repo will open SHA-bump PRs here automatically when the shared check
  changes (keep the `uses:` SHA and `workflows_ref` in lockstep on those bumps).

## Verification

Before adding the caller, the pinned checker was run locally against a fresh export
of `origin/main`: it **passes** with a single non-fatal warning (no `CODEOWNERS`
file, which is warn-only since `require_codeowners` defaults to false). Adding a
`CODEOWNERS` DRI is intentionally **out of scope** for this PR. The check should
run green on this PR itself.

## Follow-up (human/ops)

Make `AGENTS.md integrity` a required status check in this repo's branch protection.
