### PR TITLE
docs: add ComfyUI v0.28.3, v0.30.0, and v0.30.1 changelog

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,48 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.30.1" description="August 3, 2026">
+
+**Performance & Stability**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): Bumped comfyui-frontend-package to 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="August 3, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 audio-video model support (CORE-375)
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAED support for faster LTX 2.3 decoding
+
+**New Nodes**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Added CRF option to Save Video node
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText node can save `.csv` output
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): VAEDecodeAudio can decode nested audio latents
+
+**Partner Node Updates**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Updated xAI nodes for grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Added 768P resolution for MiniMax H3 partner nodes
+
+**Performance & Stability**
+* [**int8 embedding lookup**](https://github.com/Comfy-Org/ComfyUI/pull/15035): int8 convrot embedding lookup for text generation models (CORE-371)
+* [**Weight pinning**](https://github.com/Comfy-Org/ComfyUI/pull/15027): Load weights to process RAM with MRU pinning infrastructure
+* [**Comfy Kitchen AMD**](https://github.com/Comfy-Org/ComfyUI/pull/15160): Comfy Kitchen AMD support
+* [**Dataset folder**](https://github.com/Comfy-Org/ComfyUI/pull/14807): Dataset folder path to avoid arbitrary directory access
+* [**DETAIL logging**](https://github.com/Comfy-Org/ComfyUI/pull/15064): Configurable DETAIL logging side channel (CORE-369)
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/15190): Expand k/v when attention would fall back to math for GQA
+* [**Nested latent previews**](https://github.com/Comfy-Org/ComfyUI/pull/15196): Latent previews for nested latents (e.g. LTXAV)
+* [**MP4 metadata**](https://github.com/Comfy-Org/ComfyUI/pull/15195): Store MP4 metadata at the beginning of the file when possible
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15161): Bumped comfyui-frontend-package to 1.47.11
+
+**Bug Fixes**
+* [**LTXAV**](https://github.com/Comfy-Org/ComfyUI/pull/15132): Fixed crash when sampling without an audio latent
+* [**Jobs preview**](https://github.com/Comfy-Org/ComfyUI/pull/14681): Prefer media over text for job `preview_output`
+* [**cuDNN attention**](https://github.com/Comfy-Org/ComfyUI/pull/15146): Fallback to cuDNN attention on Linux when Flash Attention fails
+* [**CurveEditor**](https://github.com/Comfy-Org/ComfyUI/pull/15152): Resend cached histogram UI for CurveEditor after page refresh
+* [**ByteDance stereo audio**](https://github.com/Comfy-Org/ComfyUI/pull/15177): Encode stereo reference audio without doubling duration
+
+</Update>
+
 <Update label="v0.29.2" description="July 31, 2026">
 
 **Partner Node Updates**
@@ -56,6 +98,15 @@ icon: "clock-rotate-left"
 * [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): Fixed MageFlow on cards that don't support bf16
 * [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): Improved LTXV IC-LoRA detection
 * [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): Allow float fps for LTXVEmptyLatentAudio
+
+</Update>
+
+<Update label="v0.28.3" description="July 22, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pass videos as inline data in Gemini Omni partner node
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models
 
 </Update>
 

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,12 +2,15 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 2c0fe8fb
+translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.30.1": c4818cfa
+  "v0.30.0": 4879519e
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
+  "v0.28.3": 55070a51
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -111,6 +114,48 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.30.1" description="2026年8月3日">
+
+**パフォーマンスと安定性**
+* [**フロントエンド**](https://github.com/Comfy-Org/ComfyUI/pull/15244): comfyui-frontend-package を 1.47.12 に更新しました
+
+</Update>
+
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新規オープンソースモデルサポート**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 オーディオビデオモデルサポート (CORE-375)
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): より高速な LTX 2.3 デコードのための PrunaVAED サポート
+
+**新規ノード**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Save Video ノードに CRF オプションを追加
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText ノードが `.csv` 出力を保存可能に
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): VAEDecodeAudio がネストされたオーディオ潜在をデコード可能に
+
+**パートナーノードの更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5 用に xAI ノードを更新
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3 パートナーノードに 768P 解像度を追加
+
+**パフォーマンスと安定性**
+* [**int8 embedding lookup**](https://github.com/Comfy-Org/ComfyUI/pull/15035): テキスト生成モデル向け int8 convrot embedding ルックアップ (CORE-371)
+* [**Weight pinning**](https://github.com/Comfy-Org/ComfyUI/pull/15027): MRU ピニング基盤で重みをプロセス RAM にロード
+* [**Comfy Kitchen AMD**](https://github.com/Comfy-Org/ComfyUI/pull/15160): Comfy Kitchen の AMD サポート
+* [**Dataset folder**](https://github.com/Comfy-Org/ComfyUI/pull/14807): 任意のディレクトリアクセスを回避するためのデータセットフォルダーパス
+* [**DETAIL logging**](https://github.com/Comfy-Org/ComfyUI/pull/15064): 設定可能な DETAIL ロギングサイドチャンネル (CORE-369)
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/15190): GQA でアテンションが math にフォールバックする場合に k/v を展開
+* [**Nested latent previews**](https://github.com/Comfy-Org/ComfyUI/pull/15196): ネストされた潜在 (例: LTXAV) の潜在プレビュー
+* [**MP4 metadata**](https://github.com/Comfy-Org/ComfyUI/pull/15195): 可能な場合、MP4 メタデータをファイルの先頭に保存
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15161): comfyui-frontend-package を 1.47.11 に更新
+
+**バグ修正**
+* [**LTXAV**](https://github.com/Comfy-Org/ComfyUI/pull/15132): オーディオ潜在なしでサンプリングした際のクラッシュを修正
+* [**Jobs preview**](https://github.com/Comfy-Org/ComfyUI/pull/14681): ジョブの `preview_output` でテキストよりメディアを優先
+* [**cuDNN attention**](https://github.com/Comfy-Org/ComfyUI/pull/15146): Flash Attention が失敗した場合、Linux で cuDNN アテンションにフォールバック
+* [**CurveEditor**](https://github.com/Comfy-Org/ComfyUI/pull/15152): ページ更新後に CurveEditor のキャッシュされたヒストグラム UI を再送信
+* [**ByteDance stereo audio**](https://github.com/Comfy-Org/ComfyUI/pull/15177): 再生時間を 2 倍にせずにステレオ参照オーディオをエンコード
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **パートナーノードの更新**
@@ -163,6 +208,15 @@ translationBlockHashes:
 * [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): bf16 をサポートしないカードでの MageFlow の問題を修正
 * [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): LTXV IC-LoRA の検出を改善
 * [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): LTXVEmptyLatentAudio で浮動小数点の fps を許可
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**パートナーノードの更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni パートナーノードでビデオをインラインデータとして渡す
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新しい OpenRouter モデル
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新しい Anthropic モデル
 
 </Update>
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,12 +2,15 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 2c0fe8fb
+translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.30.1": c4818cfa
+  "v0.30.0": 4879519e
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
+  "v0.28.3": 55070a51
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -111,6 +114,48 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.30.1" description="2026년 8월 3일">
+
+**성능 및 안정성**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): comfyui-frontend-package를 1.47.12로 업그레이드
+
+</Update>
+
+<Update label="v0.30.0" description="2026년 8월 3일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 오디오-비디오 모델 지원 (CORE-375)
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 더 빠른 LTX 2.3 디코딩을 위한 PrunaVAED 지원
+
+**새로운 노드**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Save Video 노드에 CRF 옵션 추가
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText 노드가 `.csv` 출력을 저장할 수 있음
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): VAEDecodeAudio가 중첩된 오디오 잠재 데이터를 디코딩할 수 있음
+
+**파트너 노드 업데이트**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5용 xAI 노드 업데이트
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3 파트너 노드에 768P 해상도 추가
+
+**성능 및 안정성**
+* [**int8 embedding lookup**](https://github.com/Comfy-Org/ComfyUI/pull/15035): 텍스트 생성 모델을 위한 int8 convrot 임베딩 조회 (CORE-371)
+* [**Weight pinning**](https://github.com/Comfy-Org/ComfyUI/pull/15027): MRU 고정 인프라를 사용하여 프로세스 RAM에 가중치 로드
+* [**Comfy Kitchen AMD**](https://github.com/Comfy-Org/ComfyUI/pull/15160): Comfy Kitchen AMD 지원
+* [**Dataset folder**](https://github.com/Comfy-Org/ComfyUI/pull/14807): 임의 디렉터리 접근을 방지하기 위한 데이터셋 폴더 경로
+* [**DETAIL logging**](https://github.com/Comfy-Org/ComfyUI/pull/15064): 구성 가능한 DETAIL 로깅 사이드 채널 (CORE-369)
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/15190): GQA에서 어텐션이 수학 연산으로 폴백되는 경우 k/v 확장
+* [**Nested latent previews**](https://github.com/Comfy-Org/ComfyUI/pull/15196): 중첩 잠재 데이터를 위한 잠재 데이터 미리보기 (예: LTXAV)
+* [**MP4 metadata**](https://github.com/Comfy-Org/ComfyUI/pull/15195): 가능한 경우 MP4 메타데이터를 파일 시작 부분에 저장
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15161): comfyui-frontend-package를 1.47.11로 업그레이드
+
+**버그 수정**
+* [**LTXAV**](https://github.com/Comfy-Org/ComfyUI/pull/15132): 오디오 잠재 데이터 없이 샘플링할 때 발생하는 충돌 수정
+* [**Jobs preview**](https://github.com/Comfy-Org/ComfyUI/pull/14681): 작업의 `preview_output`에서 텍스트보다 미디어 우선
+* [**cuDNN attention**](https://github.com/Comfy-Org/ComfyUI/pull/15146): Linux에서 Flash Attention 실패 시 cuDNN 어텐션으로 폴백
+* [**CurveEditor**](https://github.com/Comfy-Org/ComfyUI/pull/15152): 페이지 새로 고침 후 CurveEditor의 캐시된 히스토그램 UI 재전송
+* [**ByteDance stereo audio**](https://github.com/Comfy-Org/ComfyUI/pull/15177): 재생 시간이 두 배로 늘어나지 않도록 스테레오 기준 오디오 인코딩
+
+</Update>
+
 <Update label="v0.29.2" description="2026년 7월 31일">
 
 **파트너 노드 업데이트**
@@ -163,6 +208,15 @@ translationBlockHashes:
 * [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): bf16을 지원하지 않는 카드에서 MageFlow 문제 수정
 * [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): LTXV IC-LoRA 감지 개선
 * [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): LTXVEmptyLatentAudio에서 실수 fps 허용
+
+</Update>
+
+<Update label="v0.28.3" description="2026년 7월 22일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni 파트너 노드에서 비디오를 인라인 데이터로 전달
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델
 
 </Update>
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,12 +2,15 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 2c0fe8fb
+translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.30.1": c4818cfa
+  "v0.30.0": 4879519e
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
+  "v0.28.3": 55070a51
   "v0.28.2": 27b88b8c
   "v0.28.1": 7e07b8ad
   "v0.28.0": cab64a24
@@ -111,6 +114,48 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.30.1" description="2026年8月3日">
+
+**性能与稳定性**
+* [**前端**](https://github.com/Comfy-Org/ComfyUI/pull/15244)：将 comfyui-frontend-package 升级至 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新增开源模型支持**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224)：MiniMax-H3 音视频模型支持（CORE-375）
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129)：支持 PrunaVAED，以实现更快的 LTX 2.3 解码
+
+**新增节点**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191)：为保存视频节点添加了 CRF 选项
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217)：SaveText 节点可以保存 `.csv` 输出
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211)：VAEDecodeAudio 可以解码嵌套的音频 Latent
+
+**合作节点更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197)：为 grok-imagine-video-1.5 更新了 xAI 节点
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227)：为 MiniMax H3 合作节点添加了 768P 分辨率
+
+**性能与稳定性**
+* [**int8 embedding lookup**](https://github.com/Comfy-Org/ComfyUI/pull/15035)：针对文本生成模型的 int8 convrot embedding 查找（CORE-371）
+* [**Weight pinning**](https://github.com/Comfy-Org/ComfyUI/pull/15027)：使用 MRU 固定基础设施将权重加载到处理 RAM
+* [**Comfy Kitchen AMD**](https://github.com/Comfy-Org/ComfyUI/pull/15160)：Comfy Kitchen 支持 AMD
+* [**Dataset folder**](https://github.com/Comfy-Org/ComfyUI/pull/14807)：数据集文件夹路径，以避免任意目录访问
+* [**DETAIL logging**](https://github.com/Comfy-Org/ComfyUI/pull/15064)：可配置的 DETAIL 日志记录侧通道（CORE-369）
+* [**GQA attention**](https://github.com/Comfy-Org/ComfyUI/pull/15190)：当 GQA 注意力会回退到数学计算时，展开 k/v
+* [**Nested latent previews**](https://github.com/Comfy-Org/ComfyUI/pull/15196)：针对嵌套 Latent（例如 LTXAV）的 Latent 预览
+* [**MP4 metadata**](https://github.com/Comfy-Org/ComfyUI/pull/15195)：尽可能将 MP4 元数据存储在文件开头
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15161)：将 comfyui-frontend-package 升级到 1.47.11
+
+**错误修复**
+* [**LTXAV**](https://github.com/Comfy-Org/ComfyUI/pull/15132)：修复了在没有音频 Latent 时采样崩溃的问题
+* [**Jobs preview**](https://github.com/Comfy-Org/ComfyUI/pull/14681)：对于任务的 `preview_output`，优先使用媒体而非文本
+* [**cuDNN attention**](https://github.com/Comfy-Org/ComfyUI/pull/15146)：在 Linux 上，当 Flash Attention 失败时回退到 cuDNN 注意力
+* [**CurveEditor**](https://github.com/Comfy-Org/ComfyUI/pull/15152)：页面刷新后重新发送 CurveEditor 的缓存直方图 UI
+* [**ByteDance stereo audio**](https://github.com/Comfy-Org/ComfyUI/pull/15177)：编码立体声参考音频，且不会使时长加倍
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **合作伙伴节点更新**
@@ -163,6 +208,15 @@ translationBlockHashes:
 * [**MageFlow bf16**](https://github.com/Comfy-Org/ComfyUI/pull/15081): 修复 MageFlow 在不支持 bf16 的显卡上的运行问题
 * [**LTXV IC-LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15073): 改进 LTXV IC-LoRA 检测
 * [**LTXVEmptyLatentAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15106): 允许 LTXVEmptyLatentAudio 使用浮点 fps
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014)：在 Gemini Omni 合作伙伴节点中将视频作为内联数据传递
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021)：新增 OpenRouter 模型
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023)：新增 Anthropic 模型
 
 </Update>
 


### PR DESCRIPTION
## Summary
- Add docs changelog entries for **v0.30.0** (MiniMax-H3, Pruna LTX VAE, weight pinning, Comfy Kitchen AMD, partner nodes, and related fixes), **v0.30.1** (frontend 1.47.12), and **v0.28.3** (partner node patch)
- Translate new blocks to zh / ja / ko

## Test plan
- [ ] Preview changelog pages (EN / zh / ja / ko) for v0.28.3, v0.30.0, and v0.30.1
- [ ] Confirm Mintlify build passes