### PR TITLE
github actions no longer supports node20

### DIFF
--- a/ja/registry/publishing.mdx
+++ b/ja/registry/publishing.mdx
@@ -1,11 +1,12 @@
 ---
 title: "ノードの公開"
-translationSourceHash: 76f990e5
+translationSourceHash: 7e21993f
 translationFrom: registry/publishing.mdx
 translationBlockHashes:
   "Set up a Registry Account": be894a7a
-  "Publish to the Registry": a5b78520
+  "Publish to the Registry": b39c0b89
 ---
+
 
 
 ## レジストリアカウントの設定
@@ -154,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/ko/registry/publishing.mdx
+++ b/ko/registry/publishing.mdx
@@ -1,11 +1,12 @@
 ---
 title: "노드 게시하기"
-translationSourceHash: 76f990e5
+translationSourceHash: 7e21993f
 translationFrom: registry/publishing.mdx
 translationBlockHashes:
   "Set up a Registry Account": be894a7a
-  "Publish to the Registry": a5b78520
+  "Publish to the Registry": b39c0b89
 ---
+
 
 
 ## 레지스트리 계정 설정하기
@@ -153,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 코드 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: 사용자 정의 노드 게시
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/registry/publishing.mdx
+++ b/registry/publishing.mdx
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/zh/registry/publishing.mdx
+++ b/zh/registry/publishing.mdx
@@ -1,11 +1,12 @@
 ---
 title: "发布节点"
-translationSourceHash: 76f990e5
+translationSourceHash: 7e21993f
 translationFrom: registry/publishing.mdx
 translationBlockHashes:
   "Set up a Registry Account": be894a7a
-  "Publish to the Registry": a5b78520
+  "Publish to the Registry": b39c0b89
 ---
+
 
 
 ## 设置注册表账户
@@ -158,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Publish Custom Node
         uses: Comfy-Org/publish-node-action@main
         with:


### PR DESCRIPTION
Right now the github actions for custom nodes are not working.  It returns a node20 error when running the github action after someone changes a custom node repo.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Update actions to node24


Also needs to update the github action here.
https://github.com/Comfy-Org/publish-node-action/pull/10