### PR TITLE
docs: group nodes into Core, Partner, and Custom Nodes

### DIFF
--- a/.github/scripts/i18n/sync-docs-json.mjs
+++ b/.github/scripts/i18n/sync-docs-json.mjs
@@ -120,6 +120,11 @@ export function normalizeNavTree(nodes, options = {}) {
       const pages = normalizeNavTree(node.pages, options);
       if (pages.length === 0 && pruneMissing) continue;
       out.push({ ...node, pages });
+      continue;
+    }
+    // Groups that render an OpenAPI spec have no `pages` of their own.
+    if (node && typeof node === "object" && node.openapi != null) {
+      out.push(node);
     }
   }
   return out;
@@ -161,6 +166,9 @@ export function localizeNavTree(nodes, langDir, langDirs) {
         ...node,
         pages: localizeNavTree(node.pages, langDir, langDirs),
       };
+    }
+    if (node && typeof node === "object" && node.openapi != null) {
+      return { ...node, openapi: localizeOpenApi(node.openapi, langDir) };
     }
     return node;
   });
@@ -242,6 +250,27 @@ function findGroupMatch(existingPages, newChild, langDirs) {
   return best;
 }
 
+/** @param {unknown} openapi */
+function openApiSpecKey(openapi) {
+  if (typeof openapi === "string") return openapi;
+  if (openapi && typeof openapi === "object" && typeof openapi.source === "string") {
+    return openapi.source;
+  }
+  return null;
+}
+
+/** @param {unknown[]} existingPages @param {object} newChild */
+function findOpenApiMatch(existingPages, newChild) {
+  if (!Array.isArray(existingPages)) return null;
+  const key = openApiSpecKey(newChild.openapi);
+  if (!key) return null;
+  for (const node of existingPages) {
+    if (typeof node === "string" || !node) continue;
+    if (openApiSpecKey(node.openapi) === key) return node;
+  }
+  return null;
+}
+
 /**
  * @param {unknown[]} newPages
  * @param {unknown[]} existingPages
@@ -251,7 +280,15 @@ export function mergeNavPages(newPages, existingPages, langDirs) {
   if (!Array.isArray(newPages)) return [];
   return newPages.map((newChild) => {
     if (typeof newChild === "string") return newChild;
-    if (!newChild?.pages) return newChild;
+    if (!newChild?.pages) {
+      // OpenAPI groups have no pages to match on; key them by spec instead so a
+      // localized title survives the sync.
+      if (newChild?.openapi != null) {
+        const match = findOpenApiMatch(existingPages, newChild);
+        if (match?.group) return { ...newChild, group: match.group };
+      }
+      return newChild;
+    }
 
     const match = findGroupMatch(existingPages, newChild, langDirs);
     const merged = { ...newChild };

--- a/custom-nodes/index.mdx
+++ b/custom-nodes/index.mdx
@@ -1,0 +1,44 @@
+---
+title: "Custom Nodes"
+description: "What custom nodes are, where they come from, and how to install, manage, and build them."
+sidebarTitle: "Overview"
+---
+
+Custom nodes are packages built by the community that add functionality ComfyUI does not ship with. They are ordinary ComfyUI nodes in every respect: they declare inputs and outputs, run on your machine, and connect to core nodes freely. The difference is that you install them yourself and a third-party author maintains them.
+
+For how custom nodes compare to core and partner nodes, see the [nodes overview](/nodes).
+
+## Where they come from
+
+Most custom nodes are published to the [Comfy Registry](https://registry.comfy.org), a public catalog of versioned node packages. The registry is what powers search and installation inside ComfyUI Manager, and it is where you publish your own package when it is ready to share.
+
+A package can contribute any combination of Python nodes that run on the server, frontend extensions that change the UI, workflow templates, and subgraph blueprints.
+
+## Installing and managing
+
+**ComfyUI Manager** is the recommended way to work with custom nodes. It searches the registry, installs packages along with their Python dependencies, updates or pins versions, disables packages without deleting them, and detects nodes missing from an imported workflow. Desktop builds include it; portable and manual installs may need it enabled first.
+
+<Card title="Install Custom Nodes" icon="download" href="/installation/install_custom_node">
+  Installing via ComfyUI Manager, Git, or a ZIP download, plus dependency installation.
+</Card>
+
+<Card title="ComfyUI Manager" icon="puzzle-piece" href="/manager/overview">
+  Searching, updating, disabling, and troubleshooting node packages.
+</Card>
+
+Two things to keep in mind, since custom nodes execute arbitrary Python inside your ComfyUI process:
+
+- **Trust matters.** Install packages you have reason to trust, and prefer ones that are actively maintained. The registry scans published nodes for malicious behavior such as arbitrary system calls, and marks the ones that pass with a verification flag.
+- **Dependencies can conflict.** Two packages may want incompatible versions of the same Python library. If ComfyUI stops starting after an install, disable the newest package first. See [custom node issues](/troubleshooting/custom-node-issues).
+
+## Building your own
+
+If nothing in the registry does what you need, write it. A minimal node is a Python class with an input specification and a function, and you can extend from there into custom datatypes, lazy evaluation, node expansion, and frontend extensions.
+
+<Card title="Develop Custom Nodes" icon="code" href="/custom-nodes/overview">
+  Walkthrough, backend and UI APIs, datatypes, and packaging.
+</Card>
+
+<Card title="Publish to the Registry" icon="upload" href="/registry/overview">
+  Versioning, `pyproject.toml` standards, CI/CD, and claiming an existing node.
+</Card>

--- a/docs.json
+++ b/docs.json
@@ -60,29 +60,6 @@
                     ]
                   },
                   "get_started/cloud",
-                  {
-                    "group": "Install Custom Nodes",
-                    "icon": "puzzle-piece",
-                    "pages": [
-                      "installation/install_custom_node",
-                      {
-                        "group": "ComfyUI-Manager",
-                        "pages": [
-                          "manager/overview",
-                          "manager/install",
-                          {
-                            "group": "Node Management",
-                            "pages": [
-                              "manager/pack-management",
-                              "manager/legacy-ui"
-                            ]
-                          },
-                          "manager/configuration",
-                          "manager/troubleshooting"
-                        ]
-                      }
-                    ]
-                  },
                   "get_started/first_generation"
                 ]
               },
@@ -413,194 +390,17 @@
                   }
                 ]
               },
-              {
-                "group": "Partner Nodes",
-                "icon": "handshake",
-                "pages": [
-                  "tutorials/partner-nodes/overview",
-                  "tutorials/partner-nodes/faq",
-                  "tutorials/partner-nodes/pricing",
-                  "tutorials/partner-nodes/concurrency-limits",
-                  {
-                    "group": "Black Forest Labs",
-                    "pages": [
-                      "tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
-                      "tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
-                    ]
-                  },
-                  {
-                    "group": "Beeble",
-                    "pages": [
-                      "tutorials/partner-nodes/beeble/beeble-switchx"
-                    ]
-                  },
-                  {
-                    "group": "ByteDance",
-                    "pages": [
-                      "tutorials/partner-nodes/bytedance/seedance-2-0",
-                      "tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
-                      "tutorials/partner-nodes/bytedance/seedream-5-pro",
-                      "tutorials/partner-nodes/bytedance/seedream-5-lite",
-                      "tutorials/partner-nodes/bytedance/seed-audio-1-0"
-                    ]
-                  },
-                  {
-                    "group": "Google",
-                    "pages": [
-                      "tutorials/partner-nodes/google/gemini",
-                      "tutorials/partner-nodes/google/gemini-omni-flash",
-                      "tutorials/partner-nodes/google/nano-banana-pro",
-                      "tutorials/partner-nodes/google/nano-banana-2",
-                      "tutorials/partner-nodes/google/nano-banana-2-lite"
-                    ]
-                  },
-                  {
-                    "group": "Anthropic",
-                    "pages": [
-                      "tutorials/partner-nodes/anthropic/claude"
-                    ]
-                  },
-                  {
-                    "group": "Ideogram",
-                    "pages": [
-                      "tutorials/partner-nodes/ideogram/ideogram-v4"
-                    ]
-                  },
-                  {
-                    "group": "Luma",
-                    "pages": [
-                      "tutorials/partner-nodes/luma/luma-uni-1",
-                      "tutorials/partner-nodes/luma/luma-text-to-image",
-                      "tutorials/partner-nodes/luma/luma-image-to-image",
-                      "tutorials/partner-nodes/luma/luma-text-to-video",
-                      "tutorials/partner-nodes/luma/luma-image-to-video"
-                    ]
-                  },
-                  {
-                    "group": "Moonvalley",
-                    "pages": [
-                      "tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
-                    ]
-                  },
-                  {
-                    "group": "OpenAI",
-                    "pages": [
-                      "tutorials/partner-nodes/openai/gpt-image-2",
-                      "tutorials/partner-nodes/openai/gpt-image-1",
-                      "tutorials/partner-nodes/openai/dall-e-2",
-                      "tutorials/partner-nodes/openai/dall-e-3",
-                      "tutorials/partner-nodes/openai/chat"
-                    ]
-                  },
-                  {
-                    "group": "OpenRouter",
-                    "pages": [
-                      "tutorials/partner-nodes/openrouter/llm"
-                    ]
-                  },
-                  {
-                    "group": "Recraft",
-                    "pages": [
-                      "tutorials/partner-nodes/recraft/recraft-v4",
-                      "tutorials/partner-nodes/recraft/recraft-text-to-image"
-                    ]
-                  },
-                  {
-                    "group": "Krea 2",
-                    "pages": [
-                      "tutorials/partner-nodes/krea2/krea2-t2i"
-                    ]
-                  },
-                  {
-                    "group": "Kling",
-                    "pages": [
-                      "tutorials/partner-nodes/kling/kling-3-0",
-                      "tutorials/partner-nodes/kling/kling-motion-control"
-                    ]
-                  },
-                  {
-                    "group": "Runway",
-                    "pages": [
-                      "tutorials/partner-nodes/runway/image-generation",
-                      "tutorials/partner-nodes/runway/video-generation"
-                    ]
-                  },
-                  {
-                    "group": "Rodin",
-                    "pages": [
-                      "tutorials/partner-nodes/rodin/model-generation"
-                    ]
-                  },
-                  {
-                    "group": "Tripo",
-                    "pages": [
-                      "tutorials/partner-nodes/tripo/model-generation",
-                      "tutorials/partner-nodes/tripo/tripo-3-1",
-                      "tutorials/partner-nodes/tripo/tripo-p1"
-                    ]
-                  },
-                  {
-                    "group": "Hunyuan 3D",
-                    "pages": [
-                      "tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
-                    ]
-                  },
-                  {
-                    "group": "Meshy",
-                    "pages": [
-                      "tutorials/partner-nodes/meshy/meshy-6"
-                    ]
-                  },
-                  {
-                    "group": "Bria",
-                    "pages": [
-                      "tutorials/partner-nodes/bria/fibo",
-                      "tutorials/partner-nodes/bria/background-removal"
-                    ]
-                  },
-                  {
-                    "group": "Reve",
-                    "pages": [
-                      "tutorials/partner-nodes/reve/reve-image"
-                    ]
-                  },
-                  {
-                    "group": "Wan",
-                    "pages": [
-                      "tutorials/partner-nodes/wan/wan2-7"
-                    ]
-                  },
-                  {
-                    "group": "HappyHorse",
-                    "pages": [
-                      "tutorials/partner-nodes/happyhorse/happyhorse1-1",
-                      "tutorials/partner-nodes/happyhorse/happyhorse1-0"
-                    ]
-                  },
-                  {
-                    "group": "Sonilo",
-                    "pages": [
-                      "tutorials/partner-nodes/sonilo/video-to-music"
-                    ]
-                  },
-                  {
-                    "group": "Topaz",
-                    "pages": [
-                      "tutorials/partner-nodes/topaz/astra-2"
-                    ]
-                  }
-                ]
-              },
               "changelog/index"
             ]
           },
           {
-            "tab": "Built-in Nodes",
+            "tab": "Nodes",
             "pages": [
-              "built-in-nodes/overview",
+              "nodes/index",
               {
-                "group": "Nodes",
+                "group": "Core Nodes",
                 "pages": [
+                  "built-in-nodes/overview",
                   {
                     "group": "3D",
                     "pages": [
@@ -2626,6 +2426,279 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "Partner Nodes",
+                "icon": "handshake",
+                "pages": [
+                  "tutorials/partner-nodes/overview",
+                  "tutorials/partner-nodes/faq",
+                  "tutorials/partner-nodes/pricing",
+                  "tutorials/partner-nodes/concurrency-limits",
+                  {
+                    "group": "Black Forest Labs",
+                    "pages": [
+                      "tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
+                      "tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
+                    ]
+                  },
+                  {
+                    "group": "Beeble",
+                    "pages": [
+                      "tutorials/partner-nodes/beeble/beeble-switchx"
+                    ]
+                  },
+                  {
+                    "group": "ByteDance",
+                    "pages": [
+                      "tutorials/partner-nodes/bytedance/seedance-2-0",
+                      "tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
+                      "tutorials/partner-nodes/bytedance/seedream-5-pro",
+                      "tutorials/partner-nodes/bytedance/seedream-5-lite",
+                      "tutorials/partner-nodes/bytedance/seed-audio-1-0"
+                    ]
+                  },
+                  {
+                    "group": "Google",
+                    "pages": [
+                      "tutorials/partner-nodes/google/gemini",
+                      "tutorials/partner-nodes/google/gemini-omni-flash",
+                      "tutorials/partner-nodes/google/nano-banana-pro",
+                      "tutorials/partner-nodes/google/nano-banana-2",
+                      "tutorials/partner-nodes/google/nano-banana-2-lite"
+                    ]
+                  },
+                  {
+                    "group": "Anthropic",
+                    "pages": [
+                      "tutorials/partner-nodes/anthropic/claude"
+                    ]
+                  },
+                  {
+                    "group": "Ideogram",
+                    "pages": [
+                      "tutorials/partner-nodes/ideogram/ideogram-v4"
+                    ]
+                  },
+                  {
+                    "group": "Luma",
+                    "pages": [
+                      "tutorials/partner-nodes/luma/luma-uni-1",
+                      "tutorials/partner-nodes/luma/luma-text-to-image",
+                      "tutorials/partner-nodes/luma/luma-image-to-image",
+                      "tutorials/partner-nodes/luma/luma-text-to-video",
+                      "tutorials/partner-nodes/luma/luma-image-to-video"
+                    ]
+                  },
+                  {
+                    "group": "Moonvalley",
+                    "pages": [
+                      "tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
+                    ]
+                  },
+                  {
+                    "group": "OpenAI",
+                    "pages": [
+                      "tutorials/partner-nodes/openai/gpt-image-2",
+                      "tutorials/partner-nodes/openai/gpt-image-1",
+                      "tutorials/partner-nodes/openai/dall-e-2",
+                      "tutorials/partner-nodes/openai/dall-e-3",
+                      "tutorials/partner-nodes/openai/chat"
+                    ]
+                  },
+                  {
+                    "group": "OpenRouter",
+                    "pages": [
+                      "tutorials/partner-nodes/openrouter/llm"
+                    ]
+                  },
+                  {
+                    "group": "Recraft",
+                    "pages": [
+                      "tutorials/partner-nodes/recraft/recraft-v4",
+                      "tutorials/partner-nodes/recraft/recraft-text-to-image"
+                    ]
+                  },
+                  {
+                    "group": "Krea 2",
+                    "pages": [
+                      "tutorials/partner-nodes/krea2/krea2-t2i"
+                    ]
+                  },
+                  {
+                    "group": "Kling",
+                    "pages": [
+                      "tutorials/partner-nodes/kling/kling-3-0",
+                      "tutorials/partner-nodes/kling/kling-motion-control"
+                    ]
+                  },
+                  {
+                    "group": "Runway",
+                    "pages": [
+                      "tutorials/partner-nodes/runway/image-generation",
+                      "tutorials/partner-nodes/runway/video-generation"
+                    ]
+                  },
+                  {
+                    "group": "Rodin",
+                    "pages": [
+                      "tutorials/partner-nodes/rodin/model-generation"
+                    ]
+                  },
+                  {
+                    "group": "Tripo",
+                    "pages": [
+                      "tutorials/partner-nodes/tripo/model-generation",
+                      "tutorials/partner-nodes/tripo/tripo-3-1",
+                      "tutorials/partner-nodes/tripo/tripo-p1"
+                    ]
+                  },
+                  {
+                    "group": "Hunyuan 3D",
+                    "pages": [
+                      "tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
+                    ]
+                  },
+                  {
+                    "group": "Meshy",
+                    "pages": [
+                      "tutorials/partner-nodes/meshy/meshy-6"
+                    ]
+                  },
+                  {
+                    "group": "Bria",
+                    "pages": [
+                      "tutorials/partner-nodes/bria/fibo",
+                      "tutorials/partner-nodes/bria/background-removal"
+                    ]
+                  },
+                  {
+                    "group": "Reve",
+                    "pages": [
+                      "tutorials/partner-nodes/reve/reve-image"
+                    ]
+                  },
+                  {
+                    "group": "Wan",
+                    "pages": [
+                      "tutorials/partner-nodes/wan/wan2-7"
+                    ]
+                  },
+                  {
+                    "group": "HappyHorse",
+                    "pages": [
+                      "tutorials/partner-nodes/happyhorse/happyhorse1-1",
+                      "tutorials/partner-nodes/happyhorse/happyhorse1-0"
+                    ]
+                  },
+                  {
+                    "group": "Sonilo",
+                    "pages": [
+                      "tutorials/partner-nodes/sonilo/video-to-music"
+                    ]
+                  },
+                  {
+                    "group": "Topaz",
+                    "pages": [
+                      "tutorials/partner-nodes/topaz/astra-2"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Custom Nodes",
+                "pages": [
+                  "custom-nodes/index",
+                  {
+                    "group": "Install Custom Nodes",
+                    "icon": "puzzle-piece",
+                    "pages": [
+                      "installation/install_custom_node",
+                      {
+                        "group": "ComfyUI-Manager",
+                        "pages": [
+                          "manager/overview",
+                          "manager/install",
+                          {
+                            "group": "Node Management",
+                            "pages": [
+                              "manager/pack-management",
+                              "manager/legacy-ui"
+                            ]
+                          },
+                          "manager/configuration",
+                          "manager/troubleshooting"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Develop Custom Nodes",
+                    "pages": [
+                      "custom-nodes/overview",
+                      "custom-nodes/walkthrough",
+                      {
+                        "group": "Backend",
+                        "icon": "python",
+                        "pages": [
+                          "custom-nodes/backend/server_overview",
+                          "custom-nodes/backend/lifecycle",
+                          "custom-nodes/backend/datatypes",
+                          "custom-nodes/backend/images_and_masks",
+                          "custom-nodes/backend/more_on_inputs",
+                          "custom-nodes/backend/lazy_evaluation",
+                          "custom-nodes/backend/expansion",
+                          "custom-nodes/backend/lists",
+                          "custom-nodes/backend/snippets",
+                          "custom-nodes/backend/tensors",
+                          "custom-nodes/backend/node-replacement"
+                        ]
+                      },
+                      {
+                        "group": "UI",
+                        "icon": "js",
+                        "pages": [
+                          "custom-nodes/js/javascript_overview",
+                          "custom-nodes/js/javascript_hooks",
+                          "custom-nodes/js/javascript_objects_and_hijacking",
+                          "custom-nodes/js/javascript_settings",
+                          "custom-nodes/js/javascript_dialog",
+                          "custom-nodes/js/javascript_toast",
+                          "custom-nodes/js/javascript_about_panel_badges",
+                          "custom-nodes/js/javascript_bottom_panel_tabs",
+                          "custom-nodes/js/javascript_sidebar_tabs",
+                          "custom-nodes/js/javascript_selection_toolbox",
+                          "custom-nodes/js/javascript_commands_keybindings",
+                          "custom-nodes/js/javascript_topbar_menu",
+                          "custom-nodes/js/context-menu-migration",
+                          "custom-nodes/js/subgraphs",
+                          "custom-nodes/js/javascript_examples",
+                          "custom-nodes/i18n"
+                        ]
+                      },
+                      "custom-nodes/v3_migration",
+                      "custom-nodes/help_page",
+                      "custom-nodes/workflow_templates",
+                      "custom-nodes/subgraph_blueprints"
+                    ]
+                  },
+                  {
+                    "group": "Registry",
+                    "pages": [
+                      "registry/overview",
+                      "registry/publishing",
+                      "registry/claim-my-node",
+                      "registry/standards",
+                      "registry/cicd",
+                      "registry/specifications",
+                      "registry/api-reference/overview",
+                      {
+                        "group": "Registry API Reference",
+                        "openapi": "https://api.comfy.org/openapi"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -2670,68 +2743,6 @@
                   "comfy-cli/getting-started",
                   "comfy-cli/reference",
                   "comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "Develop Custom Nodes",
-                "pages": [
-                  "custom-nodes/overview",
-                  "custom-nodes/walkthrough",
-                  {
-                    "group": "Backend",
-                    "icon": "python",
-                    "pages": [
-                      "custom-nodes/backend/server_overview",
-                      "custom-nodes/backend/lifecycle",
-                      "custom-nodes/backend/datatypes",
-                      "custom-nodes/backend/images_and_masks",
-                      "custom-nodes/backend/more_on_inputs",
-                      "custom-nodes/backend/lazy_evaluation",
-                      "custom-nodes/backend/expansion",
-                      "custom-nodes/backend/lists",
-                      "custom-nodes/backend/snippets",
-                      "custom-nodes/backend/tensors",
-                      "custom-nodes/backend/node-replacement"
-                    ]
-                  },
-                  {
-                    "group": "UI",
-                    "icon": "js",
-                    "pages": [
-                      "custom-nodes/js/javascript_overview",
-                      "custom-nodes/js/javascript_hooks",
-                      "custom-nodes/js/javascript_objects_and_hijacking",
-                      "custom-nodes/js/javascript_settings",
-                      "custom-nodes/js/javascript_dialog",
-                      "custom-nodes/js/javascript_toast",
-                      "custom-nodes/js/javascript_about_panel_badges",
-                      "custom-nodes/js/javascript_bottom_panel_tabs",
-                      "custom-nodes/js/javascript_sidebar_tabs",
-                      "custom-nodes/js/javascript_selection_toolbox",
-                      "custom-nodes/js/javascript_commands_keybindings",
-                      "custom-nodes/js/javascript_topbar_menu",
-                      "custom-nodes/js/context-menu-migration",
-                      "custom-nodes/js/subgraphs",
-                      "custom-nodes/js/javascript_examples",
-                      "custom-nodes/i18n"
-                    ]
-                  },
-                  "custom-nodes/v3_migration",
-                  "custom-nodes/help_page",
-                  "custom-nodes/workflow_templates",
-                  "custom-nodes/subgraph_blueprints"
-                ]
-              },
-              {
-                "group": "Registry",
-                "pages": [
-                  "registry/overview",
-                  "registry/publishing",
-                  "registry/claim-my-node",
-                  "registry/standards",
-                  "registry/cicd",
-                  "registry/specifications",
-                  "registry/api-reference/overview"
                 ]
               },
               {
@@ -2813,10 +2824,6 @@
             ]
           },
           {
-            "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
-          },
-          {
             "tab": "Cloud API Reference",
             "openapi": {
               "source": "openapi-cloud.yaml",
@@ -2872,29 +2879,6 @@
                     ]
                   },
                   "zh/get_started/cloud",
-                  {
-                    "group": "安装自定义节点",
-                    "icon": "puzzle-piece",
-                    "pages": [
-                      "zh/installation/install_custom_node",
-                      {
-                        "group": "ComfyUI-Manager",
-                        "pages": [
-                          "zh/manager/overview",
-                          "zh/manager/install",
-                          {
-                            "group": "自定义节点管理",
-                            "pages": [
-                              "zh/manager/pack-management",
-                              "zh/manager/legacy-ui"
-                            ]
-                          },
-                          "zh/manager/configuration",
-                          "zh/manager/troubleshooting"
-                        ]
-                      }
-                    ]
-                  },
                   "zh/get_started/first_generation"
                 ]
               },
@@ -3225,194 +3209,16 @@
                   }
                 ]
               },
-              {
-                "group": "合作伙伴节点",
-                "icon": "handshake",
-                "pages": [
-                  "zh/tutorials/partner-nodes/overview",
-                  "zh/tutorials/partner-nodes/faq",
-                  "zh/tutorials/partner-nodes/pricing",
-                  "zh/tutorials/partner-nodes/concurrency-limits",
-                  {
-                    "group": "Black Forest Labs",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
-                      "zh/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
-                    ]
-                  },
-                  {
-                    "group": "Beeble",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/beeble/beeble-switchx"
-                    ]
-                  },
-                  {
-                    "group": "ByteDance",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/bytedance/seedance-2-0",
-                      "zh/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
-                      "zh/tutorials/partner-nodes/bytedance/seedream-5-pro",
-                      "zh/tutorials/partner-nodes/bytedance/seedream-5-lite",
-                      "zh/tutorials/partner-nodes/bytedance/seed-audio-1-0"
-                    ]
-                  },
-                  {
-                    "group": "Google",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/google/gemini",
-                      "zh/tutorials/partner-nodes/google/gemini-omni-flash",
-                      "zh/tutorials/partner-nodes/google/nano-banana-pro",
-                      "zh/tutorials/partner-nodes/google/nano-banana-2",
-                      "zh/tutorials/partner-nodes/google/nano-banana-2-lite"
-                    ]
-                  },
-                  {
-                    "group": "Anthropic",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/anthropic/claude"
-                    ]
-                  },
-                  {
-                    "group": "Ideogram",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/ideogram/ideogram-v4"
-                    ]
-                  },
-                  {
-                    "group": "Luma",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/luma/luma-uni-1",
-                      "zh/tutorials/partner-nodes/luma/luma-text-to-image",
-                      "zh/tutorials/partner-nodes/luma/luma-image-to-image",
-                      "zh/tutorials/partner-nodes/luma/luma-text-to-video",
-                      "zh/tutorials/partner-nodes/luma/luma-image-to-video"
-                    ]
-                  },
-                  {
-                    "group": "Moonvalley",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
-                    ]
-                  },
-                  {
-                    "group": "OpenAI",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/openai/gpt-image-2",
-                      "zh/tutorials/partner-nodes/openai/gpt-image-1",
-                      "zh/tutorials/partner-nodes/openai/dall-e-2",
-                      "zh/tutorials/partner-nodes/openai/dall-e-3",
-                      "zh/tutorials/partner-nodes/openai/chat"
-                    ]
-                  },
-                  {
-                    "group": "OpenRouter",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/openrouter/llm"
-                    ]
-                  },
-                  {
-                    "group": "Recraft",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/recraft/recraft-v4",
-                      "zh/tutorials/partner-nodes/recraft/recraft-text-to-image"
-                    ]
-                  },
-                  {
-                    "group": "Krea 2",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/krea2/krea2-t2i"
-                    ]
-                  },
-                  {
-                    "group": "Kling",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/kling/kling-3-0",
-                      "zh/tutorials/partner-nodes/kling/kling-motion-control"
-                    ]
-                  },
-                  {
-                    "group": "Runway",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/runway/image-generation",
-                      "zh/tutorials/partner-nodes/runway/video-generation"
-                    ]
-                  },
-                  {
-                    "group": "Rodin",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/rodin/model-generation"
-                    ]
-                  },
-                  {
-                    "group": "Tripo",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/tripo/model-generation",
-                      "zh/tutorials/partner-nodes/tripo/tripo-3-1",
-                      "zh/tutorials/partner-nodes/tripo/tripo-p1"
-                    ]
-                  },
-                  {
-                    "group": "Hunyuan 3D",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
-                    ]
-                  },
-                  {
-                    "group": "Meshy",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/meshy/meshy-6"
-                    ]
-                  },
-                  {
-                    "group": "Bria",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/bria/fibo",
-                      "zh/tutorials/partner-nodes/bria/background-removal"
-                    ]
-                  },
-                  {
-                    "group": "Reve",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/reve/reve-image"
-                    ]
-                  },
-                  {
-                    "group": "Wan",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/wan/wan2-7"
-                    ]
-                  },
-                  {
-                    "group": "HappyHorse",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/happyhorse/happyhorse1-1",
-                      "zh/tutorials/partner-nodes/happyhorse/happyhorse1-0"
-                    ]
-                  },
-                  {
-                    "group": "Sonilo",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/sonilo/video-to-music"
-                    ]
-                  },
-                  {
-                    "group": "Topaz",
-                    "pages": [
-                      "zh/tutorials/partner-nodes/topaz/astra-2"
-                    ]
-                  }
-                ]
-              },
               "zh/changelog/index"
             ]
           },
           {
-            "tab": "内置节点",
+            "tab": "节点",
             "pages": [
-              "zh/built-in-nodes/overview",
               {
-                "group": "节点",
+                "group": "核心节点",
                 "pages": [
+                  "zh/built-in-nodes/overview",
                   {
                     "group": "3D",
                     "pages": [
@@ -5453,6 +5259,278 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "合作伙伴节点",
+                "icon": "handshake",
+                "pages": [
+                  "zh/tutorials/partner-nodes/overview",
+                  "zh/tutorials/partner-nodes/faq",
+                  "zh/tutorials/partner-nodes/pricing",
+                  "zh/tutorials/partner-nodes/concurrency-limits",
+                  {
+                    "group": "Black Forest Labs",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
+                      "zh/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
+                    ]
+                  },
+                  {
+                    "group": "Beeble",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/beeble/beeble-switchx"
+                    ]
+                  },
+                  {
+                    "group": "ByteDance",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/bytedance/seedance-2-0",
+                      "zh/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
+                      "zh/tutorials/partner-nodes/bytedance/seedream-5-pro",
+                      "zh/tutorials/partner-nodes/bytedance/seedream-5-lite",
+                      "zh/tutorials/partner-nodes/bytedance/seed-audio-1-0"
+                    ]
+                  },
+                  {
+                    "group": "Google",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/google/gemini",
+                      "zh/tutorials/partner-nodes/google/gemini-omni-flash",
+                      "zh/tutorials/partner-nodes/google/nano-banana-pro",
+                      "zh/tutorials/partner-nodes/google/nano-banana-2",
+                      "zh/tutorials/partner-nodes/google/nano-banana-2-lite"
+                    ]
+                  },
+                  {
+                    "group": "Anthropic",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/anthropic/claude"
+                    ]
+                  },
+                  {
+                    "group": "Ideogram",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/ideogram/ideogram-v4"
+                    ]
+                  },
+                  {
+                    "group": "Luma",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/luma/luma-uni-1",
+                      "zh/tutorials/partner-nodes/luma/luma-text-to-image",
+                      "zh/tutorials/partner-nodes/luma/luma-image-to-image",
+                      "zh/tutorials/partner-nodes/luma/luma-text-to-video",
+                      "zh/tutorials/partner-nodes/luma/luma-image-to-video"
+                    ]
+                  },
+                  {
+                    "group": "Moonvalley",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
+                    ]
+                  },
+                  {
+                    "group": "OpenAI",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/openai/gpt-image-2",
+                      "zh/tutorials/partner-nodes/openai/gpt-image-1",
+                      "zh/tutorials/partner-nodes/openai/dall-e-2",
+                      "zh/tutorials/partner-nodes/openai/dall-e-3",
+                      "zh/tutorials/partner-nodes/openai/chat"
+                    ]
+                  },
+                  {
+                    "group": "OpenRouter",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/openrouter/llm"
+                    ]
+                  },
+                  {
+                    "group": "Recraft",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/recraft/recraft-v4",
+                      "zh/tutorials/partner-nodes/recraft/recraft-text-to-image"
+                    ]
+                  },
+                  {
+                    "group": "Krea 2",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/krea2/krea2-t2i"
+                    ]
+                  },
+                  {
+                    "group": "Kling",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/kling/kling-3-0",
+                      "zh/tutorials/partner-nodes/kling/kling-motion-control"
+                    ]
+                  },
+                  {
+                    "group": "Runway",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/runway/image-generation",
+                      "zh/tutorials/partner-nodes/runway/video-generation"
+                    ]
+                  },
+                  {
+                    "group": "Rodin",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/rodin/model-generation"
+                    ]
+                  },
+                  {
+                    "group": "Tripo",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/tripo/model-generation",
+                      "zh/tutorials/partner-nodes/tripo/tripo-3-1",
+                      "zh/tutorials/partner-nodes/tripo/tripo-p1"
+                    ]
+                  },
+                  {
+                    "group": "Hunyuan 3D",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
+                    ]
+                  },
+                  {
+                    "group": "Meshy",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/meshy/meshy-6"
+                    ]
+                  },
+                  {
+                    "group": "Bria",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/bria/fibo",
+                      "zh/tutorials/partner-nodes/bria/background-removal"
+                    ]
+                  },
+                  {
+                    "group": "Reve",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/reve/reve-image"
+                    ]
+                  },
+                  {
+                    "group": "Wan",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/wan/wan2-7"
+                    ]
+                  },
+                  {
+                    "group": "HappyHorse",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/happyhorse/happyhorse1-1",
+                      "zh/tutorials/partner-nodes/happyhorse/happyhorse1-0"
+                    ]
+                  },
+                  {
+                    "group": "Sonilo",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/sonilo/video-to-music"
+                    ]
+                  },
+                  {
+                    "group": "Topaz",
+                    "pages": [
+                      "zh/tutorials/partner-nodes/topaz/astra-2"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "自定义节点",
+                "pages": [
+                  {
+                    "group": "安装自定义节点",
+                    "icon": "puzzle-piece",
+                    "pages": [
+                      "zh/installation/install_custom_node",
+                      {
+                        "group": "ComfyUI-Manager",
+                        "pages": [
+                          "zh/manager/overview",
+                          "zh/manager/install",
+                          {
+                            "group": "自定义节点管理",
+                            "pages": [
+                              "zh/manager/pack-management",
+                              "zh/manager/legacy-ui"
+                            ]
+                          },
+                          "zh/manager/configuration",
+                          "zh/manager/troubleshooting"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "开发自定义节点",
+                    "pages": [
+                      "zh/custom-nodes/overview",
+                      "zh/custom-nodes/walkthrough",
+                      {
+                        "group": "后端",
+                        "icon": "python",
+                        "pages": [
+                          "zh/custom-nodes/backend/server_overview",
+                          "zh/custom-nodes/backend/lifecycle",
+                          "zh/custom-nodes/backend/datatypes",
+                          "zh/custom-nodes/backend/images_and_masks",
+                          "zh/custom-nodes/backend/more_on_inputs",
+                          "zh/custom-nodes/backend/lazy_evaluation",
+                          "zh/custom-nodes/backend/expansion",
+                          "zh/custom-nodes/backend/lists",
+                          "zh/custom-nodes/backend/snippets",
+                          "zh/custom-nodes/backend/tensors",
+                          "zh/custom-nodes/backend/node-replacement"
+                        ]
+                      },
+                      {
+                        "group": "UI",
+                        "icon": "js",
+                        "pages": [
+                          "zh/custom-nodes/js/javascript_overview",
+                          "zh/custom-nodes/js/javascript_hooks",
+                          "zh/custom-nodes/js/javascript_objects_and_hijacking",
+                          "zh/custom-nodes/js/javascript_settings",
+                          "zh/custom-nodes/js/javascript_dialog",
+                          "zh/custom-nodes/js/javascript_toast",
+                          "zh/custom-nodes/js/javascript_about_panel_badges",
+                          "zh/custom-nodes/js/javascript_bottom_panel_tabs",
+                          "zh/custom-nodes/js/javascript_sidebar_tabs",
+                          "zh/custom-nodes/js/javascript_selection_toolbox",
+                          "zh/custom-nodes/js/javascript_commands_keybindings",
+                          "zh/custom-nodes/js/javascript_topbar_menu",
+                          "zh/custom-nodes/js/context-menu-migration",
+                          "zh/custom-nodes/js/subgraphs",
+                          "zh/custom-nodes/js/javascript_examples",
+                          "zh/custom-nodes/i18n"
+                        ]
+                      },
+                      "zh/custom-nodes/v3_migration",
+                      "zh/custom-nodes/help_page",
+                      "zh/custom-nodes/workflow_templates",
+                      "zh/custom-nodes/subgraph_blueprints"
+                    ]
+                  },
+                  {
+                    "group": "注册表(Registry)",
+                    "pages": [
+                      "zh/registry/overview",
+                      "zh/registry/publishing",
+                      "zh/registry/claim-my-node",
+                      "zh/registry/standards",
+                      "zh/registry/cicd",
+                      "zh/registry/specifications",
+                      "zh/registry/api-reference/overview",
+                      {
+                        "group": "Registry API Reference",
+                        "openapi": "https://api.comfy.org/openapi"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -5497,68 +5575,6 @@
                   "zh/comfy-cli/getting-started",
                   "zh/comfy-cli/reference",
                   "zh/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "开发自定义节点",
-                "pages": [
-                  "zh/custom-nodes/overview",
-                  "zh/custom-nodes/walkthrough",
-                  {
-                    "group": "后端",
-                    "icon": "python",
-                    "pages": [
-                      "zh/custom-nodes/backend/server_overview",
-                      "zh/custom-nodes/backend/lifecycle",
-                      "zh/custom-nodes/backend/datatypes",
-                      "zh/custom-nodes/backend/images_and_masks",
-                      "zh/custom-nodes/backend/more_on_inputs",
-                      "zh/custom-nodes/backend/lazy_evaluation",
-                      "zh/custom-nodes/backend/expansion",
-                      "zh/custom-nodes/backend/lists",
-                      "zh/custom-nodes/backend/snippets",
-                      "zh/custom-nodes/backend/tensors",
-                      "zh/custom-nodes/backend/node-replacement"
-                    ]
-                  },
-                  {
-                    "group": "UI",
-                    "icon": "js",
-                    "pages": [
-                      "zh/custom-nodes/js/javascript_overview",
-                      "zh/custom-nodes/js/javascript_hooks",
-                      "zh/custom-nodes/js/javascript_objects_and_hijacking",
-                      "zh/custom-nodes/js/javascript_settings",
-                      "zh/custom-nodes/js/javascript_dialog",
-                      "zh/custom-nodes/js/javascript_toast",
-                      "zh/custom-nodes/js/javascript_about_panel_badges",
-                      "zh/custom-nodes/js/javascript_bottom_panel_tabs",
-                      "zh/custom-nodes/js/javascript_sidebar_tabs",
-                      "zh/custom-nodes/js/javascript_selection_toolbox",
-                      "zh/custom-nodes/js/javascript_commands_keybindings",
-                      "zh/custom-nodes/js/javascript_topbar_menu",
-                      "zh/custom-nodes/js/context-menu-migration",
-                      "zh/custom-nodes/js/subgraphs",
-                      "zh/custom-nodes/js/javascript_examples",
-                      "zh/custom-nodes/i18n"
-                    ]
-                  },
-                  "zh/custom-nodes/v3_migration",
-                  "zh/custom-nodes/help_page",
-                  "zh/custom-nodes/workflow_templates",
-                  "zh/custom-nodes/subgraph_blueprints"
-                ]
-              },
-              {
-                "group": "注册表(Registry)",
-                "pages": [
-                  "zh/registry/overview",
-                  "zh/registry/publishing",
-                  "zh/registry/claim-my-node",
-                  "zh/registry/standards",
-                  "zh/registry/cicd",
-                  "zh/registry/specifications",
-                  "zh/registry/api-reference/overview"
                 ]
               },
               {
@@ -5640,10 +5656,6 @@
             ]
           },
           {
-            "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
-          },
-          {
             "tab": "Cloud API 参考文档",
             "openapi": {
               "source": "openapi-cloud.yaml",
@@ -5699,29 +5711,6 @@
                     ]
                   },
                   "ja/get_started/cloud",
-                  {
-                    "group": "カスタムノードのインストール",
-                    "icon": "puzzle-piece",
-                    "pages": [
-                      "ja/installation/install_custom_node",
-                      {
-                        "group": "ComfyUI-Manager",
-                        "pages": [
-                          "ja/manager/overview",
-                          "ja/manager/install",
-                          {
-                            "group": "カスタムノード管理",
-                            "pages": [
-                              "ja/manager/pack-management",
-                              "ja/manager/legacy-ui"
-                            ]
-                          },
-                          "ja/manager/configuration",
-                          "ja/manager/troubleshooting"
-                        ]
-                      }
-                    ]
-                  },
                   "ja/get_started/first_generation"
                 ]
               },
@@ -6052,200 +6041,16 @@
                     ]
                   }
                 ]
-              },
-              {
-                "group": "パートナーノード",
-                "icon": "handshake",
-                "pages": [
-                  "ja/tutorials/partner-nodes/overview",
-                  "ja/tutorials/partner-nodes/faq",
-                  "ja/tutorials/partner-nodes/pricing",
-                  "ja/tutorials/partner-nodes/concurrency-limits",
-                  {
-                    "group": "Black Forest Labs",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
-                      "ja/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
-                    ]
-                  },
-                  {
-                    "group": "Beeble",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/beeble/beeble-switchx"
-                    ]
-                  },
-                  {
-                    "group": "ByteDance",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/bytedance/seedance-2-0",
-                      "ja/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
-                      "ja/tutorials/partner-nodes/bytedance/seedream-5-pro",
-                      "ja/tutorials/partner-nodes/bytedance/seedream-5-lite",
-                      "ja/tutorials/partner-nodes/bytedance/seed-audio-1-0"
-                    ]
-                  },
-                  {
-                    "group": "Google",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/google/gemini",
-                      "ja/tutorials/partner-nodes/google/gemini-omni-flash",
-                      "ja/tutorials/partner-nodes/google/nano-banana-pro",
-                      "ja/tutorials/partner-nodes/google/nano-banana-2",
-                      "ja/tutorials/partner-nodes/google/nano-banana-2-lite"
-                    ]
-                  },
-                  {
-                    "group": "Anthropic",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/anthropic/claude"
-                    ]
-                  },
-                  {
-                    "group": "Ideogram",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/ideogram/ideogram-v4"
-                    ]
-                  },
-                  {
-                    "group": "Luma",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/luma/luma-uni-1",
-                      "ja/tutorials/partner-nodes/luma/luma-text-to-image",
-                      "ja/tutorials/partner-nodes/luma/luma-image-to-image",
-                      "ja/tutorials/partner-nodes/luma/luma-text-to-video",
-                      "ja/tutorials/partner-nodes/luma/luma-image-to-video"
-                    ]
-                  },
-                  {
-                    "group": "Moonvalley",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
-                    ]
-                  },
-                  {
-                    "group": "OpenAI",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/openai/gpt-image-2",
-                      "ja/tutorials/partner-nodes/openai/gpt-image-1",
-                      "ja/tutorials/partner-nodes/openai/dall-e-2",
-                      "ja/tutorials/partner-nodes/openai/dall-e-3",
-                      "ja/tutorials/partner-nodes/openai/chat"
-                    ]
-                  },
-                  {
-                    "group": "OpenRouter",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/openrouter/llm"
-                    ]
-                  },
-                  {
-                    "group": "Recraft",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/recraft/recraft-v4",
-                      "ja/tutorials/partner-nodes/recraft/recraft-text-to-image"
-                    ]
-                  },
-                  {
-                    "group": "Krea 2",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/krea2/krea2-t2i"
-                    ]
-                  },
-                  {
-                    "group": "Kling",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/kling/kling-3-0",
-                      "ja/tutorials/partner-nodes/kling/kling-motion-control"
-                    ]
-                  },
-                  {
-                    "group": "Runway",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/runway/image-generation",
-                      "ja/tutorials/partner-nodes/runway/video-generation"
-                    ]
-                  },
-                  {
-                    "group": "Rodin",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/rodin/model-generation"
-                    ]
-                  },
-                  {
-                    "group": "Tripo",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/tripo/model-generation",
-                      "ja/tutorials/partner-nodes/tripo/tripo-3-1",
-                      "ja/tutorials/partner-nodes/tripo/tripo-p1"
-                    ]
-                  },
-                  {
-                    "group": "Hunyuan 3D",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
-                    ]
-                  },
-                  {
-                    "group": "Meshy",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/meshy/meshy-6"
-                    ]
-                  },
-                  {
-                    "group": "Bria",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/bria/fibo",
-                      "ja/tutorials/partner-nodes/bria/background-removal"
-                    ]
-                  },
-                  {
-                    "group": "Reve",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/reve/reve-image"
-                    ]
-                  },
-                  {
-                    "group": "Wan",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/wan/wan2-7"
-                    ]
-                  },
-                  {
-                    "group": "HappyHorse",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/happyhorse/happyhorse1-1",
-                      "ja/tutorials/partner-nodes/happyhorse/happyhorse1-0"
-                    ]
-                  },
-                  {
-                    "group": "Sonilo",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/sonilo/video-to-music"
-                    ]
-                  },
-                  {
-                    "group": "Topaz",
-                    "pages": [
-                      "ja/tutorials/partner-nodes/topaz/astra-2"
-                    ]
-                  },
-                  {
-                    "group": "Krea 2",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/krea2/krea2-t2i"
-                    ]
-                  }
-                ]
               }
             ]
           },
           {
-            "tab": "組み込みノード",
+            "tab": "ノード",
             "pages": [
-              "ja/built-in-nodes/overview",
               {
-                "group": "ノード",
+                "group": "コアノード",
                 "pages": [
+                  "ja/built-in-nodes/overview",
                   {
                     "group": "3D",
                     "pages": [
@@ -8286,6 +8091,284 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "パートナーノード",
+                "icon": "handshake",
+                "pages": [
+                  "ja/tutorials/partner-nodes/overview",
+                  "ja/tutorials/partner-nodes/faq",
+                  "ja/tutorials/partner-nodes/pricing",
+                  "ja/tutorials/partner-nodes/concurrency-limits",
+                  {
+                    "group": "Black Forest Labs",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
+                      "ja/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
+                    ]
+                  },
+                  {
+                    "group": "Beeble",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/beeble/beeble-switchx"
+                    ]
+                  },
+                  {
+                    "group": "ByteDance",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/bytedance/seedance-2-0",
+                      "ja/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
+                      "ja/tutorials/partner-nodes/bytedance/seedream-5-pro",
+                      "ja/tutorials/partner-nodes/bytedance/seedream-5-lite",
+                      "ja/tutorials/partner-nodes/bytedance/seed-audio-1-0"
+                    ]
+                  },
+                  {
+                    "group": "Google",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/google/gemini",
+                      "ja/tutorials/partner-nodes/google/gemini-omni-flash",
+                      "ja/tutorials/partner-nodes/google/nano-banana-pro",
+                      "ja/tutorials/partner-nodes/google/nano-banana-2",
+                      "ja/tutorials/partner-nodes/google/nano-banana-2-lite"
+                    ]
+                  },
+                  {
+                    "group": "Anthropic",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/anthropic/claude"
+                    ]
+                  },
+                  {
+                    "group": "Ideogram",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/ideogram/ideogram-v4"
+                    ]
+                  },
+                  {
+                    "group": "Luma",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/luma/luma-uni-1",
+                      "ja/tutorials/partner-nodes/luma/luma-text-to-image",
+                      "ja/tutorials/partner-nodes/luma/luma-image-to-image",
+                      "ja/tutorials/partner-nodes/luma/luma-text-to-video",
+                      "ja/tutorials/partner-nodes/luma/luma-image-to-video"
+                    ]
+                  },
+                  {
+                    "group": "Moonvalley",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
+                    ]
+                  },
+                  {
+                    "group": "OpenAI",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/openai/gpt-image-2",
+                      "ja/tutorials/partner-nodes/openai/gpt-image-1",
+                      "ja/tutorials/partner-nodes/openai/dall-e-2",
+                      "ja/tutorials/partner-nodes/openai/dall-e-3",
+                      "ja/tutorials/partner-nodes/openai/chat"
+                    ]
+                  },
+                  {
+                    "group": "OpenRouter",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/openrouter/llm"
+                    ]
+                  },
+                  {
+                    "group": "Recraft",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/recraft/recraft-v4",
+                      "ja/tutorials/partner-nodes/recraft/recraft-text-to-image"
+                    ]
+                  },
+                  {
+                    "group": "Krea 2",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/krea2/krea2-t2i"
+                    ]
+                  },
+                  {
+                    "group": "Kling",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/kling/kling-3-0",
+                      "ja/tutorials/partner-nodes/kling/kling-motion-control"
+                    ]
+                  },
+                  {
+                    "group": "Runway",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/runway/image-generation",
+                      "ja/tutorials/partner-nodes/runway/video-generation"
+                    ]
+                  },
+                  {
+                    "group": "Rodin",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/rodin/model-generation"
+                    ]
+                  },
+                  {
+                    "group": "Tripo",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/tripo/model-generation",
+                      "ja/tutorials/partner-nodes/tripo/tripo-3-1",
+                      "ja/tutorials/partner-nodes/tripo/tripo-p1"
+                    ]
+                  },
+                  {
+                    "group": "Hunyuan 3D",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
+                    ]
+                  },
+                  {
+                    "group": "Meshy",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/meshy/meshy-6"
+                    ]
+                  },
+                  {
+                    "group": "Bria",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/bria/fibo",
+                      "ja/tutorials/partner-nodes/bria/background-removal"
+                    ]
+                  },
+                  {
+                    "group": "Reve",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/reve/reve-image"
+                    ]
+                  },
+                  {
+                    "group": "Wan",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/wan/wan2-7"
+                    ]
+                  },
+                  {
+                    "group": "HappyHorse",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/happyhorse/happyhorse1-1",
+                      "ja/tutorials/partner-nodes/happyhorse/happyhorse1-0"
+                    ]
+                  },
+                  {
+                    "group": "Sonilo",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/sonilo/video-to-music"
+                    ]
+                  },
+                  {
+                    "group": "Topaz",
+                    "pages": [
+                      "ja/tutorials/partner-nodes/topaz/astra-2"
+                    ]
+                  },
+                  {
+                    "group": "Krea 2",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/krea2/krea2-t2i"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "カスタムノード",
+                "pages": [
+                  {
+                    "group": "カスタムノードのインストール",
+                    "icon": "puzzle-piece",
+                    "pages": [
+                      "ja/installation/install_custom_node",
+                      {
+                        "group": "ComfyUI-Manager",
+                        "pages": [
+                          "ja/manager/overview",
+                          "ja/manager/install",
+                          {
+                            "group": "カスタムノード管理",
+                            "pages": [
+                              "ja/manager/pack-management",
+                              "ja/manager/legacy-ui"
+                            ]
+                          },
+                          "ja/manager/configuration",
+                          "ja/manager/troubleshooting"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "カスタムノード開発",
+                    "pages": [
+                      "ja/custom-nodes/overview",
+                      "ja/custom-nodes/walkthrough",
+                      {
+                        "group": "バックエンド",
+                        "icon": "python",
+                        "pages": [
+                          "ja/custom-nodes/backend/server_overview",
+                          "ja/custom-nodes/backend/lifecycle",
+                          "ja/custom-nodes/backend/datatypes",
+                          "ja/custom-nodes/backend/images_and_masks",
+                          "ja/custom-nodes/backend/more_on_inputs",
+                          "ja/custom-nodes/backend/lazy_evaluation",
+                          "ja/custom-nodes/backend/expansion",
+                          "ja/custom-nodes/backend/lists",
+                          "ja/custom-nodes/backend/snippets",
+                          "ja/custom-nodes/backend/tensors",
+                          "ja/custom-nodes/backend/node-replacement"
+                        ]
+                      },
+                      {
+                        "group": "UI",
+                        "icon": "js",
+                        "pages": [
+                          "ja/custom-nodes/js/javascript_overview",
+                          "ja/custom-nodes/js/javascript_hooks",
+                          "ja/custom-nodes/js/javascript_objects_and_hijacking",
+                          "ja/custom-nodes/js/javascript_settings",
+                          "ja/custom-nodes/js/javascript_dialog",
+                          "ja/custom-nodes/js/javascript_toast",
+                          "ja/custom-nodes/js/javascript_about_panel_badges",
+                          "ja/custom-nodes/js/javascript_bottom_panel_tabs",
+                          "ja/custom-nodes/js/javascript_sidebar_tabs",
+                          "ja/custom-nodes/js/javascript_selection_toolbox",
+                          "ja/custom-nodes/js/javascript_commands_keybindings",
+                          "ja/custom-nodes/js/javascript_topbar_menu",
+                          "ja/custom-nodes/js/context-menu-migration",
+                          "ja/custom-nodes/js/subgraphs",
+                          "ja/custom-nodes/js/javascript_examples",
+                          "ja/custom-nodes/i18n"
+                        ]
+                      },
+                      "ja/custom-nodes/v3_migration",
+                      "ja/custom-nodes/help_page",
+                      "ja/custom-nodes/workflow_templates",
+                      "ja/custom-nodes/subgraph_blueprints"
+                    ]
+                  },
+                  {
+                    "group": "レジストリ（Registry）",
+                    "pages": [
+                      "ja/registry/overview",
+                      "ja/registry/publishing",
+                      "ja/registry/claim-my-node",
+                      "ja/registry/standards",
+                      "ja/registry/cicd",
+                      "ja/registry/specifications",
+                      "ja/registry/api-reference/overview",
+                      {
+                        "group": "Registry APIリファレンス",
+                        "openapi": "https://api.comfy.org/openapi"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -8330,68 +8413,6 @@
                   "ja/comfy-cli/getting-started",
                   "ja/comfy-cli/reference",
                   "ja/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "カスタムノード開発",
-                "pages": [
-                  "ja/custom-nodes/overview",
-                  "ja/custom-nodes/walkthrough",
-                  {
-                    "group": "バックエンド",
-                    "icon": "python",
-                    "pages": [
-                      "ja/custom-nodes/backend/server_overview",
-                      "ja/custom-nodes/backend/lifecycle",
-                      "ja/custom-nodes/backend/datatypes",
-                      "ja/custom-nodes/backend/images_and_masks",
-                      "ja/custom-nodes/backend/more_on_inputs",
-                      "ja/custom-nodes/backend/lazy_evaluation",
-                      "ja/custom-nodes/backend/expansion",
-                      "ja/custom-nodes/backend/lists",
-                      "ja/custom-nodes/backend/snippets",
-                      "ja/custom-nodes/backend/tensors",
-                      "ja/custom-nodes/backend/node-replacement"
-                    ]
-                  },
-                  {
-                    "group": "UI",
-                    "icon": "js",
-                    "pages": [
-                      "ja/custom-nodes/js/javascript_overview",
-                      "ja/custom-nodes/js/javascript_hooks",
-                      "ja/custom-nodes/js/javascript_objects_and_hijacking",
-                      "ja/custom-nodes/js/javascript_settings",
-                      "ja/custom-nodes/js/javascript_dialog",
-                      "ja/custom-nodes/js/javascript_toast",
-                      "ja/custom-nodes/js/javascript_about_panel_badges",
-                      "ja/custom-nodes/js/javascript_bottom_panel_tabs",
-                      "ja/custom-nodes/js/javascript_sidebar_tabs",
-                      "ja/custom-nodes/js/javascript_selection_toolbox",
-                      "ja/custom-nodes/js/javascript_commands_keybindings",
-                      "ja/custom-nodes/js/javascript_topbar_menu",
-                      "ja/custom-nodes/js/context-menu-migration",
-                      "ja/custom-nodes/js/subgraphs",
-                      "ja/custom-nodes/js/javascript_examples",
-                      "ja/custom-nodes/i18n"
-                    ]
-                  },
-                  "ja/custom-nodes/v3_migration",
-                  "ja/custom-nodes/help_page",
-                  "ja/custom-nodes/workflow_templates",
-                  "ja/custom-nodes/subgraph_blueprints"
-                ]
-              },
-              {
-                "group": "レジストリ（Registry）",
-                "pages": [
-                  "ja/registry/overview",
-                  "ja/registry/publishing",
-                  "ja/registry/claim-my-node",
-                  "ja/registry/standards",
-                  "ja/registry/cicd",
-                  "ja/registry/specifications",
-                  "ja/registry/api-reference/overview"
                 ]
               },
               {
@@ -8471,10 +8492,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry APIリファレンス",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud APIリファレンス",
@@ -8610,29 +8627,6 @@
                     ]
                   },
                   "ko/get_started/cloud",
-                  {
-                    "group": "커스텀 노드 설치",
-                    "icon": "puzzle-piece",
-                    "pages": [
-                      "ko/installation/install_custom_node",
-                      {
-                        "group": "ComfyUI 매니저",
-                        "pages": [
-                          "ko/manager/overview",
-                          "ko/manager/install",
-                          {
-                            "group": "노드 관리",
-                            "pages": [
-                              "ko/manager/pack-management",
-                              "ko/manager/legacy-ui"
-                            ]
-                          },
-                          "ko/manager/configuration",
-                          "ko/manager/troubleshooting"
-                        ]
-                      }
-                    ]
-                  },
                   "ko/get_started/first_generation"
                 ]
               },
@@ -8962,187 +8956,16 @@
                   }
                 ]
               },
-              {
-                "group": "파트너 노드",
-                "icon": "handshake",
-                "pages": [
-                  "ko/tutorials/partner-nodes/overview",
-                  "ko/tutorials/partner-nodes/faq",
-                  "ko/tutorials/partner-nodes/pricing",
-                  "ko/tutorials/partner-nodes/concurrency-limits",
-                  {
-                    "group": "Black Forest Labs",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
-                      "ko/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
-                    ]
-                  },
-                  {
-                    "group": "Beeble",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/beeble/beeble-switchx"
-                    ]
-                  },
-                  {
-                    "group": "ByteDance",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/bytedance/seedance-2-0",
-                      "ko/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
-                      "ko/tutorials/partner-nodes/bytedance/seedream-5-pro",
-                      "ko/tutorials/partner-nodes/bytedance/seedream-5-lite",
-                      "ko/tutorials/partner-nodes/bytedance/seed-audio-1-0"
-                    ]
-                  },
-                  {
-                    "group": "Google",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/google/gemini",
-                      "ko/tutorials/partner-nodes/google/gemini-omni-flash",
-                      "ko/tutorials/partner-nodes/google/nano-banana-pro",
-                      "ko/tutorials/partner-nodes/google/nano-banana-2",
-                      "ko/tutorials/partner-nodes/google/nano-banana-2-lite"
-                    ]
-                  },
-                  {
-                    "group": "Anthropic",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/anthropic/claude"
-                    ]
-                  },
-                  {
-                    "group": "Ideogram",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/ideogram/ideogram-v4"
-                    ]
-                  },
-                  {
-                    "group": "Luma",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/luma/luma-uni-1",
-                      "ko/tutorials/partner-nodes/luma/luma-text-to-image",
-                      "ko/tutorials/partner-nodes/luma/luma-image-to-image",
-                      "ko/tutorials/partner-nodes/luma/luma-text-to-video",
-                      "ko/tutorials/partner-nodes/luma/luma-image-to-video"
-                    ]
-                  },
-                  {
-                    "group": "Moonvalley",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
-                    ]
-                  },
-                  {
-                    "group": "OpenAI",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/openai/gpt-image-2",
-                      "ko/tutorials/partner-nodes/openai/gpt-image-1",
-                      "ko/tutorials/partner-nodes/openai/dall-e-2",
-                      "ko/tutorials/partner-nodes/openai/dall-e-3",
-                      "ko/tutorials/partner-nodes/openai/chat"
-                    ]
-                  },
-                  {
-                    "group": "OpenRouter",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/openrouter/llm"
-                    ]
-                  },
-                  {
-                    "group": "Recraft",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/recraft/recraft-v4",
-                      "ko/tutorials/partner-nodes/recraft/recraft-text-to-image"
-                    ]
-                  },
-                  {
-                    "group": "Kling",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/kling/kling-3-0",
-                      "ko/tutorials/partner-nodes/kling/kling-motion-control"
-                    ]
-                  },
-                  {
-                    "group": "Runway",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/runway/image-generation",
-                      "ko/tutorials/partner-nodes/runway/video-generation"
-                    ]
-                  },
-                  {
-                    "group": "Rodin",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/rodin/model-generation"
-                    ]
-                  },
-                  {
-                    "group": "Tripo",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/tripo/model-generation",
-                      "ko/tutorials/partner-nodes/tripo/tripo-3-1"
-                    ]
-                  },
-                  {
-                    "group": "Hunyuan 3D",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
-                    ]
-                  },
-                  {
-                    "group": "Meshy",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/meshy/meshy-6"
-                    ]
-                  },
-                  {
-                    "group": "Bria",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/bria/fibo",
-                      "ko/tutorials/partner-nodes/bria/background-removal"
-                    ]
-                  },
-                  {
-                    "group": "Reve",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/reve/reve-image"
-                    ]
-                  },
-                  {
-                    "group": "Wan",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/wan/wan2-7"
-                    ]
-                  },
-                  {
-                    "group": "HappyHorse",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/happyhorse/happyhorse1-1",
-                      "ko/tutorials/partner-nodes/happyhorse/happyhorse1-0"
-                    ]
-                  },
-                  {
-                    "group": "Sonilo",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/sonilo/video-to-music"
-                    ]
-                  },
-                  {
-                    "group": "Topaz",
-                    "pages": [
-                      "ko/tutorials/partner-nodes/topaz/astra-2"
-                    ]
-                  }
-                ]
-              },
               "ko/changelog/index"
             ]
           },
           {
-            "tab": "내장 노드 (Built-in Nodes)",
+            "tab": "노드",
             "pages": [
-              "ko/built-in-nodes/overview",
               {
-                "group": "노드",
+                "group": "코어 노드",
                 "pages": [
+                  "ko/built-in-nodes/overview",
                   {
                     "group": "3D",
                     "pages": [
@@ -11063,6 +10886,271 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "파트너 노드",
+                "icon": "handshake",
+                "pages": [
+                  "ko/tutorials/partner-nodes/overview",
+                  "ko/tutorials/partner-nodes/faq",
+                  "ko/tutorials/partner-nodes/pricing",
+                  "ko/tutorials/partner-nodes/concurrency-limits",
+                  {
+                    "group": "Black Forest Labs",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
+                      "ko/tutorials/partner-nodes/black-forest-labs/flux-1-kontext"
+                    ]
+                  },
+                  {
+                    "group": "Beeble",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/beeble/beeble-switchx"
+                    ]
+                  },
+                  {
+                    "group": "ByteDance",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/bytedance/seedance-2-0",
+                      "ko/tutorials/partner-nodes/bytedance/seedance-2-0-real-human",
+                      "ko/tutorials/partner-nodes/bytedance/seedream-5-pro",
+                      "ko/tutorials/partner-nodes/bytedance/seedream-5-lite",
+                      "ko/tutorials/partner-nodes/bytedance/seed-audio-1-0"
+                    ]
+                  },
+                  {
+                    "group": "Google",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/google/gemini",
+                      "ko/tutorials/partner-nodes/google/gemini-omni-flash",
+                      "ko/tutorials/partner-nodes/google/nano-banana-pro",
+                      "ko/tutorials/partner-nodes/google/nano-banana-2",
+                      "ko/tutorials/partner-nodes/google/nano-banana-2-lite"
+                    ]
+                  },
+                  {
+                    "group": "Anthropic",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/anthropic/claude"
+                    ]
+                  },
+                  {
+                    "group": "Ideogram",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/ideogram/ideogram-v4"
+                    ]
+                  },
+                  {
+                    "group": "Luma",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/luma/luma-uni-1",
+                      "ko/tutorials/partner-nodes/luma/luma-text-to-image",
+                      "ko/tutorials/partner-nodes/luma/luma-image-to-image",
+                      "ko/tutorials/partner-nodes/luma/luma-text-to-video",
+                      "ko/tutorials/partner-nodes/luma/luma-image-to-video"
+                    ]
+                  },
+                  {
+                    "group": "Moonvalley",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/moonvalley/moonvalley-video-generation"
+                    ]
+                  },
+                  {
+                    "group": "OpenAI",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/openai/gpt-image-2",
+                      "ko/tutorials/partner-nodes/openai/gpt-image-1",
+                      "ko/tutorials/partner-nodes/openai/dall-e-2",
+                      "ko/tutorials/partner-nodes/openai/dall-e-3",
+                      "ko/tutorials/partner-nodes/openai/chat"
+                    ]
+                  },
+                  {
+                    "group": "OpenRouter",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/openrouter/llm"
+                    ]
+                  },
+                  {
+                    "group": "Recraft",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/recraft/recraft-v4",
+                      "ko/tutorials/partner-nodes/recraft/recraft-text-to-image"
+                    ]
+                  },
+                  {
+                    "group": "Kling",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/kling/kling-3-0",
+                      "ko/tutorials/partner-nodes/kling/kling-motion-control"
+                    ]
+                  },
+                  {
+                    "group": "Runway",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/runway/image-generation",
+                      "ko/tutorials/partner-nodes/runway/video-generation"
+                    ]
+                  },
+                  {
+                    "group": "Rodin",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/rodin/model-generation"
+                    ]
+                  },
+                  {
+                    "group": "Tripo",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/tripo/model-generation",
+                      "ko/tutorials/partner-nodes/tripo/tripo-3-1"
+                    ]
+                  },
+                  {
+                    "group": "Hunyuan 3D",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0"
+                    ]
+                  },
+                  {
+                    "group": "Meshy",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/meshy/meshy-6"
+                    ]
+                  },
+                  {
+                    "group": "Bria",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/bria/fibo",
+                      "ko/tutorials/partner-nodes/bria/background-removal"
+                    ]
+                  },
+                  {
+                    "group": "Reve",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/reve/reve-image"
+                    ]
+                  },
+                  {
+                    "group": "Wan",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/wan/wan2-7"
+                    ]
+                  },
+                  {
+                    "group": "HappyHorse",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/happyhorse/happyhorse1-1",
+                      "ko/tutorials/partner-nodes/happyhorse/happyhorse1-0"
+                    ]
+                  },
+                  {
+                    "group": "Sonilo",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/sonilo/video-to-music"
+                    ]
+                  },
+                  {
+                    "group": "Topaz",
+                    "pages": [
+                      "ko/tutorials/partner-nodes/topaz/astra-2"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "커스텀 노드",
+                "pages": [
+                  {
+                    "group": "커스텀 노드 설치",
+                    "icon": "puzzle-piece",
+                    "pages": [
+                      "ko/installation/install_custom_node",
+                      {
+                        "group": "ComfyUI 매니저",
+                        "pages": [
+                          "ko/manager/overview",
+                          "ko/manager/install",
+                          {
+                            "group": "노드 관리",
+                            "pages": [
+                              "ko/manager/pack-management",
+                              "ko/manager/legacy-ui"
+                            ]
+                          },
+                          "ko/manager/configuration",
+                          "ko/manager/troubleshooting"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "커스텀 노드 개발",
+                    "pages": [
+                      "ko/custom-nodes/overview",
+                      "ko/custom-nodes/walkthrough",
+                      {
+                        "group": "백엔드",
+                        "icon": "python",
+                        "pages": [
+                          "ko/custom-nodes/backend/server_overview",
+                          "ko/custom-nodes/backend/lifecycle",
+                          "ko/custom-nodes/backend/datatypes",
+                          "ko/custom-nodes/backend/images_and_masks",
+                          "ko/custom-nodes/backend/more_on_inputs",
+                          "ko/custom-nodes/backend/lazy_evaluation",
+                          "ko/custom-nodes/backend/expansion",
+                          "ko/custom-nodes/backend/lists",
+                          "ko/custom-nodes/backend/snippets",
+                          "ko/custom-nodes/backend/tensors",
+                          "ko/custom-nodes/backend/node-replacement"
+                        ]
+                      },
+                      {
+                        "group": "UI",
+                        "icon": "js",
+                        "pages": [
+                          "ko/custom-nodes/js/javascript_overview",
+                          "ko/custom-nodes/js/javascript_hooks",
+                          "ko/custom-nodes/js/javascript_objects_and_hijacking",
+                          "ko/custom-nodes/js/javascript_settings",
+                          "ko/custom-nodes/js/javascript_dialog",
+                          "ko/custom-nodes/js/javascript_toast",
+                          "ko/custom-nodes/js/javascript_about_panel_badges",
+                          "ko/custom-nodes/js/javascript_bottom_panel_tabs",
+                          "ko/custom-nodes/js/javascript_sidebar_tabs",
+                          "ko/custom-nodes/js/javascript_selection_toolbox",
+                          "ko/custom-nodes/js/javascript_commands_keybindings",
+                          "ko/custom-nodes/js/javascript_topbar_menu",
+                          "ko/custom-nodes/js/context-menu-migration",
+                          "ko/custom-nodes/js/subgraphs",
+                          "ko/custom-nodes/js/javascript_examples",
+                          "ko/custom-nodes/i18n"
+                        ]
+                      },
+                      "ko/custom-nodes/v3_migration",
+                      "ko/custom-nodes/help_page",
+                      "ko/custom-nodes/workflow_templates",
+                      "ko/custom-nodes/subgraph_blueprints"
+                    ]
+                  },
+                  {
+                    "group": "레지스트리",
+                    "pages": [
+                      "ko/registry/overview",
+                      "ko/registry/publishing",
+                      "ko/registry/claim-my-node",
+                      "ko/registry/standards",
+                      "ko/registry/cicd",
+                      "ko/registry/specifications",
+                      "ko/registry/api-reference/overview",
+                      {
+                        "group": "Registry API 참조",
+                        "openapi": "https://api.comfy.org/openapi"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -11107,68 +11195,6 @@
                   "ko/comfy-cli/getting-started",
                   "ko/comfy-cli/reference",
                   "ko/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "커스텀 노드 개발",
-                "pages": [
-                  "ko/custom-nodes/overview",
-                  "ko/custom-nodes/walkthrough",
-                  {
-                    "group": "백엔드",
-                    "icon": "python",
-                    "pages": [
-                      "ko/custom-nodes/backend/server_overview",
-                      "ko/custom-nodes/backend/lifecycle",
-                      "ko/custom-nodes/backend/datatypes",
-                      "ko/custom-nodes/backend/images_and_masks",
-                      "ko/custom-nodes/backend/more_on_inputs",
-                      "ko/custom-nodes/backend/lazy_evaluation",
-                      "ko/custom-nodes/backend/expansion",
-                      "ko/custom-nodes/backend/lists",
-                      "ko/custom-nodes/backend/snippets",
-                      "ko/custom-nodes/backend/tensors",
-                      "ko/custom-nodes/backend/node-replacement"
-                    ]
-                  },
-                  {
-                    "group": "UI",
-                    "icon": "js",
-                    "pages": [
-                      "ko/custom-nodes/js/javascript_overview",
-                      "ko/custom-nodes/js/javascript_hooks",
-                      "ko/custom-nodes/js/javascript_objects_and_hijacking",
-                      "ko/custom-nodes/js/javascript_settings",
-                      "ko/custom-nodes/js/javascript_dialog",
-                      "ko/custom-nodes/js/javascript_toast",
-                      "ko/custom-nodes/js/javascript_about_panel_badges",
-                      "ko/custom-nodes/js/javascript_bottom_panel_tabs",
-                      "ko/custom-nodes/js/javascript_sidebar_tabs",
-                      "ko/custom-nodes/js/javascript_selection_toolbox",
-                      "ko/custom-nodes/js/javascript_commands_keybindings",
-                      "ko/custom-nodes/js/javascript_topbar_menu",
-                      "ko/custom-nodes/js/context-menu-migration",
-                      "ko/custom-nodes/js/subgraphs",
-                      "ko/custom-nodes/js/javascript_examples",
-                      "ko/custom-nodes/i18n"
-                    ]
-                  },
-                  "ko/custom-nodes/v3_migration",
-                  "ko/custom-nodes/help_page",
-                  "ko/custom-nodes/workflow_templates",
-                  "ko/custom-nodes/subgraph_blueprints"
-                ]
-              },
-              {
-                "group": "레지스트리",
-                "pages": [
-                  "ko/registry/overview",
-                  "ko/registry/publishing",
-                  "ko/registry/claim-my-node",
-                  "ko/registry/standards",
-                  "ko/registry/cicd",
-                  "ko/registry/specifications",
-                  "ko/registry/api-reference/overview"
                 ]
               },
               {
@@ -11248,10 +11274,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry API 참조",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud API 참조",

--- a/nodes/index.mdx
+++ b/nodes/index.mdx
@@ -1,0 +1,31 @@
+---
+title: "Nodes"
+description: "The three kinds of nodes in ComfyUI: core nodes, partner nodes, and custom nodes."
+sidebarTitle: "Overview"
+---
+
+A node is a single unit of work in a workflow. It takes inputs, does something with them (load a model, encode a prompt, sample, save an image), and passes its outputs to the next node. Workflows are built by connecting nodes together.
+
+## Core nodes
+
+Built-in nodes maintained by the Comfy Org team. They ship with every ComfyUI install and run on your own hardware.
+
+<Card title="Core Nodes" icon="cube" href="/built-in-nodes/overview">
+  Reference for every built-in node, grouped by category.
+</Card>
+
+## Partner nodes
+
+Nodes that provide access to third-party models (Nano Banana, Seedance, Kling, and others). They are included with ComfyUI, run on the provider's infrastructure, and cost [Comfy credits](/interface/credits) per run.
+
+<Card title="Partner Nodes" icon="handshake" href="/tutorials/partner-nodes/overview">
+  Prerequisites, pricing, and per-model guides.
+</Card>
+
+## Custom nodes
+
+Community-built nodes you install yourself from the [Comfy Registry](https://registry.comfy.org), usually through ComfyUI Manager. You can also write and publish your own.
+
+<Card title="Custom Nodes" icon="puzzle-piece" href="/custom-nodes">
+  Installing, managing, developing, and publishing custom nodes.
+</Card>

--- a/nodes/index.mdx
+++ b/nodes/index.mdx
@@ -16,7 +16,7 @@ Built-in nodes maintained by the Comfy Org team. They ship with every ComfyUI in
 
 ## Partner nodes
 
-Nodes that provide access to third-party models (Nano Banana, Seedance, Kling, and others). They are included with ComfyUI, run on the provider's infrastructure, and cost [Comfy credits](/interface/credits) per run.
+Nodes that provide access to third-party models (Nano Banana, Seedance, Kling, and others). They are included with ComfyUI, run on the provider's infrastructure, and cost [credits](/interface/credits) to run.
 
 <Card title="Partner Nodes" icon="handshake" href="/tutorials/partner-nodes/overview">
   Prerequisites, pricing, and per-model guides.


### PR DESCRIPTION
## Summary

Renames the **Built-in Nodes** tab to **Nodes** and organizes it into three groups: Core Nodes (the built-in node reference), Partner Nodes (moved from Get Started), and Custom Nodes (install, develop, and registry docs moved from Get Started and Development). The Registry API Reference tab is now a group nested under Registry.

Adds two overview pages: `/nodes` explains what a node is and how core, partner, and custom nodes differ, and `/custom-nodes` introduces the Custom Nodes group.

The i18n nav sync now keeps groups that render an OpenAPI spec instead of pages, so the nested Registry API reference survives a sync and keeps its localized title. zh/ja/ko navigation mirrors the new structure; the two new pages are English-only until the translation pipeline runs.
