### PR TITLE
docs: partner node pricing update (Aug 7, 2026)

### DIFF
--- a/ja/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
+++ b/ja/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
@@ -16,7 +16,7 @@ translationBlockHashes:
 import ReqHint from "/snippets/ja/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx";
 
-Nano Banana 2 Liteは、Google DeepMindの最速かつ最もコスト効率の高いGemini Imageモデルです。迅速な発想と大量のワークフロー向けに設計されています。`gemini-3.1-flash-lite-image`を搭載し、約4秒・1画像あたり$0.034でテキストから画像への生成を実現。コンセプトの素早い可視化、高速プロトタイピング、反復的なデザイン探索に最適です。
+Nano Banana 2 Liteは、Google DeepMindの最速かつ最もコスト効率の高いGemini Imageモデルです。迅速な発想と大量のワークフロー向けに設計されています。`gemini-3.1-flash-lite-image`を搭載し、約4秒・1画像あたり$0.041でテキストから画像への生成を実現。コンセプトの素早い可視化、高速プロトタイピング、反復的なデザイン探索に最適です。
 
 <ReqHint/>
 <UpdateReminder/>
@@ -24,7 +24,7 @@ Nano Banana 2 Liteは、Google DeepMindの最速かつ最もコスト効率の�
 ## Nano Banana 2 Liteの特長
 
 - **超高速生成**: テキストから画像への出力をわずか4秒で実現。インタラクティブなプロトタイピングと迅速なビジュアルドラフトに最適です。
-- **コスト効率**: 1K解像度の画像1枚あたり$0.034 — Nano Bananaファミリーで最も手頃なオプションです。
+- **コスト効率**: 1K解像度の画像1枚あたり$0.041。Nano Bananaファミリーで最も手頃なオプションです。
 - **キャラクターの一貫性**: 複数の高速生成間でキャラクターのアイデンティティとオブジェクトの忠実性を維持します。
 - **画像内テキストレンダリング**: 生成画像に直接、読み取り可能なテキストをドラフトコピーしてレンダリングし、ローカライズされた広告バリエーションを作成できます。
 - **設定可能なモデル選択**: 同じノード内でNano Banana 2 Lite、Nano Banana 2、Nano Banana Proを切り替えられます。

--- a/ja/tutorials/partner-nodes/pricing.mdx
+++ b/ja/tutorials/partner-nodes/pricing.mdx
@@ -52,6 +52,10 @@ translationBlockHashes:
 
 以下の表は、現在のパートナーノードの料金を一覧表示したものです。すべての価格はクレジット単位です。
 
+<Note>
+  **2026年8月7日の価格改定**: Nano Banana Pro、Nano Banana 2、Nano Banana 2 Lite、GPT Image 2 の出力料金が、プロバイダーの introductory 割引終了に伴い約 20% 値上げされました。他のパートナーおよび OSS モデルの価格は変更ありません。
+</Note>
+
 ## Anthropic
 
 ### Chat（`ClaudeNode`）
@@ -280,9 +284,9 @@ Seedream 5.0 Proは解像度ベースの課金方式を採用しています：*
 | モデル                                             | 入力クレジット / 1K | 出力（テキスト）クレジット / 1K | 出力（画像）クレジット / 1K |
 | :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
 | Nano Banana（`gemini-2.5-flash-image`）           |             0.0633 |                     0.5275 | 6.33                        |
-| Nano Banana Pro（`gemini-3-pro-image`）           |              0.422 |                      2.532 | 25.32                       |
-| Nano Banana 2（`gemini-3.1-flash-image`）         |             0.1055 |                      0.633 | 12.66                       |
-| Nano Banana 2 Lite（`gemini-3.1-flash-lite-image`）|           0.05275 |                     0.3165 | 6.33                        |
+| Nano Banana Pro（`gemini-3-pro-image`）           |              0.422 |                      2.532 | 30.38                       |
+| Nano Banana 2（`gemini-3.1-flash-image`）         |             0.1055 |                      0.633 | 15.19                       |
+| Nano Banana 2 Lite（`gemini-3.1-flash-lite-image`）|           0.05275 |                     0.3165 | 7.60                        |
 
 ### 動画: Google Gemini Omni
 
@@ -711,7 +715,7 @@ DALL·E と Sora は固定の画像あたりまたは秒あたりのレートを
 | gpt-image-1.5 | 入力          | 1688         |
 | gpt-image-1.5 | 出力（画像）      | 6752         |
 | gpt-image-2   | 入力          | 1688         |
-| gpt-image-2   | 出力（画像）      | 6330         |
+| gpt-image-2   | 出力（画像）      | 7600         |
 
 非推奨の **OpenAI GPT Image 2** ノード（古い実装）は同じモデルとレートを使用します。
 

--- a/ko/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
+++ b/ko/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
@@ -16,7 +16,7 @@ translationBlockHashes:
 import ReqHint from "/snippets/ko/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx";
 
-Nano Banana 2 Lite는 Google DeepMind의 가장 빠르고 비용 효율적인 Gemini Image 모델로, 빠른 아이디어 구상과 대용량 워크플로를 위해 설계되었습니다. `gemini-3.1-flash-lite-image`를 기반으로 하여 텍스트 기반 이미지 생성을 약 4초 만에 이미지당 $0.034의 비용으로 제공하므로, 신속한 개념 시각화, 빠른 프로토타이핑, 반복적인 디자인 탐색에 이상적입니다.
+Nano Banana 2 Lite는 Google DeepMind의 가장 빠르고 비용 효율적인 Gemini Image 모델로, 빠른 아이디어 구상과 대용량 워크플로를 위해 설계되었습니다. `gemini-3.1-flash-lite-image`를 기반으로 하여 텍스트 기반 이미지 생성을 약 4초 만에 이미지당 $0.041의 비용으로 제공하므로, 신속한 개념 시각화, 빠른 프로토타이핑, 반복적인 디자인 탐색에 이상적입니다.
 
 <ReqHint/>
 <UpdateReminder/>
@@ -24,7 +24,7 @@ Nano Banana 2 Lite는 Google DeepMind의 가장 빠르고 비용 효율적인 Ge
 ## Nano Banana 2 Lite의 기능
 
 - **초고속 생성**: 텍스트 기반 이미지 출력을 단 4초 만에 제공하여 대화형 프로토타이핑 및 신속한 시각적 초안 작성에 적합합니다.
-- **비용 효율성**: 1K 해상도 이미지당 $0.034로 책정되어 Nano Banana 제품군 중 가장 저렴한 옵션입니다.
+- **비용 효율성**: 1K 해상도 이미지당 $0.041로 책정되어 Nano Banana 제품군 중 가장 저렴한 옵션입니다.
 - **캐릭터 일관성**: 여러 번의 빠른 생성에서 캐릭터 정체성과 객체 충실도를 유지합니다.
 - **이미지 내 텍스트 렌더링**: 생성된 이미지에 직접 읽을 수 있는 텍스트를 초안 복사 및 렌더링하여 지역화된 광고 변형을 만듭니다.
 - **구성 가능한 모델 선택**: 동일한 노드 내에서 Nano Banana 2 Lite, Nano Banana 2 및 Nano Banana Pro 중에서 선택할 수 있습니다.

--- a/ko/tutorials/partner-nodes/pricing.mdx
+++ b/ko/tutorials/partner-nodes/pricing.mdx
@@ -52,6 +52,10 @@ translationBlockHashes:
 
 다음 표에는 현재 파트너 노드의 가격 정책이 나와 있습니다. 모든 가격은 크레딧 단위로 표시됩니다.
 
+<Note>
+  **2026년 8월 7일 가격 업데이트**: Nano Banana Pro, Nano Banana 2, Nano Banana 2 Lite, GPT Image 2의 출력 요율이 프로바이더 introductory 할인 종료에 따라 약 20% 인상되었습니다. 다른 파트너 및 오픈 소스 모델 가격은 변경되지 않습니다.
+</Note>
+
 ## Anthropic
 
 ### 채팅 (`ClaudeNode`)
@@ -280,9 +284,9 @@ Seedream 5.0 Pro는 해상도 기반 요금제를 사용합니다: **1K** (≤2.
 | 모델                                            | 입력 크레딧 / 1K | 출력 (텍스트) 크레딧 / 1K | 출력 (이미지) 크레딧 / 1K |
 | :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
 | Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
-| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 25.32                       |
-| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 12.66                       |
-| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 30.38                       |
+| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 15.19                       |
+| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 7.60                        |
 
 ### 비디오: Google Gemini Omni
 
@@ -710,7 +714,7 @@ DALL·E와 Sora는 이미지당 또는 초당 고정 요금을 사용합니다. 
 | gpt-image-1.5 | 입력          | 1688         |
 | gpt-image-1.5 | 출력 (이미지) | 6752         |
 | gpt-image-2   | 입력          | 1688         |
-| gpt-image-2   | 출력 (이미지) | 6330         |
+| gpt-image-2   | 출력 (이미지) | 7600         |
 
 지원 중단된 **OpenAI GPT Image 2** 노드(이전 구현)는 동일한 모델과 요금을 사용합니다.
 

--- a/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
+++ b/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Nano Banana 2 Lite"
 import ReqHint from "/snippets/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/tutorials/update-reminder.mdx";
 
-Nano Banana 2 Lite is Google DeepMind's fastest and most cost-efficient Gemini Image model, designed for rapid ideation and high-volume workflows. Powered by `gemini-3.1-flash-lite-image`, it delivers text-to-image generation in approximately 4 seconds at $0.034 per image, making it ideal for quick concept visualization, rapid prototyping, and iterative design exploration.
+Nano Banana 2 Lite is Google DeepMind's fastest and most cost-efficient Gemini Image model, designed for rapid ideation and high-volume workflows. Powered by `gemini-3.1-flash-lite-image`, it delivers text-to-image generation in approximately 4 seconds at $0.041 per image, making it ideal for quick concept visualization, rapid prototyping, and iterative design exploration.
 
 <ReqHint/>
 <UpdateReminder/>
@@ -15,7 +15,7 @@ Nano Banana 2 Lite is Google DeepMind's fastest and most cost-efficient Gemini I
 ## What Nano Banana 2 Lite offers
 
 - **Ultra-fast generation**: Text-to-image outputs in as little as 4 seconds, built for interactive prototyping and rapid visual drafting
-- **Cost-efficient**: Priced at $0.034 per 1K-resolution image — the most affordable option in the Nano Banana family
+- **Cost-efficient**: Priced at $0.041 per 1K-resolution image, the most affordable option in the Nano Banana family
 - **Character consistency**: Maintain character identities and object fidelity across multiple rapid generations
 - **In-image text rendering**: Draft copy and render legible text directly into generated images for localized ad variations
 - **Configurable model selection**: Choose between Nano Banana 2 Lite, Nano Banana 2, and Nano Banana Pro within the same node

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -7,6 +7,10 @@ mode: "wide"
 
 The following table lists the pricing of the current Partner Nodes. All prices are in credits.
 
+<Note>
+  **August 7, 2026 pricing update**: Output rates for Nano Banana Pro, Nano Banana 2, Nano Banana 2 Lite, and GPT Image 2 increased by approximately 20% after introductory provider discounts ended. Other partner and open-source models are unchanged.
+</Note>
+
 ## Anthropic
 
 ### Chat (`ClaudeNode`)
@@ -235,9 +239,9 @@ Token-based billing.
 | Model                                            | Input credits / 1K | Output (text) credits / 1K | Output (image) credits / 1K |
 | :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
 | Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
-| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 25.32                       |
-| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 12.66                       |
-| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 30.38                       |
+| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 15.19                       |
+| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 7.60                        |
 
 ### Video: Google Gemini Omni
 
@@ -666,7 +670,7 @@ Billed from API token usage after generation. Approximate badge by `quality` (`l
 | gpt-image-1.5 | input          | 1688         |
 | gpt-image-1.5 | output (image) | 6752         |
 | gpt-image-2   | input          | 1688         |
-| gpt-image-2   | output (image) | 6330         |
+| gpt-image-2   | output (image) | 7600         |
 
 The deprecated **OpenAI GPT Image 2** node (older implementation) uses the same models and rates.
 

--- a/zh/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
+++ b/zh/tutorials/partner-nodes/google/nano-banana-2-lite.mdx
@@ -16,7 +16,7 @@ translationBlockHashes:
 import ReqHint from "/snippets/zh/tutorials/partner-nodes/req-hint.mdx";
 import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx";
 
-Nano Banana 2 Lite 是 Google DeepMind 速度最快、成本效益最高的 Gemini Image 模型，专为快速构思和高吞吐量工作流而设计。该模型基于 `gemini-3.1-flash-lite-image`，可在约 4 秒内以每张 $0.034 的价格完成文生图，非常适合快速概念可视化、快速原型设计和迭代式设计探索。
+Nano Banana 2 Lite 是 Google DeepMind 速度最快、成本效益最高的 Gemini Image 模型，专为快速构思和高吞吐量工作流而设计。该模型基于 `gemini-3.1-flash-lite-image`，可在约 4 秒内以每张 $0.041 的价格完成文生图，非常适合快速概念可视化、快速原型设计和迭代式设计探索。
 
 <ReqHint/>
 <UpdateReminder/>
@@ -24,7 +24,7 @@ Nano Banana 2 Lite 是 Google DeepMind 速度最快、成本效益最高的 Gemi
 ## Nano Banana 2 Lite 的功能
 
 - **超快生成**：文生图输出仅需 4 秒，专为交互式原型设计和快速视觉草拟而构建
-- **成本高效**：每张 1K 分辨率图像仅需 $0.034 —— Nano Banana 系列中最经济的选择
+- **成本高效**：每张 1K 分辨率图像仅需 $0.041，Nano Banana 系列中最经济的选择
 - **角色一致性**：在多次快速生成中保持角色身份和物体保真度
 - **图像内文本渲染**：将草稿文案和可读文本直接渲染到生成的图像中，用于本地化广告变体
 - **可配置模型选择**：在同一节点中选择 Nano Banana 2 Lite、Nano Banana 2 和 Nano Banana Pro

--- a/zh/tutorials/partner-nodes/pricing.mdx
+++ b/zh/tutorials/partner-nodes/pricing.mdx
@@ -52,6 +52,10 @@ translationBlockHashes:
 
 下表列出了当前合作伙伴节点的定价。所有价格均以积分计。
 
+<Note>
+  **2026 年 8 月 7 日定价更新**：Nano Banana Pro、Nano Banana 2、Nano Banana 2 Lite 和 GPT Image 2 的输出费率在提供商 introductory 折扣结束后上调约 20%。其他合作伙伴和开源模型价格不变。
+</Note>
+
 ## Anthropic
 
 ### 聊天（`ClaudeNode`）
@@ -280,9 +284,9 @@ Seedream 5.0 Pro 使用基于分辨率的计费方式：**1K**（≤2.36 百�
 | 模型                                              | 输入积分 / 1K | 输出（文本）积分 / 1K | 输出（图片）积分 / 1K |
 | :----------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
 | Nano Banana (`gemini-2.5-flash-image`)           |             0.0633 |                     0.5275 | 6.33                        |
-| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 25.32                       |
-| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 12.66                       |
-| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 6.33                        |
+| Nano Banana Pro (`gemini-3-pro-image`)           |              0.422 |                      2.532 | 30.38                       |
+| Nano Banana 2 (`gemini-3.1-flash-image`)         |             0.1055 |                      0.633 | 15.19                       |
+| Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`) |           0.05275 |                     0.3165 | 7.60                        |
 
 ### 视频：Google Gemini Omni
 
@@ -711,7 +715,7 @@ DALL·E 和 Sora 使用固定的每张图片或每秒费率。**OpenAI GPT Image
 | gpt-image-1.5 | 输入          | 1688         |
 | gpt-image-1.5 | 输出（图片） | 6752         |
 | gpt-image-2   | 输入          | 1688         |
-| gpt-image-2   | 输出（图片） | 6330         |
+| gpt-image-2   | 输出（图片） | 7600         |
 
 已弃用的 **OpenAI GPT Image 2** 节点（旧版实现）使用相同的模型和费率。
 


### PR DESCRIPTION
## Summary

Updates docs for the partner-node reprice effective **Friday, August 7, 2026** ([Slack thread](https://comfy-organization.slack.com/archives/C08NYSK0K0A/p1785546654576569)).

Provider introductory discounts ended for select OpenAI and Gemini image models. Output rates increase by approximately 20%. Other partner APIs and open-source models are unchanged.

| Model | Old output rate (credits / 1K image tokens) | New rate |
| :--- | :--- | :--- |
| Nano Banana Pro | 25.32 | 30.38 |
| Nano Banana 2 | 12.66 | 15.19 |
| Nano Banana 2 Lite | 6.33 | 7.60 |
| GPT Image 2 (`output` tokens / 1M) | 6330 | 7600 |

Also updates Nano Banana 2 Lite tutorial per-image estimate ($0.034 → $0.041) to match the reprice.

## Files changed

- `tutorials/partner-nodes/pricing.mdx` (+ ja/zh/ko)
- `tutorials/partner-nodes/google/nano-banana-2-lite.mdx` (+ ja/zh/ko)

## Merge timing

Tiger asked for docs to land on **Aug 7** alongside Metronome and frontend price-badge deploy. Please merge and publish on or before that date.

## Test plan

- [ ] Verify [Partner Nodes pricing page](https://docs.comfy.org/tutorials/partner-nodes/pricing) shows updated Nano Banana and GPT Image 2 tables
- [ ] Confirm Note callout appears on EN + ja/zh/ko pricing pages
- [ ] Spot-check Nano Banana 2 Lite tutorial dollar amounts in all locales