### PR TITLE
fix(i18n): stabilize heading section sync

### DIFF
--- a/.github/scripts/i18n/chunked-translate.test.ts
+++ b/.github/scripts/i18n/chunked-translate.test.ts
@@ -3,6 +3,7 @@ import {
   blockHash,
   documentBlockHashes,
   getSectionSyncStatus,
+  mapTargetSectionsByStoredLabels,
   parseDocument,
   softSplitByBudget,
   splitByH3Subheadings,
@@ -91,6 +92,97 @@ describe("getSectionSyncStatus update_blocks", () => {
     );
     const status = getSectionSyncStatus(en, target, "update_blocks", false, "zh");
     expect(status.pendingBlocks).toEqual(["v0.26.0"]);
+  });
+});
+
+describe("getSectionSyncStatus heading_sections", () => {
+  function headingDoc(sections: Array<{ label: string; body: string }>): string {
+    return `---\ntitle: Test\n---\nIntro\n\n${sections
+      .map((section) => `## ${section.label}\n${section.body}`)
+      .join("\n\n")}\n`;
+  }
+
+  function translatedHeadingDoc(
+    enContent: string,
+    targetSections: Array<{ heading: string; body: string }>
+  ): string {
+    const enHashes = documentBlockHashes(parseDocument(enContent, "heading_sections").blocks);
+    const hashLines = Object.entries(enHashes)
+      .map(([label, hash]) => `  ${JSON.stringify(label)}: ${hash}`)
+      .join("\n");
+    return `---\ntitle: 测试\ntranslationBlockHashes:\n${hashLines}\n---\n简介\n\n${targetSections
+      .map((section) => `## ${section.heading}\n${section.body}`)
+      .join("\n\n")}\n`;
+  }
+
+  test("maps a changed section by label when another section is inserted", () => {
+    const oldEn = headingDoc([
+      { label: "Alpha", body: "A" },
+      { label: "Beta", body: "B" },
+    ]);
+    const en = headingDoc([
+      { label: "Alpha", body: "A updated" },
+      { label: "Inserted", body: "I" },
+      { label: "Beta", body: "B" },
+    ]);
+    const target = translatedHeadingDoc(oldEn, [
+      { heading: "阿尔法", body: "甲" },
+      { heading: "贝塔", body: "乙" },
+    ]);
+
+    const status = getSectionSyncStatus(en, target, "heading_sections", false, "zh");
+    expect(status.pendingBlocks).toEqual(["Alpha", "Inserted"]);
+
+    const targetByLabel = mapTargetSectionsByStoredLabels(
+      parseDocument(target, "heading_sections").blocks.map((b) => b.content).join("\n\n"),
+      ["_intro", "Alpha", "Beta"]
+    );
+    expect(targetByLabel.get("Alpha")).toContain("## 阿尔法");
+    expect(targetByLabel.get("Beta")).toContain("## 贝塔");
+    expect(targetByLabel.has("Inserted")).toBe(false);
+  });
+
+  test("marks every section pending when target body is missing sections", () => {
+    const en = headingDoc([
+      { label: "Alpha", body: "A" },
+      { label: "Beta", body: "B" },
+    ]);
+    const fullTarget = translatedHeadingDoc(en, [
+      { heading: "阿尔法", body: "甲" },
+      { heading: "贝塔", body: "乙" },
+    ]);
+    const truncatedTarget = fullTarget.replace(/\n\n## 贝塔[\s\S]*$/, "\n");
+
+    const status = getSectionSyncStatus(
+      en,
+      truncatedTarget,
+      "heading_sections",
+      false,
+      "zh"
+    );
+    expect(status.upToDate).toBe(false);
+    expect(status.pendingBlocks).toEqual(["_intro", "Alpha", "Beta"]);
+  });
+
+  test("re-serializes deletion and reorder without re-translating unchanged sections", () => {
+    const oldEn = headingDoc([
+      { label: "Alpha", body: "A" },
+      { label: "Removed", body: "R" },
+      { label: "Beta", body: "B" },
+    ]);
+    const en = headingDoc([
+      { label: "Beta", body: "B" },
+      { label: "Alpha", body: "A" },
+    ]);
+    const target = translatedHeadingDoc(oldEn, [
+      { heading: "阿尔法", body: "甲" },
+      { heading: "已删除", body: "删" },
+      { heading: "贝塔", body: "乙" },
+    ]);
+
+    const status = getSectionSyncStatus(en, target, "heading_sections", false, "zh");
+    expect(status.pendingBlocks).toEqual([]);
+    expect(status.needsReserialize).toBe(true);
   });
 });
 

--- a/.github/scripts/i18n/chunked-translate.test.ts
+++ b/.github/scripts/i18n/chunked-translate.test.ts
@@ -142,6 +142,58 @@ describe("getSectionSyncStatus heading_sections", () => {
     expect(targetByLabel.has("Inserted")).toBe(false);
   });
 
+  test("refuses positional mapping when intro boundary drifts but counts match", () => {
+    const body = `## 阿尔法
+甲
+
+## 贝塔
+乙
+
+## 伽马
+丙
+`;
+    const storedLabels = ["_intro", "Alpha", "Beta"];
+    const targetByLabel = mapTargetSectionsByStoredLabels(body, storedLabels);
+    expect(targetByLabel.size).toBe(0);
+  });
+
+  test("falls back to positional seeding when stored-label mapping is empty", () => {
+    const en = headingDoc([
+      { label: "Alpha", body: "A" },
+      { label: "Beta", body: "B" },
+    ]);
+    const target = translatedHeadingDoc(en, [
+      { heading: "阿尔法", body: "甲" },
+      { heading: "贝塔", body: "乙" },
+    ]);
+    const truncatedTarget = target.replace(/\n\n## 贝塔[\s\S]*$/, "\n");
+    const storedLabels = ["_intro", "Alpha", "Beta"];
+    const targetBody = parseDocument(truncatedTarget, "heading_sections").blocks
+      .map((b) => b.content)
+      .join("\n\n");
+    const targetHeadingSections = parseDocument(truncatedTarget, "heading_sections").blocks;
+    const mappedByStoredLabel = mapTargetSectionsByStoredLabels(targetBody, storedLabels);
+    expect(mappedByStoredLabel.size).toBe(0);
+
+    const existingContentForLabel = new Map<string, string>();
+    if (mappedByStoredLabel.size === 0 && targetHeadingSections.length !== storedLabels.length) {
+      storedLabels.forEach((label, index) => {
+        if (index < targetHeadingSections.length) {
+          existingContentForLabel.set(label, targetHeadingSections[index]!.content);
+        }
+      });
+    }
+
+    const slots = parseDocument(en, "heading_sections").blocks.map((b) => {
+      const content = existingContentForLabel.get(b.label) ?? null;
+      return { label: b.label, content: content?.trim() ? content : null };
+    });
+
+    expect(slots.find((s) => s.label === "_intro")?.content).toContain("简介");
+    expect(slots.find((s) => s.label === "Alpha")?.content).toContain("## 阿尔法");
+    expect(slots.find((s) => s.label === "Beta")?.content).toBeNull();
+  });
+
   test("marks every section pending when target body is missing sections", () => {
     const en = headingDoc([
       { label: "Alpha", body: "A" },

--- a/.github/scripts/i18n/chunked-translate.ts
+++ b/.github/scripts/i18n/chunked-translate.ts
@@ -6,8 +6,8 @@
  * - heading_sections: long pages — split on level-2 `##` headings
  *
  * Incremental sync stores per-block English hashes in frontmatter
- * (`translationBlockHashes`) keyed by stable English labels. Target files
- * are split by section index (headings are translated, so labels differ).
+ * (`translationBlockHashes`) keyed by stable English labels. Target headings
+ * are translated, so stored label order maps them back to their English keys.
  */
 
 import { createHash } from "crypto";
@@ -361,6 +361,29 @@ export function parseTargetSectionsByIndex(body: string, enBlockCount: number): 
   return sections.slice(0, enBlockCount);
 }
 
+/**
+ * Map localized target sections back to their stable English labels.
+ *
+ * Target H2 text is translated, so the labels stored in frontmatter are the
+ * only reliable identity. Refuse a partial positional mapping when the target
+ * section count differs from the stored label count. In that case, callers
+ * must treat the structure as incomplete and re-translate instead of borrowing
+ * content from a neighboring section.
+ */
+export function mapTargetSectionsByStoredLabels(
+  body: string,
+  storedLabels: string[]
+): Map<string, string> {
+  const targetSections = parseHeadingSections(body);
+  if (targetSections.length !== storedLabels.length) {
+    return new Map();
+  }
+
+  return new Map(
+    storedLabels.map((label, index) => [label, targetSections[index]!.content])
+  );
+}
+
 export function countH2Sections(body: string): number {
   let inFence = false;
   let count = 0;
@@ -654,19 +677,36 @@ export function getSectionSyncStatus(
   }
 
   const storedHashes = parseBlockHashesFromFrontmatter(existingFmBody);
+  const targetByStoredLabel = mapTargetSectionsByStoredLabels(
+    parseFrontmatterAndBody(existingContent).body,
+    storedLabels
+  );
+  const targetStructureComplete =
+    storedLabels.length > 0 && targetByStoredLabel.size === storedLabels.length;
 
   const pendingBlocks = enDoc.blocks
-    .filter((b) => storedHashes[b.label] !== enHashes[b.label])
+    .filter(
+      (b) =>
+        !targetStructureComplete ||
+        !targetByStoredLabel.get(b.label)?.trim() ||
+        storedHashes[b.label] !== enHashes[b.label]
+    )
     .map((b) => b.label);
 
   const hasStructureDrift = Object.keys(storedHashes).some((k) => !(k in enHashes));
 
   return {
-    upToDate: pendingBlocks.length === 0 && !hasStructureDrift && !hasOrderDrift,
+    upToDate:
+      targetStructureComplete &&
+      pendingBlocks.length === 0 &&
+      !hasStructureDrift &&
+      !hasOrderDrift,
     pendingBlocks,
     needsFrontmatter: Object.keys(storedHashes).length === 0,
     needsReserialize:
-      pendingBlocks.length === 0 && (hasStructureDrift || hasOrderDrift),
+      targetStructureComplete &&
+      pendingBlocks.length === 0 &&
+      (hasStructureDrift || hasOrderDrift),
   };
 }
 

--- a/.github/scripts/i18n/chunked-translate.ts
+++ b/.github/scripts/i18n/chunked-translate.ts
@@ -379,6 +379,11 @@ export function mapTargetSectionsByStoredLabels(
     return new Map();
   }
 
+  const introIndex = storedLabels.indexOf("_intro");
+  if (introIndex !== -1 && targetSections[introIndex]?.label !== "_intro") {
+    return new Map();
+  }
+
   return new Map(
     storedLabels.map((label, index) => [label, targetSections[index]!.content])
   );

--- a/.github/scripts/i18n/translate-i18n.ts
+++ b/.github/scripts/i18n/translate-i18n.ts
@@ -91,6 +91,7 @@ import {
   parseBlockHashesFromFrontmatter,
   parseDocument,
   parseFrontmatterAndBody,
+  parseHeadingSections,
   resolveChunkStrategy,
   serializeChunkedDocument,
   splitOversizedBlock,
@@ -693,15 +694,37 @@ async function translateChunkedFile(
   const storedLabels = existingFmBody
     ? parseBlockHashLabelOrderFromFrontmatter(existingFmBody)
     : [];
-  const targetByStoredLabel =
+  const targetBody = existingContent
+    ? parseFrontmatterAndBody(existingContent).body
+    : "";
+  const targetHeadingSections =
     strategy === "heading_sections" && existingContent
-      ? mapTargetSectionsByStoredLabels(
-          parseFrontmatterAndBody(existingContent).body,
-          storedLabels
-        )
-      : existingByLabel;
-  const existingContentForLabel =
-    strategy === "heading_sections" ? targetByStoredLabel : existingByLabel;
+      ? parseHeadingSections(targetBody)
+      : [];
+  const mappedByStoredLabel =
+    strategy === "heading_sections" && existingContent
+      ? mapTargetSectionsByStoredLabels(targetBody, storedLabels)
+      : new Map<string, string>();
+  const existingContentForLabel = new Map<string, string>();
+  if (strategy === "heading_sections") {
+    if (mappedByStoredLabel.size > 0) {
+      for (const [label, content] of mappedByStoredLabel) {
+        existingContentForLabel.set(label, content);
+      }
+    } else if (targetHeadingSections.length !== storedLabels.length) {
+      // Section count drift: positional seeding preserves already-translated blocks
+      // without borrowing content across a mismatched intro boundary.
+      storedLabels.forEach((label, index) => {
+        if (index < targetHeadingSections.length) {
+          existingContentForLabel.set(label, targetHeadingSections[index]!.content);
+        }
+      });
+    }
+  } else {
+    for (const [label, content] of existingByLabel) {
+      existingContentForLabel.set(label, content);
+    }
+  }
   const pendingLabels = new Set(
     force ? enDoc.blocks.map((b) => b.label) : status.pendingBlocks
   );

--- a/.github/scripts/i18n/translate-i18n.ts
+++ b/.github/scripts/i18n/translate-i18n.ts
@@ -86,12 +86,11 @@ import {
   changelogLabelHash,
   documentBlockHashes,
   getSectionSyncStatus,
+  mapTargetSectionsByStoredLabels,
   parseBlockHashLabelOrderFromFrontmatter,
   parseBlockHashesFromFrontmatter,
   parseDocument,
   parseFrontmatterAndBody,
-  parseHeadingSections,
-  parseTargetSectionsByIndex,
   resolveChunkStrategy,
   serializeChunkedDocument,
   splitOversizedBlock,
@@ -686,10 +685,6 @@ async function translateChunkedFile(
   const existingByLabel = new Map(
     (existingDoc?.blocks ?? []).map((b) => [b.label, b.content])
   );
-  const existingByIndex =
-    strategy === "heading_sections" && existingContent
-      ? parseTargetSectionsByIndex(parseFrontmatterAndBody(existingContent).body, enDoc.blocks.length)
-      : [];
 
   // Use stored label order (from frontmatter) to map EN labels to target section positions.
   // This handles the case where a new H2 section is inserted in the middle of the English
@@ -698,31 +693,25 @@ async function translateChunkedFile(
   const storedLabels = existingFmBody
     ? parseBlockHashLabelOrderFromFrontmatter(existingFmBody)
     : [];
-  const targetHeadingSections =
+  const targetByStoredLabel =
     strategy === "heading_sections" && existingContent
-      ? parseHeadingSections(parseFrontmatterAndBody(existingContent).body)
-      : [];
+      ? mapTargetSectionsByStoredLabels(
+          parseFrontmatterAndBody(existingContent).body,
+          storedLabels
+        )
+      : existingByLabel;
+  const existingContentForLabel =
+    strategy === "heading_sections" ? targetByStoredLabel : existingByLabel;
+  const pendingLabels = new Set(
+    force ? enDoc.blocks.map((b) => b.label) : status.pendingBlocks
+  );
 
-  const slots: BlockSlot[] = enDoc.blocks.map((b, i) => {
-    if (!force && !status.pendingBlocks.includes(b.label)) {
-      let content: string | null = null;
-
-      if (strategy === "heading_sections") {
-        // Match by stored label position (stable across insertions), not by EN index
-        const storedPos = storedLabels.indexOf(b.label);
-        if (storedPos >= 0 && storedPos < targetHeadingSections.length) {
-          content = targetHeadingSections[storedPos].content;
-        }
-        // No fallback to positional — a new block not in storedLabels is genuinely new
-        // (e.g. an H2 section inserted between existing ones). Positional fallback
-        // would pull content from the wrong section, creating duplicates and misalignment.
-      } else {
-        content = existingByLabel.get(b.label) ?? null;
-      }
-
-      return { label: b.label, content: content?.trim() ? content : null };
-    }
-    return { label: b.label, content: null };
+  // Keep old target content in pending slots until a replacement succeeds. This
+  // makes checkpoints non-destructive and prevents an interrupted run from
+  // dropping all blocks that had not been processed yet.
+  const slots: BlockSlot[] = enDoc.blocks.map((b) => {
+    const content = existingContentForLabel.get(b.label) ?? null;
+    return { label: b.label, content: content?.trim() ? content : null };
   });
 
   if (status.needsReserialize && status.pendingBlocks.length === 0) {
@@ -756,8 +745,24 @@ async function translateChunkedFile(
   const allMismatches: string[] = [];
   let blocksTranslated = 0;
   let frontmatterDirty = false;
-  const hashesForMeta: Record<string, string> = { ...enBlockHashes };
+  const hashesForMeta: Record<string, string> = {};
+  for (const slot of slots) {
+    if (!slot.content?.trim()) continue;
+    if (!pendingLabels.has(slot.label)) {
+      hashesForMeta[slot.label] = enBlockHashes[slot.label]!;
+    } else if (oldBlockHashes[slot.label]) {
+      hashesForMeta[slot.label] = oldBlockHashes[slot.label]!;
+    }
+  }
   const failedLabels: string[] = [];
+  const checkpointFileHash = (): string => {
+    const allCurrent = enDoc.blocks.every(
+      (b) =>
+        slots.find((s) => s.label === b.label)?.content?.trim() &&
+        hashesForMeta[b.label] === enBlockHashes[b.label]
+    );
+    return allCurrent ? fileHash : aggregateDocumentHash(hashesForMeta);
+  };
 
   let translatedFrontmatter = existingDoc?.frontmatter ?? "";
   if (force || status.needsFrontmatter) {
@@ -780,7 +785,7 @@ async function translateChunkedFile(
       targetPath,
       translatedFrontmatter,
       slots,
-      fileHash,
+      checkpointFileHash(),
       enRel,
       hashesForMeta,
       strategy,
@@ -791,13 +796,10 @@ async function translateChunkedFile(
 
   for (let i = 0; i < slots.length; i++) {
     const slot = slots[i]!;
-    if (slot.content !== null) continue;
+    if (!pendingLabels.has(slot.label)) continue;
 
     const enBlock = enDoc.blocks[i]!;
-    const existingBlock =
-      strategy === "heading_sections"
-        ? existingByIndex[i] ?? ""
-        : existingByLabel.get(slot.label) ?? "";
+    const existingBlock = existingContentForLabel.get(slot.label) ?? "";
 
     const blockTag =
       strategy === "heading_sections"
@@ -837,6 +839,7 @@ async function translateChunkedFile(
       failedLabels.push(slot.label);
     } else {
       slot.content = translatedBlock;
+      hashesForMeta[slot.label] = enBlockHashes[slot.label]!;
       blocksTranslated++;
     }
 
@@ -845,8 +848,7 @@ async function translateChunkedFile(
       targetPath,
       translatedFrontmatter,
       slots,
-      // Keep source hash as full EN aggregate only when nothing failed.
-      failedLabels.length === 0 ? fileHash : aggregateDocumentHash(hashesForMeta),
+      checkpointFileHash(),
       enRel,
       hashesForMeta,
       strategy,


### PR DESCRIPTION
## Summary
- Map localized heading sections back to stable English labels from stored metadata.
- Treat incomplete target heading structure as pending instead of trusting stale hashes.
- Keep existing translated block content during checkpoints so interrupted runs do not drop untouched sections.

## Why
The heading-section translation flow could use positional fallback when English sections were inserted, deleted, or reordered. That made it possible to borrow a neighboring translated section as context or fallback content, and stale frontmatter hashes could make an incomplete target look up to date.

## Validation
- `bun test ./.github/scripts/i18n`
- `bun build .github/scripts/i18n/translate-i18n.ts --target=bun --outfile=/tmp/comfy-docs-translate-i18n-check.js`
- `git diff --check`