### PR TITLE
docs: update MiniMax-H3 changelog link and sync CMS release notes

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -443,6 +443,34 @@
       "published_at": "2026-07-19T03:16:21.011Z"
     },
     {
+      "project": "cloud",
+      "version": "0.28.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-03T06:40:40.710Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.28.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-03T06:38:37.165Z"
+    },
+    {
       "project": "comfyui",
       "version": "0.29.0",
       "locales": [
@@ -469,6 +497,48 @@
         "zh"
       ],
       "published_at": "2026-07-31T13:20:22.647Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.30.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-03T07:00:16.206Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.30.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-03T07:06:27.943Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.30.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-03T07:04:59.023Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="August 3, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): Adds audio-video model support for MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAED support for faster LTX 2.3 decoding
+
+**New Node Updates**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Adds CRF option to Save Video node
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText node can now save .csv output
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Handles decoding of nested audio latents
+
+**Partner Node Updates**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Updated xAI nodes for grok-imagine-video-1.5 support
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Adds 768P resolution for MiniMax H3 nodes
+
+</Update>
+
 <Update label="v0.29.2" description="July 31, 2026">
 
 **Partner Node Updates**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual model support
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models, including Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models, including Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="July 22, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pass videos as inline data in Gemini Omni partner node
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="3 de agosto de 2026">
+
+**Nuevo soporte de modelos de código abierto**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): Añade soporte para el modelo de audio y vídeo MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Soporte de PrunaVAED para una decodificación LTX 2.3 más rápida
+
+**Nuevas actualizaciones de nodos**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Añade la opción CRF al nodo Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): El nodo SaveText ahora puede guardar la salida en .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Gestiona la decodificación de latentes de audio anidados
+
+**Actualizaciones de nodos de socios**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Nodos xAI actualizados para dar soporte a grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Añade la resolución 768P para los nodos MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 de julio de 2026">
 
 **Actualizaciones de nodos de socios**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance audio multilingüe**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Soporte para el modelo ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter, incluido Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic, incluido Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="22 de julio de 2026">
+
+**Actualizaciones de nodos partner**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pasa videos como datos en línea en el nodo partner de Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="3 août 2026">
+
+**Prise en charge de nouveaux modèles open-source**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): Ajoute la prise en charge du modèle audio-vidéo pour MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Prise en charge de PrunaVAED pour un décodage LTX 2.3 plus rapide
+
+**Nouvelles mises à jour de nœuds**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Ajoute l'option CRF au nœud Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): Le nœud SaveText peut désormais enregistrer la sortie .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Gère le décodage des latents audio imbriqués
+
+**Mises à jour des nœuds partenaires**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Nœuds xAI mis à jour pour la prise en charge de grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Ajoute la résolution 768P pour les nœuds MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 juillet 2026">
 
 **Mises à jour des nœuds partenaires**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance audio multilingue**](https://github.com/Comfy-Org/ComfyUI/pull/15034) : support du modèle ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021) : nouveaux modèles OpenRouter, y compris Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023) : nouveaux modèles Anthropic, y compris Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="July 22, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Transmettre des vidéos en tant que données intégrées dans le nœud partenaire Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nouveaux modèles OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nouveaux modèles Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新しいオープンソースモデルのサポート**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3オーディオ・ビデオモデルのサポートを追加
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAEDサポートによりLTX 2.3のデコードを高速化
+
+**新しいノード更新**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): ビデオを保存ノードにCRFオプションを追加
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveTextノードで.csv出力を保存可能に
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): ネストされたオーディオ潜在変数のデコードを処理
+
+**パートナーノード更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5サポート用にxAIノードを更新
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3ノードに768P解像度を追加
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **パートナーノードの更新**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual モデルのサポート
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新しい OpenRouter モデル（Claude Opus 5 を含む）
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新しい Anthropic モデル（Claude Opus 5 を含む）
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**パートナーノードの更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni パートナーノードでビデオをインラインデータとして渡す
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): OpenRouter の新モデル
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Anthropic の新モデル
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="2026년 8월 3일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3에 오디오-비디오 모델 지원 추가
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 더 빠른 LTX 2.3 디코딩을 위한 PrunaVAED 지원
+
+**새로운 노드 업데이트**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Save Video 노드에 CRF 옵션 추가
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText 노드가 이제 .csv 출력을 저장할 수 있음
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): 중첩된 오디오 잠재 표현의 디코딩 처리
+
+**파트너 노드 업데이트**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5 지원을 위해 xAI 노드 업데이트됨
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3 노드에 768P 해상도 추가
+
+</Update>
+
 <Update label="v0.29.2" description="2026년 7월 31일">
 
 **파트너 노드 업데이트**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance 오디오 다국어**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual 모델 지원
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델, Claude Opus 5 포함
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델, Claude Opus 5 포함
+
+</Update>
+
+<Update label="v0.28.3" description="2026년 7월 22일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni 파트너 노드에서 비디오를 인라인 데이터로 전달
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="3 августа 2026 г.">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): Добавлена поддержка аудио-видео модели MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Поддержка PrunaVAED для более быстрого декодирования LTX 2.3
+
+**Обновления новых нод**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Добавлен параметр CRF в ноду Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): Нода SaveText теперь может сохранять вывод в формате .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Обрабатывает декодирование вложенных аудио-латентов
+
+**Обновления партнёрских нод**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Обновлены ноды xAI для поддержки grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Добавлено разрешение 768P для нод MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 июля 2026 г.">
 
 **Обновления партнёрских узлов**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Поддержка модели ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter, включая Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic, включая Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="22 июля 2026">
+
+**Обновления партнёрских узлов**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Передача видео в виде встроенных данных в партнёрском узле Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,23 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新增开源模型支持**
+* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): 为 MiniMax-H3 新增音视频模型支持
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 支持 PrunaVAED，实现更快的 LTX 2.3 解码
+
+**节点更新**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): 为保存视频节点新增 CRF 选项
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText 节点现在可以保存 .csv 输出
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): 处理嵌套音频潜空间的解码
+
+**合作伙伴节点更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): 已更新 xAI 节点以支持 grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): 为 MiniMax H3 节点新增 768P 分辨率
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **合作伙伴节点更新**
@@ -29,6 +46,15 @@ cmsStaging: true
 * [**字节跳动音频多语言**](https://github.com/Comfy-Org/ComfyUI/pull/15034)：字节跳动 audio-1.0-multilingual 模型支持
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021)：新增 OpenRouter 模型，包括 Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023)：新增 Anthropic 模型，包括 Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): 在 Gemini Omni 合作伙伴节点中以内联数据传递视频
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新增 OpenRouter 模型
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新增 Anthropic 模型
 
 </Update>
 

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="August 3, 2026">
+
+**Performance & Stability**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): Bumped comfyui-frontend-package to 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="August 3, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): Adds audio-video model support for MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAED support for faster LTX 2.3 decoding
+
+**New Node Updates**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Adds CRF option to Save Video node
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText node can now save .csv output
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Handles decoding of nested audio latents
+
+**Partner Node Updates**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Updated xAI nodes for grok-imagine-video-1.5 support
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Adds 768P resolution for MiniMax H3 nodes
+
+</Update>
+
 <Update label="v0.29.2" description="July 31, 2026">
 
 **Partner Node Updates**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual model support
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models, including Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models, including Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="July 22, 2026">
+
+**Partner Node Updates**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pass videos as inline data in Gemini Omni partner node
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): New OpenRouter models
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): New Anthropic models
 
 </Update>
 

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="3 de agosto de 2026">
+
+**Rendimiento y estabilidad**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): Se actualizó comfyui-frontend-package a 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="3 de agosto de 2026">
+
+**Nuevo soporte de modelos de código abierto**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): Añade soporte para el modelo de audio y vídeo MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Soporte de PrunaVAED para una decodificación LTX 2.3 más rápida
+
+**Nuevas actualizaciones de nodos**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Añade la opción CRF al nodo Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): El nodo SaveText ahora puede guardar la salida en .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Gestiona la decodificación de latentes de audio anidados
+
+**Actualizaciones de nodos de socios**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Nodos xAI actualizados para dar soporte a grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Añade la resolución 768P para los nodos MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 de julio de 2026">
 
 **Actualizaciones de nodos de socios**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance audio multilingüe**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Soporte para el modelo ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter, incluido Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic, incluido Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="22 de julio de 2026">
+
+**Actualizaciones de nodos partner**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Pasa videos como datos en línea en el nodo partner de Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nuevos modelos de OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nuevos modelos de Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="3 août 2026">
+
+**Performance et stabilité**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): Mise à jour de comfyui-frontend-package vers 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="3 août 2026">
+
+**Prise en charge de nouveaux modèles open-source**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): Ajoute la prise en charge du modèle audio-vidéo pour MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Prise en charge de PrunaVAED pour un décodage LTX 2.3 plus rapide
+
+**Nouvelles mises à jour de nœuds**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Ajoute l'option CRF au nœud Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): Le nœud SaveText peut désormais enregistrer la sortie .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Gère le décodage des latents audio imbriqués
+
+**Mises à jour des nœuds partenaires**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Nœuds xAI mis à jour pour la prise en charge de grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Ajoute la résolution 768P pour les nœuds MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 juillet 2026">
 
 **Mises à jour des nœuds partenaires**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance audio multilingue**](https://github.com/Comfy-Org/ComfyUI/pull/15034) : support du modèle ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021) : nouveaux modèles OpenRouter, y compris Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023) : nouveaux modèles Anthropic, y compris Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="July 22, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Transmettre des vidéos en tant que données intégrées dans le nœud partenaire Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Nouveaux modèles OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Nouveaux modèles Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="2026年8月3日">
+
+**パフォーマンスと安定性**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): comfyui-frontend-package を 1.47.12 に更新しました。
+
+</Update>
+
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新しいオープンソースモデルのサポート**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): MiniMax-H3オーディオ・ビデオモデルのサポートを追加
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAEDサポートによりLTX 2.3のデコードを高速化
+
+**新しいノード更新**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): ビデオを保存ノードにCRFオプションを追加
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveTextノードで.csv出力を保存可能に
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): ネストされたオーディオ潜在変数のデコードを処理
+
+**パートナーノード更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5サポート用にxAIノードを更新
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3ノードに768P解像度を追加
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **パートナーノードの更新**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual モデルのサポート
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新しい OpenRouter モデル（Claude Opus 5 を含む）
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新しい Anthropic モデル（Claude Opus 5 を含む）
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**パートナーノードの更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni パートナーノードでビデオをインラインデータとして渡す
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): OpenRouter の新モデル
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Anthropic の新モデル
 
 </Update>
 

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="2026년 8월 3일">
+
+**성능 및 안정성**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): comfyui-frontend-package를 1.47.12로 업데이트
+
+</Update>
+
+<Update label="v0.30.0" description="2026년 8월 3일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): MiniMax-H3에 오디오-비디오 모델 지원 추가
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 더 빠른 LTX 2.3 디코딩을 위한 PrunaVAED 지원
+
+**새로운 노드 업데이트**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Save Video 노드에 CRF 옵션 추가
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText 노드가 이제 .csv 출력을 저장할 수 있음
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): 중첩된 오디오 잠재 표현의 디코딩 처리
+
+**파트너 노드 업데이트**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): grok-imagine-video-1.5 지원을 위해 xAI 노드 업데이트됨
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): MiniMax H3 노드에 768P 해상도 추가
+
+</Update>
+
 <Update label="v0.29.2" description="2026년 7월 31일">
 
 **파트너 노드 업데이트**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance 오디오 다국어**](https://github.com/Comfy-Org/ComfyUI/pull/15034): ByteDance audio-1.0-multilingual 모델 지원
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델, Claude Opus 5 포함
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델, Claude Opus 5 포함
+
+</Update>
+
+<Update label="v0.28.3" description="2026년 7월 22일">
+
+**파트너 노드 업데이트**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Gemini Omni 파트너 노드에서 비디오를 인라인 데이터로 전달
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 새로운 OpenRouter 모델
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 새로운 Anthropic 모델
 
 </Update>
 

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="3 августа 2026">
+
+**Производительность и стабильность**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15244): Обновлён comfyui-frontend-package до 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="3 августа 2026 г.">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): Добавлена поддержка аудио-видео модели MiniMax-H3
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): Поддержка PrunaVAED для более быстрого декодирования LTX 2.3
+
+**Обновления новых нод**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): Добавлен параметр CRF в ноду Save Video
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): Нода SaveText теперь может сохранять вывод в формате .csv
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): Обрабатывает декодирование вложенных аудио-латентов
+
+**Обновления партнёрских нод**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): Обновлены ноды xAI для поддержки grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): Добавлено разрешение 768P для нод MiniMax H3
+
+</Update>
+
 <Update label="v0.29.2" description="31 июля 2026 г.">
 
 **Обновления партнёрских узлов**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**ByteDance audio multilingual**](https://github.com/Comfy-Org/ComfyUI/pull/15034): Поддержка модели ByteDance audio-1.0-multilingual
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter, включая Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic, включая Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="22 июля 2026">
+
+**Обновления партнёрских узлов**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): Передача видео в виде встроенных данных в партнёрском узле Gemini Omni
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): Новые модели OpenRouter
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): Новые модели Anthropic
 
 </Update>
 

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,30 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.30.1" description="2026年8月3日">
+
+**性能与稳定性**
+* [**前端**](https://github.com/Comfy-Org/ComfyUI/pull/15244): 将 comfyui-frontend-package 升级至 1.47.12
+
+</Update>
+
+<Update label="v0.30.0" description="2026年8月3日">
+
+**新增开源模型支持**
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): 为 MiniMax-H3 新增音视频模型支持
+* [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 支持 PrunaVAED，实现更快的 LTX 2.3 解码
+
+**节点更新**
+* [**Save Video CRF**](https://github.com/Comfy-Org/ComfyUI/pull/15191): 为保存视频节点新增 CRF 选项
+* [**SaveText CSV**](https://github.com/Comfy-Org/ComfyUI/pull/15217): SaveText 节点现在可以保存 .csv 输出
+* [**VAEDecodeAudio**](https://github.com/Comfy-Org/ComfyUI/pull/15211): 处理嵌套音频潜空间的解码
+
+**合作伙伴节点更新**
+* [**xAI Grok Imagine Video 1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15197): 已更新 xAI 节点以支持 grok-imagine-video-1.5
+* [**MiniMax H3 768P**](https://github.com/Comfy-Org/ComfyUI/pull/15227): 为 MiniMax H3 节点新增 768P 分辨率
+
+</Update>
+
 <Update label="v0.29.2" description="2026年7月31日">
 
 **合作伙伴节点更新**
@@ -29,6 +53,15 @@ cmsStaging: true
 * [**字节跳动音频多语言**](https://github.com/Comfy-Org/ComfyUI/pull/15034)：字节跳动 audio-1.0-multilingual 模型支持
 * [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021)：新增 OpenRouter 模型，包括 Claude Opus 5
 * [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023)：新增 Anthropic 模型，包括 Claude Opus 5
+
+</Update>
+
+<Update label="v0.28.3" description="2026年7月22日">
+
+**合作伙伴节点更新**
+* [**Gemini Video Omni**](https://github.com/Comfy-Org/ComfyUI/pull/15014): 在 Gemini Omni 合作伙伴节点中以内联数据传递视频
+* [**OpenRouter**](https://github.com/Comfy-Org/ComfyUI/pull/15021): 新增 OpenRouter 模型
+* [**Anthropic**](https://github.com/Comfy-Org/ComfyUI/pull/15023): 新增 Anthropic 模型
 
 </Update>
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -14,7 +14,7 @@ icon: "clock-rotate-left"
 <Update label="v0.30.0" description="August 3, 2026">
 
 **New Open-Source Model Support**
-* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 audio-video model support (CORE-375)
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): MiniMax-H3 audio-video model support (CORE-375)
 * [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): PrunaVAED support for faster LTX 2.3 decoding
 
 **New Nodes**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
   "v0.30.1": c4818cfa
-  "v0.30.0": 4879519e
+  "v0.30.0": fba9c84f
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
@@ -114,6 +114,7 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
 <Update label="v0.30.1" description="2026年8月3日">
 
 **パフォーマンスと安定性**
@@ -124,7 +125,7 @@ translationBlockHashes:
 <Update label="v0.30.0" description="2026年8月3日">
 
 **新規オープンソースモデルサポート**
-* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 オーディオビデオモデルサポート (CORE-375)
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): MiniMax-H3 オーディオビデオモデルサポート (CORE-375)
 * [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): より高速な LTX 2.3 デコードのための PrunaVAED サポート
 
 **新規ノード**

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
   "v0.30.1": c4818cfa
-  "v0.30.0": 4879519e
+  "v0.30.0": fba9c84f
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
@@ -114,6 +114,7 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
 <Update label="v0.30.1" description="2026년 8월 3일">
 
 **성능 및 안정성**
@@ -124,7 +125,7 @@ translationBlockHashes:
 <Update label="v0.30.0" description="2026년 8월 3일">
 
 **새로운 오픈소스 모델 지원**
-* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224): MiniMax-H3 오디오-비디오 모델 지원 (CORE-375)
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO): MiniMax-H3 오디오-비디오 모델 지원 (CORE-375)
 * [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129): 더 빠른 LTX 2.3 디코딩을 위한 PrunaVAED 지원
 
 **새로운 노드**

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -6,7 +6,7 @@ translationSourceHash: 982c793f
 translationFrom: changelog/index.mdx
 translationBlockHashes:
   "v0.30.1": c4818cfa
-  "v0.30.0": 4879519e
+  "v0.30.0": fba9c84f
   "v0.29.2": a168cef8
   "v0.29.1": 3b558eb8
   "v0.29.0": 7beaa255
@@ -114,6 +114,7 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+
 <Update label="v0.30.1" description="2026年8月3日">
 
 **性能与稳定性**
@@ -124,7 +125,7 @@ translationBlockHashes:
 <Update label="v0.30.0" description="2026年8月3日">
 
 **新增开源模型支持**
-* [**MiniMax-H3**](https://github.com/Comfy-Org/ComfyUI/pull/15224)：MiniMax-H3 音视频模型支持（CORE-375）
+* [**MiniMax-H3**](https://links.comfy.org/3TuT9TO)：MiniMax-H3 音视频模型支持（CORE-375）
 * [**Pruna LTX VAE**](https://github.com/Comfy-Org/ComfyUI/pull/15129)：支持 PrunaVAED，以实现更快的 LTX 2.3 解码
 
 **新增节点**


### PR DESCRIPTION
## Summary
- Update **v0.30.0** MiniMax-H3 link in docs changelog (EN / zh / ja / ko) to https://links.comfy.org/3TuT9TO
- Commit CMS staging and `published-versions.json` for v0.28.3, v0.30.0, and v0.30.1 (comfyui + cloud)
- ComfyUI CMS v0.30.0 MiniMax-H3 uses the same newsletter link; cloud v0.30.1 is excluded from staging

## Test plan
- [ ] Preview changelog v0.30.0 on docs site (EN / zh / ja / ko)
- [ ] Confirm MiniMax-H3 link opens the newsletter page
- [ ] Verify CMS staging matches published Strapi entries