### PR TITLE
docs: add v0.29.x changelog and publish ComfyUI CMS release notes

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -113,6 +113,20 @@
       "published_at": "2026-05-28T12:06:14.649Z"
     },
     {
+      "project": "comfyui",
+      "version": "0.22.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-31T13:19:53.783Z"
+    },
+    {
       "project": "cloud",
       "version": "0.23.0",
       "locales": [
@@ -275,6 +289,20 @@
       "published_at": "2026-06-25T06:08:07.770Z"
     },
     {
+      "project": "comfyui",
+      "version": "0.26.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-31T13:20:03.540Z"
+    },
+    {
       "project": "cloud",
       "version": "0.27.0",
       "locales": [
@@ -413,6 +441,34 @@
         "zh"
       ],
       "published_at": "2026-07-19T03:16:21.011Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.29.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-31T13:20:13.310Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.29.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-07-31T13:20:22.647Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="July 31, 2026">
+
+**Partner Node Updates**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Adds Ideogram P-Image model support
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Adds MiniMax H3 model support
+
+</Update>
+
+<Update label="v0.29.0" description="July 29, 2026">
+
+**New Open-Source Model Support**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Native JoyImageEdit model support
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B model support
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow model support
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Native Uni3C ControlNet support for Wan models
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite control model support
+
+**New Node Updates**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Video processing nodes and Image Processing Node video support
+
+**Partner Node Updates**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 models and V4 image edit nodes
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual model support
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models, including Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models, including Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="July 18, 2026">
 
 **Partner Node Updates**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="June 25, 2026">
 
 **Partner Node Updates**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Added ByteDance SeeDance 2.0 Mini on Text-to-Video, First-Last-Frame, and Reference nodes
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Added ByteDance SeeDance 2.0 Mini on Text-to-Video, First-Last-Frame, and Reference nodes
 
 </Update>
 
@@ -141,6 +169,14 @@ New Open-Source Model Support
 
 Partner Node Updates
 * **OpenRouter LLM Node**: Partner node for OpenRouter language model API
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Partner Node Updates**
+* **Krea2 Image nodes**: Added new image generation nodes for Krea2 workflows
+* **SeeDance 2**: Improved video reference uploading via memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 de julio de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Añade soporte para el modelo Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Añade soporte para el modelo MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 de julio de 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Soporte nativo para el modelo JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Soporte para el modelo Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): Soporte para el modelo MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Soporte nativo para Uni3C ControlNet en modelos Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Soporte para el modelo de control Anima llite
+
+**Nuevas actualizaciones de nodos**
+* [**Procesamiento de video para Trainer**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Nodos de procesamiento de video y soporte de video en el nodo de procesamiento de imágenes
+
+**Actualizaciones de nodos de socios**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Modelos Recraft V4.1 y nodos de edición de imágenes V4
+* [**ByteDance audio multilingüe**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Soporte para el modelo ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter, incluido Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic, incluido Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="July 18, 2026">
 
 **Actualizaciones de nodos asociados**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="Junio 25, 2026">
+<Update label="v0.26.2" description="25 de junio de 2026">
 
-**Actualizaciones de Nodos Asociados**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Añadido ByteDance SeeDance 2.0 Mini en nodos de Texto a Video, Primer-Último Fotograma y Referencia
+**Actualizaciones de nodos Partner**
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Se añadió ByteDance SeeDance 2.0 Mini en los nodos Text-to-Video, First-Last-Frame y Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ Nuevo soporte para modelos de código abierto
 
 Actualizaciones de nodos asociados
 * **OpenRouter LLM Node**: Nodo asociado para la API de modelo de lenguaje de OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Actualizaciones de nodos asociados**
+* **Nodos de imagen Krea2**: Se añadieron nuevos nodos de generación de imágenes para flujos de trabajo de Krea2
+* **SeeDance 2**: Se mejoró la carga de referencias de video mediante memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154) : Ajoute la prise en charge du modèle Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167) : Ajoute la prise en charge du modèle MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 juillet 2026">
+
+**Nouveau support de modèles open-source**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428) : support natif du modèle JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304) : support du modèle Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026) : support du modèle MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946) : support natif d'Uni3C ControlNet pour les modèles Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954) : support du modèle de contrôle Anima llite
+
+**Nouvelles mises à jour de nœuds**
+* [**Traitement vidéo Trainer**](https://github.com/Comfy-Org/ComfyUI/pull/13588) : nœuds de traitement vidéo et prise en charge vidéo du nœud de traitement d'images
+
+**Mise à jour des nœuds partenaires**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105) : modèles Recraft V4.1 et nœuds d'édition d'images V4
+* [**ByteDance audio multilingue**](https://github.com/Comfy-Org/ComfyUI/pull/15034) : support du modèle ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021) : nouveaux modèles OpenRouter, y compris Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023) : nouveaux modèles Anthropic, y compris Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="18 juillet 2026">
 
 **Mises à jour des nœuds partenaires**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="June 25, 2026">
+<Update label="v0.26.2" description="25 juin 2026">
 
 **Mises à jour des nœuds partenaires**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh) : Ajout de ByteDance SeeDance 2.0 Mini sur les nœuds Text-to-Video, First-Last-Frame et Reference
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ) : Ajout de ByteDance SeeDance 2.0 Mini sur les nœuds Text-to-Video, First-Last-Frame et Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ Prise en charge de nouveaux modèles open source
 
 Mises à jour des nœuds partenaires
 * **Nœud LLM OpenRouter** : Nœud partenaire pour l’API de modèle de langage OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="20 mai 2026">
+
+**Mises à jour des nœuds partenaires**
+* **Nœuds d'image Krea2** : Ajout de nouveaux nœuds de génération d'images pour les flux de travail Krea2
+* **SeeDance 2** : Amélioration du téléversement des références vidéo via memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026年7月31日">
+
+**パートナーノードの更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Image モデルのサポートを追加
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3 モデルのサポートを追加
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新規オープンソースモデルのサポート**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): JoyImageEdit モデルのネイティブサポート
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B モデルのサポート
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow モデルのサポート
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan モデル向け Uni3C ControlNet のネイティブサポート
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite コントロールモデルのサポート
+
+**新規ノードの更新**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): ビデオ処理ノードと Image Processing Node のビデオサポート
+
+**新規パートナーノードの更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 モデルと V4 画像編集ノード
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual モデルのサポート
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新しい OpenRouter モデル（Claude Opus 5 を含む）
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新しい Anthropic モデル（Claude Opus 5 を含む）
+
+</Update>
+
 <Update label="v0.28.2" description="2026年7月18日">
 
 **パートナーノード更新**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026年6月25日">
 
 **パートナーノードの更新**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): テキストから動画へノード、First-Last-Frameノード、ReferenceノードにByteDance SeeDance 2.0 Miniを追加しました
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): テキストから動画へ、First-Last-Frame、および Reference ノードに ByteDance SeeDance 2.0 Mini を追加
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 パートナーノードの更新
 * **OpenRouter LLM Node**: OpenRouter言語モデルAPI向けのパートナーノード
+
+</Update>
+
+<Update label="v0.22.3" description="2026年5月20日">
+
+**パートナーノードの更新**
+* **Krea2 画像ノード**: Krea2 ワークフロー向けの新しい画像生成ノードを追加しました
+* **SeeDance 2**: ビデオリファレンスのアップロードをmemoryview経由で改善しました
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026년 7월 31일">
+
+**파트너 노드 업데이트**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Image 모델 지원 추가
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3 모델 지원 추가
+
+</Update>
+
+<Update label="v0.29.0" description="2026년 7월 29일">
+
+**새로운 오픈소스 모델 지원**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): 네이티브 JoyImageEdit 모델 지원
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B 모델 지원
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow 모델 지원
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan 모델을 위한 네이티브 Uni3C 컨트롤넷 지원
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite 컨트롤 모델 지원
+
+**새로운 노드 업데이트**
+* [**Trainer 비디오 처리**](https://github.com/Comfy-Org/ComfyUI/pull/13588): 비디오 처리 노드 및 이미지 처리 노드의 비디오 지원
+
+**파트너 노드 업데이트**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 모델 및 V4 이미지 편집 노드
+* [**ByteDance 오디오 다국어**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual 모델 지원
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델, Claude Opus 5 포함
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델, Claude Opus 5 포함
+
+</Update>
+
 <Update label="v0.28.2" description="2026년 7월 18일">
 
 **파트너 노드 업데이트**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026년 6월 25일">
 
 **파트너 노드 업데이트**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): 텍스트 기반 비디오 생성, 첫 번째-마지막 프레임 및 참조 노드에 ByteDance SeeDance 2.0 Mini 추가
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): 텍스트 기반 비디오 생성(Text-to-Video), First-Last-Frame 및 Reference 노드에 ByteDance SeeDance 2.0 Mini를 추가했습니다.
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 파트너 노드 업데이트
 * **OpenRouter LLM 노드**: OpenRouter 언어 모델 API를 위한 파트너 노드
+
+</Update>
+
+<Update label="v0.22.3" description="2026년 5월 20일">
+
+**파트너 노드 업데이트**
+* **Krea2 이미지 노드**: Krea2 워크플로를 위한 새로운 이미지 생성 노드 추가
+* **SeeDance 2**: memoryview를 통한 비디오 참조 업로드 개선
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 июля 2026 г.">
+
+**Обновления партнёрских узлов**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Добавляет поддержку модели Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Добавляет поддержку модели MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 июля 2026">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Нативная поддержка моделей JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Поддержка модели Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): Поддержка модели MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Нативная поддержка Uni3C ControlNet для моделей Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Поддержка управляющей модели Anima llite
+
+**Обновления новых узлов**
+* [**Trainer: обработка видео**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Узлы обработки видео и поддержка видео в узле Image Processing Node
+
+**Обновления партнерских узлов**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Модели Recraft V4.1 и узлы редактирования изображений V4
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Поддержка модели ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter, включая Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic, включая Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="18 июля 2026 г.">
 
 **Обновления партнерских узлов**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="25 июня 2026 г.">
+<Update label="v0.26.2" description="25 июня 2026 года">
 
 **Обновления партнерских узлов**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Добавлен ByteDance SeeDance 2.0 Mini для узлов Text-to-Video, First-Last-Frame и Reference
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Добавлена поддержка ByteDance SeeDance 2.0 Mini в узлах Text-to-Video, First-Last-Frame и Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 Обновления партнёрских узлов
 * **Узел OpenRouter LLM**: Партнёрский узел для API языковой модели OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Обновления партнёрских узлов**
+* **Узлы изображений Krea2**: Добавлены новые узлы генерации изображений для рабочих процессов Krea2
+* **SeeDance 2**: Улучшена загрузка видеореференсов через memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026年7月31日">
+
+**合作伙伴节点更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154)：新增 Ideogram P-Image 模型支持
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167)：新增 MiniMax H3 模型支持
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新增开源模型支持**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428)：JoyImageEdit 原生模型支持
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304)：Gemma4 12B 模型支持
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026)：MageFlow 模型支持
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946)：为 Wan万相模型提供原生 Uni3C ControlNet 支持
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954)：Anima llite 控制模型支持
+
+**新增节点更新**
+* [**Trainer 视频处理**](https://github.com/Comfy-Org/ComfyUI/pull/13588)：视频处理节点与图像处理节点的视频支持
+
+**合作伙伴节点更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105)：Recraft V4.1 模型与 V4 图像编辑节点
+* [**字节跳动音频多语言**](https://github.com/Comfy-Org/ComfyUI/pull/15034)：字节跳动 audio-1.0-multilingual 模型支持
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021)：新增 OpenRouter 模型，包括 Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023)：新增 Anthropic 模型，包括 Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="2026年7月18日">
 
 **合作伙伴节点更新**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026年6月25日">
 
 **合作伙伴节点更新**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh)：在文生视频、首尾帧和参考节点中新增了字节跳动 SeeDance 2.0 Mini 支持
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ)：在文生视频、首尾帧和参考节点上新增了字节跳动 SeeDance 2.0 Mini
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 合作伙伴节点更新
 * **OpenRouter LLM 节点**：面向OpenRouter语言模型API的合作伙伴节点
+
+</Update>
+
+<Update label="v0.22.3" description="2026年5月20日">
+
+**合作伙伴节点更新**
+* **Krea2 图像节点**：为 Krea2 工作流添加了新的图像生成节点
+* **SeeDance 2**：改进了通过 memoryview 上传参考视频的功能
 
 </Update>
 

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="July 31, 2026">
+
+**Partner Node Updates**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Adds Ideogram P-Image model support
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Adds MiniMax H3 model support
+
+</Update>
+
+<Update label="v0.29.0" description="July 29, 2026">
+
+**New Open-Source Model Support**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Native JoyImageEdit model support
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B model support
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow model support
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Native Uni3C ControlNet support for Wan models
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite control model support
+
+**New Node Updates**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Video processing nodes and Image Processing Node video support
+
+**Partner Node Updates**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 models and V4 image edit nodes
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual model support
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models, including Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models, including Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="July 18, 2026">
 
 **Partner Node Updates**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="June 25, 2026">
 
 **Partner Node Updates**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Added ByteDance SeeDance 2.0 Mini on Text-to-Video, First-Last-Frame, and Reference nodes
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Added ByteDance SeeDance 2.0 Mini on Text-to-Video, First-Last-Frame, and Reference nodes
 
 </Update>
 
@@ -141,6 +169,14 @@ New Open-Source Model Support
 
 Partner Node Updates
 * **OpenRouter LLM Node**: Partner node for OpenRouter language model API
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Partner Node Updates**
+* **Krea2 Image nodes**: Added new image generation nodes for Krea2 workflows
+* **SeeDance 2**: Improved video reference uploading via memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 de julio de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Añade soporte para el modelo Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Añade soporte para el modelo MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 de julio de 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Soporte nativo para el modelo JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Soporte para el modelo Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): Soporte para el modelo MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Soporte nativo para Uni3C ControlNet en modelos Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Soporte para el modelo de control Anima llite
+
+**Nuevas actualizaciones de nodos**
+* [**Procesamiento de video para Trainer**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Nodos de procesamiento de video y soporte de video en el nodo de procesamiento de imágenes
+
+**Actualizaciones de nodos de socios**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Modelos Recraft V4.1 y nodos de edición de imágenes V4
+* [**ByteDance audio multilingüe**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Soporte para el modelo ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter, incluido Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic, incluido Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="July 18, 2026">
 
 **Actualizaciones de nodos asociados**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="Junio 25, 2026">
+<Update label="v0.26.2" description="25 de junio de 2026">
 
-**Actualizaciones de Nodos Asociados**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Añadido ByteDance SeeDance 2.0 Mini en nodos de Texto a Video, Primer-Último Fotograma y Referencia
+**Actualizaciones de nodos Partner**
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Se añadió ByteDance SeeDance 2.0 Mini en los nodos Text-to-Video, First-Last-Frame y Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ Nuevo soporte para modelos de código abierto
 
 Actualizaciones de nodos asociados
 * **OpenRouter LLM Node**: Nodo asociado para la API de modelo de lenguaje de OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Actualizaciones de nodos asociados**
+* **Nodos de imagen Krea2**: Se añadieron nuevos nodos de generación de imágenes para flujos de trabajo de Krea2
+* **SeeDance 2**: Se mejoró la carga de referencias de video mediante memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 juillet 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154) : Ajoute la prise en charge du modèle Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167) : Ajoute la prise en charge du modèle MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 juillet 2026">
+
+**Nouveau support de modèles open-source**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428) : support natif du modèle JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304) : support du modèle Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026) : support du modèle MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946) : support natif d'Uni3C ControlNet pour les modèles Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954) : support du modèle de contrôle Anima llite
+
+**Nouvelles mises à jour de nœuds**
+* [**Traitement vidéo Trainer**](https://github.com/Comfy-Org/ComfyUI/pull/13588) : nœuds de traitement vidéo et prise en charge vidéo du nœud de traitement d'images
+
+**Mise à jour des nœuds partenaires**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105) : modèles Recraft V4.1 et nœuds d'édition d'images V4
+* [**ByteDance audio multilingue**](https://github.com/Comfy-Org/ComfyUI/pull/15034) : support du modèle ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021) : nouveaux modèles OpenRouter, y compris Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023) : nouveaux modèles Anthropic, y compris Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="18 juillet 2026">
 
 **Mises à jour des nœuds partenaires**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="June 25, 2026">
+<Update label="v0.26.2" description="25 juin 2026">
 
 **Mises à jour des nœuds partenaires**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh) : Ajout de ByteDance SeeDance 2.0 Mini sur les nœuds Text-to-Video, First-Last-Frame et Reference
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ) : Ajout de ByteDance SeeDance 2.0 Mini sur les nœuds Text-to-Video, First-Last-Frame et Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ Prise en charge de nouveaux modèles open source
 
 Mises à jour des nœuds partenaires
 * **Nœud LLM OpenRouter** : Nœud partenaire pour l’API de modèle de langage OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="20 mai 2026">
+
+**Mises à jour des nœuds partenaires**
+* **Nœuds d'image Krea2** : Ajout de nouveaux nœuds de génération d'images pour les flux de travail Krea2
+* **SeeDance 2** : Amélioration du téléversement des références vidéo via memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026年7月31日">
+
+**パートナーノードの更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Image モデルのサポートを追加
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3 モデルのサポートを追加
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新規オープンソースモデルのサポート**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): JoyImageEdit モデルのネイティブサポート
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B モデルのサポート
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow モデルのサポート
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan モデル向け Uni3C ControlNet のネイティブサポート
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite コントロールモデルのサポート
+
+**新規ノードの更新**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): ビデオ処理ノードと Image Processing Node のビデオサポート
+
+**新規パートナーノードの更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 モデルと V4 画像編集ノード
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual モデルのサポート
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新しい OpenRouter モデル（Claude Opus 5 を含む）
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新しい Anthropic モデル（Claude Opus 5 を含む）
+
+</Update>
+
 <Update label="v0.28.2" description="2026年7月18日">
 
 **パートナーノード更新**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026年6月25日">
 
 **パートナーノードの更新**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): テキストから動画へノード、First-Last-Frameノード、ReferenceノードにByteDance SeeDance 2.0 Miniを追加しました
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): テキストから動画へ、First-Last-Frame、および Reference ノードに ByteDance SeeDance 2.0 Mini を追加
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 パートナーノードの更新
 * **OpenRouter LLM Node**: OpenRouter言語モデルAPI向けのパートナーノード
+
+</Update>
+
+<Update label="v0.22.3" description="2026年5月20日">
+
+**パートナーノードの更新**
+* **Krea2 画像ノード**: Krea2 ワークフロー向けの新しい画像生成ノードを追加しました
+* **SeeDance 2**: ビデオリファレンスのアップロードをmemoryview経由で改善しました
 
 </Update>
 

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026년 7월 31일">
+
+**파트너 노드 업데이트**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Image 모델 지원 추가
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3 모델 지원 추가
+
+</Update>
+
+<Update label="v0.29.0" description="2026년 7월 29일">
+
+**새로운 오픈소스 모델 지원**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): 네이티브 JoyImageEdit 모델 지원
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B 모델 지원
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow 모델 지원
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan 모델을 위한 네이티브 Uni3C 컨트롤넷 지원
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite 컨트롤 모델 지원
+
+**새로운 노드 업데이트**
+* [**Trainer 비디오 처리**](https://github.com/Comfy-Org/ComfyUI/pull/13588): 비디오 처리 노드 및 이미지 처리 노드의 비디오 지원
+
+**파트너 노드 업데이트**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 모델 및 V4 이미지 편집 노드
+* [**ByteDance 오디오 다국어**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual 모델 지원
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델, Claude Opus 5 포함
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델, Claude Opus 5 포함
+
+</Update>
+
 <Update label="v0.28.2" description="2026년 7월 18일">
 
 **파트너 노드 업데이트**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026년 6월 25일">
 
 **파트너 노드 업데이트**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): 텍스트 기반 비디오 생성, 첫 번째-마지막 프레임 및 참조 노드에 ByteDance SeeDance 2.0 Mini 추가
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): 텍스트 기반 비디오 생성(Text-to-Video), First-Last-Frame 및 Reference 노드에 ByteDance SeeDance 2.0 Mini를 추가했습니다.
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 파트너 노드 업데이트
 * **OpenRouter LLM 노드**: OpenRouter 언어 모델 API를 위한 파트너 노드
+
+</Update>
+
+<Update label="v0.22.3" description="2026년 5월 20일">
+
+**파트너 노드 업데이트**
+* **Krea2 이미지 노드**: Krea2 워크플로를 위한 새로운 이미지 생성 노드 추가
+* **SeeDance 2**: memoryview를 통한 비디오 참조 업로드 개선
 
 </Update>
 

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="31 июля 2026 г.">
+
+**Обновления партнёрских узлов**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Добавляет поддержку модели Ideogram P-Image
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Добавляет поддержку модели MiniMax H3
+
+</Update>
+
+<Update label="v0.29.0" description="29 июля 2026">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Нативная поддержка моделей JoyImageEdit
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Поддержка модели Gemma4 12B
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): Поддержка модели MageFlow
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Нативная поддержка Uni3C ControlNet для моделей Wan
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Поддержка управляющей модели Anima llite
+
+**Обновления новых узлов**
+* [**Trainer: обработка видео**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Узлы обработки видео и поддержка видео в узле Image Processing Node
+
+**Обновления партнерских узлов**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Модели Recraft V4.1 и узлы редактирования изображений V4
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Поддержка модели ByteDance audio-1.0-multilingual
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter, включая Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic, включая Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="18 июля 2026 г.">
 
 **Обновления партнерских узлов**
@@ -68,10 +96,10 @@ cmsStaging: true
 
 </Update>
 
-<Update label="v0.26.2" description="25 июня 2026 г.">
+<Update label="v0.26.2" description="25 июня 2026 года">
 
 **Обновления партнерских узлов**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh): Добавлен ByteDance SeeDance 2.0 Mini для узлов Text-to-Video, First-Last-Frame и Reference
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ): Добавлена поддержка ByteDance SeeDance 2.0 Mini в узлах Text-to-Video, First-Last-Frame и Reference
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 Обновления партнёрских узлов
 * **Узел OpenRouter LLM**: Партнёрский узел для API языковой модели OpenRouter
+
+</Update>
+
+<Update label="v0.22.3" description="May 20, 2026">
+
+**Обновления партнёрских узлов**
+* **Узлы изображений Krea2**: Добавлены новые узлы генерации изображений для рабочих процессов Krea2
+* **SeeDance 2**: Улучшена загрузка видеореференсов через memoryview
 
 </Update>
 

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,34 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.29.2" description="2026年7月31日">
+
+**合作伙伴节点更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154)：新增 Ideogram P-Image 模型支持
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167)：新增 MiniMax H3 模型支持
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新增开源模型支持**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428)：JoyImageEdit 原生模型支持
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304)：Gemma4 12B 模型支持
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026)：MageFlow 模型支持
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946)：为 Wan万相模型提供原生 Uni3C ControlNet 支持
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954)：Anima llite 控制模型支持
+
+**新增节点更新**
+* [**Trainer 视频处理**](https://github.com/Comfy-Org/ComfyUI/pull/13588)：视频处理节点与图像处理节点的视频支持
+
+**合作伙伴节点更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105)：Recraft V4.1 模型与 V4 图像编辑节点
+* [**字节跳动音频多语言**](https://github.com/Comfy-Org/ComfyUI/pull/15034)：字节跳动 audio-1.0-multilingual 模型支持
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021)：新增 OpenRouter 模型，包括 Claude Opus 5
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023)：新增 Anthropic 模型，包括 Claude Opus 5
+
+</Update>
+
 <Update label="v0.28.2" description="2026年7月18日">
 
 **合作伙伴节点更新**
@@ -71,7 +99,7 @@ cmsStaging: true
 <Update label="v0.26.2" description="2026年6月25日">
 
 **合作伙伴节点更新**
-* [**SeeDance 2.0 Mini**](https://links.comfy.org/4aGBKxh)：在文生视频、首尾帧和参考节点中新增了字节跳动 SeeDance 2.0 Mini 支持
+* [**SeeDance 2.0 Mini**](https://links.comfy.org/4eOUnjJ)：在文生视频、首尾帧和参考节点上新增了字节跳动 SeeDance 2.0 Mini
 
 </Update>
 
@@ -141,6 +169,14 @@ cmsStaging: true
 
 合作伙伴节点更新
 * **OpenRouter LLM 节点**：面向OpenRouter语言模型API的合作伙伴节点
+
+</Update>
+
+<Update label="v0.22.3" description="2026年5月20日">
+
+**合作伙伴节点更新**
+* **Krea2 图像节点**：为 Krea2 工作流添加了新的图像生成节点
+* **SeeDance 2**：改进了通过 memoryview 上传参考视频的功能
 
 </Update>
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,61 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.29.2" description="July 31, 2026">
+
+**Partner Node Updates**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Added Ideogram P-Image model support
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): Added MiniMax H3 model support
+
+</Update>
+
+<Update label="v0.29.1" description="July 31, 2026">
+
+**Bug Fixes**
+* [**user.css**](https://github.com/Comfy-Org/ComfyUI/pull/15000): Fixed `user.css` loading broken by a prior frontend change
+* [**SVG previews**](https://github.com/Comfy-Org/ComfyUI/pull/15149): Fixed SVG node output and Media Assets previews after stored-XSS download hardening
+
+</Update>
+
+<Update label="v0.29.0" description="July 29, 2026">
+
+**New Open-Source Model Support**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): Native JoyImageEdit model support
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B model support (CORE-277)
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow model support (CORE-372)
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Native Uni3C ControlNet support for Wan models (CORE-365)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite control model support
+
+**New Nodes**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): Video processing nodes, Image Processing Node video support, and trainer video support (CORE-81)
+
+**Partner Node Updates**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 models and V4 image edit nodes
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual model
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models, including [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15075)
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models, including [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15079)
+* [**Runway Gen3a deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/15050): Deprecated Runway Gen3a model
+
+**Performance & Stability**
+* [**Video transcode**](https://github.com/Comfy-Org/ComfyUI/pull/14813): Stream video transcode instead of buffering every frame in RAM (CORE-353, CORE-351)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14953): Faster Anima inference
+* [**Comfy Kitchen**](https://github.com/Comfy-Org/ComfyUI/pull/14963): Comfy Kitchen optimizations and fixes, plus [more int8 optimizations](https://github.com/Comfy-Org/ComfyUI/pull/14980)
+* [**Krea 2 reference images**](https://github.com/Comfy-Org/ComfyUI/pull/14843): Regular and timestep-zero reference images for Krea 2 Ostris and identity edit ref LoRAs
+* [**FreSca**](https://github.com/Comfy-Org/ComfyUI/pull/15007): FreSca 5D+ (e.g. Anima) fix and model-agnostic iteration
+* [**Latent upscaler**](https://github.com/Comfy-Org/ComfyUI/pull/15063): Converted `latent_upsampler` model to ModelPatcherDynamic
+* [**Background usage clamp**](https://github.com/Comfy-Org/ComfyUI/pull/15068): Default background usage clamp raised to 128GB
+* [**gfx1035**](https://github.com/Comfy-Org/ComfyUI/pull/15009): Fixed gfx1035 not being treated like RDNA2
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15045): Bumped comfyui-frontend-package to 1.47.10
+
+**Bug Fixes**
+* [**Wan dancer batches**](https://github.com/Comfy-Org/ComfyUI/pull/14999): Fixed Wan dancer issue with batches
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pass videos as inline data in Gemini Omni partner node
+* [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): Fixed MageFlow on cards that don't support bf16
+* [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): Improved LTXV IC-LoRA detection
+* [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): Allow float fps for LTXVEmptyLatentAudio
+
+</Update>
+
 <Update label="v0.28.2" description="July 18, 2026">
 
 **Partner Node Updates**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 7082b633
+translationSourceHash: 2c0fe8fb
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.29.2": a168cef8
+  "v0.29.1": 3b558eb8
+  "v0.29.0": 7beaa255
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -108,7 +111,60 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.29.2" description="2026年7月31日">
 
+**パートナーノードの更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Imageモデルのサポートを追加
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3モデルのサポートを追加
+
+</Update>
+
+<Update label="v0.29.1" description="2026年7月31日">
+
+**バグ修正**
+* [**user.css**](https://github.com/Comfy-Org/ComfyUI/pull/15000): 以前のフロントエンド変更により壊れていた `user.css` の読み込みを修正しました
+* [**SVG プレビュー**](https://github.com/Comfy-Org/ComfyUI/pull/15149): 保存型XSS対策のダウンロード堅牢化後に、SVG ノード出力とメディアアセットのプレビューを修正しました
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新規オープンソースモデルのサポート**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): JoyImageEdit モデルのネイティブサポート
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B モデルのサポート (CORE-277)
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow モデルのサポート (CORE-372)
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan モデル向け Uni3C コントロールネットのネイティブサポート (CORE-365)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite コントロールモデルのサポート
+
+**新規ノード**
+* [**Trainer video processing**](https://github.com/Comfy-Org/ComfyUI/pull/13588): ビデオ処理ノード、Image Processing Node のビデオサポート、トレーナーのビデオサポート (CORE-81)
+
+**パートナーノードの更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 モデルと V4 画像編集ノード
+* [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual モデル
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15075) を含む新しい OpenRouter モデル
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15079) を含む新しい Anthropic モデル
+* [**Runway Gen3a deprecated**](https://github.com/Comfy-Org/ComfyUI/pull/15050): Runway Gen3a モデルを非推奨に変更
+
+**パフォーマンスと安定性**
+* [**Video transcode**](https://github.com/Comfy-Org/ComfyUI/pull/14813): すべてのフレームを RAM にバッファリングする代わりに、ビデオトランスコードをストリーミング処理 (CORE-353, CORE-351)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14953): Anima の推論を高速化
+* [**Comfy Kitchen**](https://github.com/Comfy-Org/ComfyUI/pull/14963): Comfy Kitchen の最適化と修正、さらに [int8 の最適化](https://github.com/Comfy-Org/ComfyUI/pull/14980)
+* [**Krea 2 reference images**](https://github.com/Comfy-Org/ComfyUI/pull/14843): Krea 2 Ostris および identity edit ref LoRA 用の通常の参照画像とタイムステップゼロの参照画像
+* [**FreSca**](https://github.com/Comfy-Org/ComfyUI/pull/15007): FreSca 5D+（例：Anima）の修正とモデル非依存の反復処理
+* [**Latent upscaler**](https://github.com/Comfy-Org/ComfyUI/pull/15063): `latent_upsampler` モデルを ModelPatcherDynamic に変換
+* [**Background usage clamp**](https://github.com/Comfy-Org/ComfyUI/pull/15068): デフォルトのバックグラウンド使用量クランプを 128GB に引き上げ
+* [**gfx1035**](https://github.com/Comfy-Org/ComfyUI/pull/15009): gfx1035 が RDNA2 として扱われない問題を修正
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15045): comfyui-frontend-package を 1.47.10 に更新
+
+**バグ修正**
+* [**Wan dancer batches**](https://github.com/Comfy-Org/ComfyUI/pull/14999): バッチにおける Wan ダンサーの問題を修正
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni パートナーノードでビデオをインラインデータとして渡すように修正
+* [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): bf16 をサポートしないカードでの MageFlow の問題を修正
+* [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): LTXV IC-LoRA の検出を改善
+* [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): LTXVEmptyLatentAudio で浮動小数点の fps を許可
+
+</Update>
 
 <Update label="v0.28.2" description="2026年7月18日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 7082b633
+translationSourceHash: 2c0fe8fb
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.29.2": a168cef8
+  "v0.29.1": 3b558eb8
+  "v0.29.0": 7beaa255
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -108,7 +111,60 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.29.2" description="2026년 7월 31일">
 
+**파트너 노드 업데이트**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): Ideogram P-Image 모델 지원 추가
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): MiniMax H3 모델 지원 추가
+
+</Update>
+
+<Update label="v0.29.1" description="2026년 7월 31일">
+
+**버그 수정**
+* [**user.css**](https://github.com/Comfy-Org/ComfyUI/pull/15000): 이전 프론트엔드 변경으로 깨진 `user.css` 로딩을 수정했습니다
+* [**SVG 미리보기**](https://github.com/Comfy-Org/ComfyUI/pull/15149): 저장형 XSS 다운로드 강화 이후 SVG 노드 출력 및 미디어 에셋 미리보기를 수정했습니다
+
+</Update>
+
+<Update label="v0.29.0" description="2026년 7월 29일">
+
+**새로운 오픈소스 모델 지원**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): 기본 JoyImageEdit 모델 지원
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B 모델 지원 (CORE-277)
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow 모델 지원 (CORE-372)
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): Wan 모델용 기본 Uni3C 컨트롤넷 지원 (CORE-365)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite 컨트롤 모델 지원
+
+**새로운 노드**
+* [**트레이너 비디오 처리**](https://github.com/Comfy-Org/ComfyUI/pull/13588): 비디오 처리 노드, 이미지 처리 노드의 비디오 지원, 트레이너 비디오 지원 (CORE-81)
+
+**파트너 노드 업데이트**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 모델 및 V4 이미지 편집 노드
+* [**ByteDance 오디오 다국어**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual 모델
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15075)를 포함한 새로운 OpenRouter 모델
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15079)를 포함한 새로운 Anthropic 모델
+* [**Runway Gen3a 지원 중단**](https://github.com/Comfy-Org/ComfyUI/pull/15050): 지원 중단된 Runway Gen3a 모델
+
+**성능 및 안정성**
+* [**비디오 트랜스코드**](https://github.com/Comfy-Org/ComfyUI/pull/14813): 모든 프레임을 RAM에 버퍼링하는 대신 비디오 트랜스코드를 스트리밍 (CORE-353, CORE-351)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14953): 더 빠른 Anima 추론
+* [**Comfy Kitchen**](https://github.com/Comfy-Org/ComfyUI/pull/14963): Comfy Kitchen 최적화 및 수정, [추가 int8 최적화](https://github.com/Comfy-Org/ComfyUI/pull/14980) 포함
+* [**Krea 2 참조 이미지**](https://github.com/Comfy-Org/ComfyUI/pull/14843): Krea 2 Ostris 및 identity edit ref LoRA용 일반 및 timestep-zero 참조 이미지
+* [**FreSca**](https://github.com/Comfy-Org/ComfyUI/pull/15007): FreSca 5D+ (예: Anima) 수정 및 모델 무관 반복
+* [**잠재 데이터 업스케일러**](https://github.com/Comfy-Org/ComfyUI/pull/15063): `latent_upsampler` 모델을 ModelPatcherDynamic으로 변환
+* [**배경 사용량 상한**](https://github.com/Comfy-Org/ComfyUI/pull/15068): 기본 배경 사용량 상한을 128GB로 상향
+* [**gfx1035**](https://github.com/Comfy-Org/ComfyUI/pull/15009): gfx1035가 RDNA2처럼 처리되지 않던 문제 수정
+* [**프런트엔드**](https://github.com/Comfy-Org/ComfyUI/pull/15045): comfyui-frontend-package를 1.47.10으로 업그레이드
+
+**버그 수정**
+* [**Wan 댄서 배치**](https://github.com/Comfy-Org/ComfyUI/pull/14999): 배치 처리 시 Wan 댄서 문제 수정
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni 파트너 노드에서 비디오를 인라인 데이터로 전달
+* [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): bf16을 지원하지 않는 카드에서 MageFlow 문제 수정
+* [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): LTXV IC-LoRA 감지 개선
+* [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): LTXVEmptyLatentAudio에서 실수 fps 허용
+
+</Update>
 
 <Update label="v0.28.2" description="2026년 7월 18일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 7082b633
+translationSourceHash: 2c0fe8fb
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.29.2": a168cef8
+  "v0.29.1": 3b558eb8
+  "v0.29.0": 7beaa255
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -108,8 +111,60 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.29.2" description="2026年7月31日">
 
+**合作伙伴节点更新**
+* [**Ideogram P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15154): 添加了 Ideogram P-Image 模型支持
+* [**MiniMax H3**](https://github.com/Comfy-Org/ComfyUI/pull/15167): 添加了 MiniMax H3 模型支持
 
+</Update>
+
+<Update label="v0.29.1" description="2026年7月31日">
+
+**问题修复**
+* [**user.css**](https://github.com/Comfy-Org/ComfyUI/pull/15000): 修复了先前前端更改导致的 `user.css` 加载失效问题
+* [**SVG 预览**](https://github.com/Comfy-Org/ComfyUI/pull/15149): 修复了存储型 XSS 下载加固之后的 SVG 节点输出和媒体资产预览问题
+
+</Update>
+
+<Update label="v0.29.0" description="2026年7月29日">
+
+**新增开源模型支持**
+* [**JoyImageEdit**](https://github.com/Comfy-Org/ComfyUI/pull/14428): 原生 JoyImageEdit 模型支持
+* [**Gemma4 12B**](https://github.com/Comfy-Org/ComfyUI/pull/14304): Gemma4 12B 模型支持 (CORE-277)
+* [**MageFlow**](https://github.com/Comfy-Org/ComfyUI/pull/15026): MageFlow 模型支持 (CORE-372)
+* [**Uni3C ControlNet**](https://github.com/Comfy-Org/ComfyUI/pull/14946): 针对 Wan 万相模型的原生 Uni3C ControlNet 支持 (CORE-365)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14954): Anima llite 控制模型支持
+
+**新节点**
+* [**Trainer 视频处理**](https://github.com/Comfy-Org/ComfyUI/pull/13588): 视频处理节点、图像处理节点的视频支持，以及 trainer 视频支持 (CORE-81)
+
+**合作伙伴节点更新**
+* [**Recraft V4.1**](https://github.com/Comfy-Org/ComfyUI/pull/15105): Recraft V4.1 模型及 V4 图像编辑节点
+* [**字节跳动多语言音频**](https://github.com/Comfy-Org/ComfyUI/pull/15034): 字节跳动 audio-1.0-multilingual 模型
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新增 OpenRouter 模型，包括 [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15075)
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新增 Anthropic 模型，包括 [Claude Opus 5](https://github.com/Comfy-Org/ComfyUI/pull/15079)
+* [**弃用 Runway Gen3a**](https://github.com/Comfy-Org/ComfyUI/pull/15050): 弃用 Runway Gen3a 模型
+
+**性能与稳定性**
+* [**视频转码**](https://github.com/Comfy-Org/ComfyUI/pull/14813): 以流式方式转码视频，而不是在 RAM 中缓冲每一帧 (CORE-353, CORE-351)
+* [**Anima**](https://github.com/Comfy-Org/ComfyUI/pull/14953): 更快的 Anima 推理
+* [**Comfy Kitchen**](https://github.com/Comfy-Org/ComfyUI/pull/14963): Comfy Kitchen 优化与修复，以及[更多 int8 优化](https://github.com/Comfy-Org/ComfyUI/pull/14980)
+* [**Krea 2 参考图像**](https://github.com/Comfy-Org/ComfyUI/pull/14843): 用于 Krea 2 Ostris 和 identity edit ref LoRA 的常规及 timestep-zero 参考图像
+* [**FreSca**](https://github.com/Comfy-Org/ComfyUI/pull/15007): FreSca 5D+（例如 Anima）修复及模型无关的迭代
+* [**Latent 放大器**](https://github.com/Comfy-Org/ComfyUI/pull/15063): 将 `latent_upsampler` 模型转换为 ModelPatcherDynamic
+* [**后台使用上限**](https://github.com/Comfy-Org/ComfyUI/pull/15068): 默认后台使用上限提升至 128GB
+* [**gfx1035**](https://github.com/Comfy-Org/ComfyUI/pull/15009): 修复 gfx1035 未被当作 RDNA2 处理的问题
+* [**前端**](https://github.com/Comfy-Org/ComfyUI/pull/15045): 将 comfyui-frontend-package 升级至 1.47.10
+
+**Bug 修复**
+* [**Wan 万相舞者分批**](https://github.com/Comfy-Org/ComfyUI/pull/14999): 修复 Wan 万相舞者在分批处理时的问题
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): 在 Gemini Omni 合作伙伴节点中以内联数据方式传递视频
+* [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): 修复 MageFlow 在不支持 bf16 的显卡上的运行问题
+* [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): 改进 LTXV IC-LoRA 检测
+* [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): 允许 LTXVEmptyLatentAudio 使用浮点 fps
+
+</Update>
 
 <Update label="v0.28.2" description="2026年7月18日">
 


### PR DESCRIPTION
## Summary
- Add English docs changelog for **v0.29.0**, **v0.29.1**, and **v0.29.2** (JoyImageEdit, MageFlow, partner nodes, frontend fixes).
- Translate new blocks to **zh**, **ja**, and **ko**.
- Update CMS staging and `published-versions.json` after publishing **ComfyUI** release-note drafts for v0.29.2, v0.29.0, v0.26.2, and v0.22.3 (7 locales each).
- **v0.29.1** is docs-only (bug fixes); no CMS popup entry per simplify rules.
- **Cloud** CMS not synced or published in this batch.

## Test plan
- [ ] Mintlify preview: `changelog/index.mdx` renders v0.29.0 / v0.29.1 / v0.29.2 blocks
- [ ] zh/ja/ko changelog pages show matching translated blocks
- [ ] Strapi ComfyUI release notes show published v0.29.2 popup in app