### PR TITLE
docs(qwen-image-layered): document the layers widget and the layers + 1 output

### DIFF
--- a/ja/tutorials/image/qwen/qwen-image-layered.mdx
+++ b/ja/tutorials/image/qwen/qwen-image-layered.mdx
@@ -2,13 +2,14 @@
 title: "Qwen-Image-Layered ComfyUI ワークフロー例"
 description: "Qwen-Image-Layered は、画像を複数の RGBA レイヤーに分解できるモデルであり、レイヤー分解を通じて本質的な編集可能性を実現します。"
 sidebarTitle: "Qwen-Image-Layered"
-translationSourceHash: bf2f2000
+translationSourceHash: dba6b09a
 translationFrom: tutorials/image/qwen/qwen-image-layered.mdx
 translationBlockHashes:
   "_intro": 19900234
   "Qwen-Image-Layered workflow": ba937275
   "Model links": 98d12555
   "FP8 version": 6bffdd17
+  "Layers and output": 2419fd13
   "Workflow settings": b0f81aa2
 ---
 
@@ -74,6 +75,30 @@ import UpdateReminder from '/snippets/ja/tutorials/update-reminder.mdx'
 - [qwen_image_layered_fp8mixed.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image-Layered_ComfyUI/blob/main/split_files/diffusion_models/qwen_image_layered_fp8mixed.safetensors)
 
 その後、[サブグラフ](/ja/interface/features/subgraph)内の **Load Diffusion model** ノードを更新し、このファイルを使用するように設定してください。
+
+## レイヤーと出力
+
+レイヤーの数は、[サブグラフ](/ja/interface/features/subgraph)内の **Empty Qwen Image Layered Latent** ノードにある `layers` ウィジェットで設定します。
+
+このモデルはレイヤーだけでなく完全な画像も生成するため、1 回の生成は常に `layers + 1` 枚の画像にデコードされます：
+
+| `layers` | デコードされる画像数 | 内容 |
+| --- | --- | --- |
+| `0` | 1 | 完全な画像のみ |
+| `2`（テンプレートの既定値） | 3 | 完全な画像、続いて 2 枚のレイヤー |
+| `5` | 6 | 完全な画像、続いて 5 枚のレイヤー |
+
+**最初の画像は完全な画像であり、レイヤーではありません。** 画像からレイヤーへのワークフローでは入力画像を再現したものになるため、レイヤーだけが必要な場合は破棄してください。`layers` には `0` を指定でき、その場合はこの画像だけが得られます。
+
+**すべてのレイヤーを合成し直すと完全な画像が再現されます。** これは確認に使えます。レイヤーを重ねても最初の画像が再現されない場合、分解は意図したとおりに機能していません。
+
+### レイヤーが個別の画像になる仕組み
+
+**Empty Qwen Image Layered Latent** ノードは `[batch_size, 16, layers + 1, height // 8, width // 8]` という形状の 5D Latent を確保します。レイヤーは 3 番目の軸に並び、これは映像モデルがフレームを置くのと同じ時間軸です。**LatentCutToBatch** ノードの `dim` を `t` に設定するとその軸がバッチ次元へ移されるため、**VAE Decode** の後は各レイヤーがバッチ内の個別の画像になります。
+
+したがって、レイヤーの重なり順はバッチ内のインデックスそのものであり、インデックス 0 の完全な画像から数えます。z-index フィールドも、その順序を保持するレイヤーごとのメタデータも存在しないため、バッチを並べ替えたりフィルタリングしたりすることは、そのままレイヤーの並べ替えになります。
+
+Qwen-Image-Layered の VAE は 4 チャンネルにデコードするため、デコードされたレイヤーはアルファチャンネルを持ちます。
 
 ## ワークフローの設定
 

--- a/ko/tutorials/image/qwen/qwen-image-layered.mdx
+++ b/ko/tutorials/image/qwen/qwen-image-layered.mdx
@@ -2,13 +2,14 @@
 title: "Qwen-Image-Layered ComfyUI 워크플로우 예시"
 description: "Qwen-Image-Layered는 이미지를 여러 개의 RGBA 레이어로 분해할 수 있는 모델로, 레이어 분해를 통해 본질적인 편집 가능성을 제공합니다."
 sidebarTitle: "Qwen-Image-Layered"
-translationSourceHash: bf2f2000
+translationSourceHash: dba6b09a
 translationFrom: tutorials/image/qwen/qwen-image-layered.mdx
 translationBlockHashes:
   "_intro": 19900234
   "Qwen-Image-Layered workflow": ba937275
   "Model links": 98d12555
   "FP8 version": 6bffdd17
+  "Layers and output": 2419fd13
   "Workflow settings": b0f81aa2
 ---
 
@@ -74,6 +75,30 @@ import UpdateReminder from '/snippets/ko/tutorials/update-reminder.mdx'
 - [qwen_image_layered_fp8mixed.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image-Layered_ComfyUI/blob/main/split_files/diffusion_models/qwen_image_layered_fp8mixed.safetensors)
 
 그런 다음 [서브그래프](/ko/interface/features/subgraph) 내의 **Load Diffusion model** 노드를 업데이트하여 이를 사용하세요.
+
+## 레이어와 출력
+
+레이어 수는 [서브그래프](/ko/interface/features/subgraph) 내의 **Empty Qwen Image Layered Latent** 노드에 있는 `layers` 위젯으로 설정합니다.
+
+이 모델은 레이어와 함께 전체 이미지도 다시 생성하므로, 한 번의 생성은 항상 `layers + 1`개의 이미지로 디코딩됩니다.
+
+| `layers` | 디코딩되는 이미지 수 | 내용 |
+| --- | --- | --- |
+| `0` | 1 | 전체 이미지만 |
+| `2` (템플릿 기본값) | 3 | 전체 이미지, 그다음 레이어 2개 |
+| `5` | 6 | 전체 이미지, 그다음 레이어 5개 |
+
+**첫 번째 이미지는 전체 이미지이며 레이어가 아닙니다.** 이미지를 레이어로 분해하는 워크플로우에서는 입력 이미지를 재현한 것이므로, 레이어만 필요하다면 이 이미지는 버리세요. `layers`에는 `0`을 지정할 수 있으며, 이 경우 해당 이미지 하나만 얻게 됩니다.
+
+**모든 레이어를 다시 합성하면 전체 이미지가 재현됩니다.** 이를 검증에 사용하세요. 레이어를 쌓아도 첫 번째 이미지가 재현되지 않는다면 분해가 의도대로 이루어지지 않은 것입니다.
+
+### 레이어가 개별 이미지가 되는 방식
+
+**Empty Qwen Image Layered Latent** 노드는 `[batch_size, 16, layers + 1, height // 8, width // 8]` 형태의 5D Latent를 할당합니다. 레이어는 세 번째 축에 놓이며, 이는 비디오 모델이 프레임을 두는 것과 같은 시간 축입니다. **LatentCutToBatch** 노드의 `dim`을 `t`로 설정하면 그 축이 배치 차원으로 옮겨지므로, **VAE Decode** 이후 각 레이어는 배치 안의 개별 이미지가 됩니다.
+
+따라서 레이어의 쌓임 순서는 배치 안에서의 인덱스 그 자체이며, 인덱스 0의 전체 이미지부터 셉니다. z-index 필드도, 그 순서를 담는 레이어별 메타데이터도 없으므로 배치를 재정렬하거나 걸러내는 것은 곧 레이어를 재정렬하는 것입니다.
+
+Qwen-Image-Layered VAE는 4채널로 디코딩하므로 디코딩된 레이어는 알파 채널을 가집니다.
 
 ## 워크플로우 설정
 

--- a/tutorials/image/qwen/qwen-image-layered.mdx
+++ b/tutorials/image/qwen/qwen-image-layered.mdx
@@ -66,6 +66,30 @@ By default we are using bf16, which requires high VRAM. For lower VRAM usage, yo
 
 Then update the **Load Diffusion model** node inside the [Subgraph](/interface/features/subgraph) to use it.
 
+## Layers and output
+
+The number of layers is set by the `layers` widget on the **Empty Qwen Image Layered Latent** node inside the [Subgraph](/interface/features/subgraph).
+
+This model regenerates the full image as well as the layers, so a generation always decodes to `layers + 1` images:
+
+| `layers` | Images decoded | Contents |
+| --- | --- | --- |
+| `0` | 1 | The full image only |
+| `2` (template default) | 3 | The full image, then 2 layers |
+| `5` | 6 | The full image, then 5 layers |
+
+**The first image is the full image, not a layer.** In the image to layers workflow it reproduces the input image, so discard it when you only want the layers. `layers` accepts `0`, which gives you that image on its own.
+
+**Compositing all of the layers back together recreates the full image.** Use it as a check: if stacking the layers does not reproduce the first image, the decomposition did not do what you wanted.
+
+### How the layers become separate images
+
+The **Empty Qwen Image Layered Latent** node allocates a 5D latent shaped `[batch_size, 16, layers + 1, height // 8, width // 8]`. The layers sit on the third axis, the same temporal axis that video models use for frames. The **LatentCutToBatch** node with `dim` set to `t` moves that axis into the batch dimension, so after **VAE Decode** each layer is a separate image in the batch.
+
+A layer's position in the stack is therefore its index in the batch, counting from the full image at index 0. There is no z-index field and no per-layer metadata carrying that order, so reordering or filtering the batch reorders the layers.
+
+The Qwen-Image-Layered VAE decodes to 4 channels, so the decoded layers carry an alpha channel.
+
 ## Workflow settings
 
 ### Sampler settings

--- a/zh/tutorials/image/qwen/qwen-image-layered.mdx
+++ b/zh/tutorials/image/qwen/qwen-image-layered.mdx
@@ -2,13 +2,14 @@
 title: "Qwen-Image-Layered ComfyUI 工作流示例"
 description: "Qwen-Image-Layered 是一个能够将图像分解为多个 RGBA 图层的模型，通过图层分解实现固有的可编辑性。"
 sidebarTitle: "Qwen-Image-Layered"
-translationSourceHash: bf2f2000
+translationSourceHash: dba6b09a
 translationFrom: tutorials/image/qwen/qwen-image-layered.mdx
 translationBlockHashes:
   "_intro": 19900234
   "Qwen-Image-Layered workflow": ba937275
   "Model links": 98d12555
   "FP8 version": 6bffdd17
+  "Layers and output": 2419fd13
   "Workflow settings": b0f81aa2
 ---
 
@@ -74,6 +75,30 @@ import UpdateReminder from '/snippets/zh/tutorials/update-reminder.mdx'
 - [qwen_image_layered_fp8mixed.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image-Layered_ComfyUI/blob/main/split_files/diffusion_models/qwen_image_layered_fp8mixed.safetensors)
 
 然后更新[子图](/zh/interface/features/subgraph)中的 **Load Diffusion model** 节点来使用它。
+
+## 图层和输出
+
+图层数量由[子图](/zh/interface/features/subgraph)内 **Empty Qwen Image Layered Latent** 节点上的 `layers` 组件设置。
+
+该模型会在生成图层的同时重新生成完整图像，因此一次生成总是解码出 `layers + 1` 张图像：
+
+| `layers` | 解码出的图像数 | 内容 |
+| --- | --- | --- |
+| `0` | 1 | 仅完整图像 |
+| `2`（模板默认值） | 3 | 完整图像，然后是 2 个图层 |
+| `5` | 6 | 完整图像，然后是 5 个图层 |
+
+**第一张图像是完整图像，而不是图层。** 在图像转图层的工作流中，它重现的是输入图像，因此当你只需要图层时应将其丢弃。`layers` 可以设为 `0`，此时只会得到这一张图像。
+
+**将所有图层合成回去可以重建完整图像。** 可以用它来检查：如果堆叠图层无法重现第一张图像，说明分解没有达到预期效果。
+
+### 图层如何变成单独的图像
+
+**Empty Qwen Image Layered Latent** 节点会分配一个形状为 `[batch_size, 16, layers + 1, height // 8, width // 8]` 的 5D Latent。图层位于第三个轴上，也就是视频模型用于存放帧的那个时间轴。将 **LatentCutToBatch** 节点的 `dim` 设置为 `t`，会把该轴移动到批次维度上，因此在 **VAE Decode** 之后，每个图层都是批次中一张单独的图像。
+
+因此，图层在堆栈中的位置就是它在批次中的索引，从索引 0 处的完整图像开始计数。这里没有 z-index 字段，也没有承载该顺序的逐图层元数据，因此重新排序或过滤批次就等于重新排序图层。
+
+Qwen-Image-Layered VAE 解码为 4 个通道，因此解码出的图层带有 Alpha 通道。
 
 ## 工作流设置
 


### PR DESCRIPTION
## Problem

`tutorials/image/qwen/qwen-image-layered.mdx` has no section on the `layers` widget and never says what a generation produces. A reader following the template gets three images out of a `layers = 2` run and has no way to know that the first one is not a layer.

These semantics are not written down anywhere: not in core, not on docs.comfy.org, not on the Hugging Face model card. A core maintainer could not work them out from the code and had to ask.

## What is actually true

comfyanonymous, on this model:

> it's a model specific thing, it's because this model is an image generation model that regenerates the full image and the layers
>
> so if you set layers to zero you get only the original image
>
> but if you set layers to 2 you get the original image + 2 layers
>
> the first image is exactly the same as the original and should be discarded
>
> and all the layers when composited together should recreate the original image

Verified against source:

- `comfy_extras/nodes_qwen.py:109-130`: `EmptyQwenImageLayeredLatentImage` allocates `torch.zeros([batch_size, 16, layers + 1, height // 8, width // 8])`, and `layers` has `min=0`.
- `comfy_extras/nodes_latent.py:217-256`: `LatentCutToBatch` with `dim="t"` reshapes the temporal axis into the batch dimension, so the decoded z-order is purely the batch index. Nothing else carries it.
- `comfy/sd.py:791` sets `output_channels` from `encoder.conv1.weight`; the Qwen-Image-Layered VAE ships that as `[96, 4, 3, 3, 3]`, so it decodes to 4 channels.
- The shipped template `templates/image_qwen_image_layered.json` wires `EmptyQwenImageLayeredLatentImage` (`layers = 2`) into `LatentCutToBatch(dim="t")` into `VAEDecode` into `SaveImage`, which is why the default run saves 3 images.

## Change

A new `## Layers and output` section on the English page and its zh / ja / ko mirrors, covering:

- the `layers + 1` output count, with a small table for `0` / `2` / `5`
- that image 0 is the full image, not a layer, and should be discarded when only the layers are wanted
- that `layers = 0` is valid and yields that image alone
- the reconstruction guarantee, framed as a check the reader can actually run
- the temporal-axis mechanism and the fact that z-order is positional with no z-index field or per-layer metadata
- that decoded layers carry alpha

No screenshots needed: this page embeds none, and it stated no output count that is now contradicted.

## Translations

zh / ja / ko were regenerated with the repo's own pipeline (`pnpm translate` on the new block only, incremental), then read back and repunctuated by hand so the new section matches the fullwidth punctuation and latin spacing of the surrounding text on each page. `pnpm translate:check-truncation` reports no issues for this page.

## Related, not fixed here

comfyanonymous also said *"our qwen layered template is slightly wrong"*, meaning the template saves the duplicate first image. That is a fix in `Comfy-Org/workflow_templates`, not here.
