### PR TITLE
Make translate:sync-hash idempotent

### DIFF
--- a/.github/scripts/i18n/chunked-translate.ts
+++ b/.github/scripts/i18n/chunked-translate.ts
@@ -232,6 +232,20 @@ export function stripTranslationMetaFromFrontmatter(body: string): string {
   return out;
 }
 
+/**
+ * Reassemble the opening `---` plus whatever frontmatter survived meta
+ * stripping, ready for a translation meta block to be appended.
+ *
+ * When the frontmatter held nothing but translation metadata, `cleaned` is
+ * empty and the naive `${open}${cleaned}\n` leaves a blank first line inside
+ * the frontmatter that the next run cannot remove — the write stops being
+ * idempotent. See https://github.com/Comfy-Org/docs/issues/1358.
+ */
+export function frontmatterMetaPrefix(open: string, cleaned: string): string {
+  const head = cleaned.replace(/\n+$/, "");
+  return head ? `${open}${head}\n` : open;
+}
+
 export function setChunkedTranslationMeta(
   content: string,
   fileHash: string,
@@ -253,7 +267,7 @@ export function setChunkedTranslationMeta(
   const [, open, body, close] = fmMatch;
   const rest = content.slice(fmMatch[0].length);
   const cleaned = stripTranslationMetaFromFrontmatter(body);
-  return `${open}${cleaned}\n${metaBlock}${close}${rest}`;
+  return `${frontmatterMetaPrefix(open, cleaned)}${metaBlock}${close}${rest}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/i18n/sync-hash-i18n.test.ts
+++ b/.github/scripts/i18n/sync-hash-i18n.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { computeSyncedContent, syncChunkedHashes, syncPlainHashes } from "./sync-hash-i18n.ts";
+import { parseFrontmatterAndBody } from "./chunked-translate.ts";
+
+// Regression coverage for https://github.com/Comfy-Org/docs/issues/1358.
+//
+// syncChunkedHashes used to reassemble the file as `${frontmatter}\n${body}`
+// while parseFrontmatterAndBody had already put the separating newline into
+// `frontmatter`. Every pass therefore gained one blank line after the closing
+// `---`, `output === targetContent` in syncOneFile could never hold, and
+// `translate:sync-hash --dry-run` reported 71 of 84 files as drifted on a clean
+// main. The invariant these tests protect is simply: running the sync twice must
+// be the same as running it once.
+
+const EN = `---
+title: "Wan Dancer"
+description: "Generate dance video from music."
+---
+
+Intro paragraph that belongs to the implicit _intro block.
+
+## Model Highlights
+
+Layered audio-driven framework built on Wan 2.2.
+
+## Workflow Overview
+
+Feed a reference image and an audio track.
+`;
+
+const TARGET = `---
+title: "Wan Dancer：从音乐生成舞蹈视频"
+description: "使用 Wan Dancer 从音乐生成舞蹈视频。"
+---
+
+import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx"
+
+开头段落。
+
+## 模型亮点
+
+基于 Wan 2.2 构建的分层音频驱动框架。
+
+## 工作流概览
+
+输入参考图像和音频。
+`;
+
+const EN_REL = "tutorials/video/wan/wan-dancer.mdx";
+
+function blankLinesAfterFrontmatter(content: string): number {
+  const match = content.match(/^---\n[\s\S]*?\n---\n(\n*)/);
+  return match?.[1]?.length ?? 0;
+}
+
+describe("syncChunkedHashes idempotency", () => {
+  test("running the sync twice is the same as running it once", () => {
+    const once = syncChunkedHashes(EN, TARGET, "heading_sections", EN_REL);
+    const twice = syncChunkedHashes(EN, once, "heading_sections", EN_REL);
+    expect(twice).toBe(once);
+  });
+
+  test("stays stable over repeated passes", () => {
+    let content = syncChunkedHashes(EN, TARGET, "heading_sections", EN_REL);
+    for (let i = 0; i < 5; i++) {
+      content = syncChunkedHashes(EN, content, "heading_sections", EN_REL);
+    }
+    expect(content).toBe(syncChunkedHashes(EN, TARGET, "heading_sections", EN_REL));
+  });
+
+  test("does not insert a blank line after the frontmatter", () => {
+    expect(blankLinesAfterFrontmatter(TARGET)).toBe(1);
+    let content = TARGET;
+    for (let i = 0; i < 3; i++) {
+      content = syncChunkedHashes(EN, content, "heading_sections", EN_REL);
+      expect(blankLinesAfterFrontmatter(content)).toBe(1);
+    }
+  });
+
+  test("leaves the body byte-for-byte untouched", () => {
+    const before = parseFrontmatterAndBody(TARGET).body;
+    const after = parseFrontmatterAndBody(
+      syncChunkedHashes(EN, TARGET, "heading_sections", EN_REL)
+    ).body;
+    expect(after).toBe(before);
+  });
+
+  test("preserves blank lines a previous buggy run already committed", () => {
+    // Files touched by the old script carry extra blank lines. The fix must not
+    // add more, and must not silently reflow prose that a human may have edited.
+    const withExtraBlanks = TARGET.replace(/^(---\n[\s\S]*?\n---\n)/, "$1\n\n");
+    expect(blankLinesAfterFrontmatter(withExtraBlanks)).toBe(3);
+    const once = syncChunkedHashes(EN, withExtraBlanks, "heading_sections", EN_REL);
+    expect(blankLinesAfterFrontmatter(once)).toBe(3);
+    expect(syncChunkedHashes(EN, once, "heading_sections", EN_REL)).toBe(once);
+  });
+
+  test("handles frontmatter that holds nothing but translation metadata", () => {
+    // zh/custom-nodes/workflow_templates.mdx is shaped like this. Stripping the
+    // meta leaves an empty frontmatter body, and the old code then emitted
+    // "---\n\ntranslationSourceHash: …", a blank line no later run could clear.
+    const metaOnly = [
+      "---",
+      "translationSourceHash: deadbeef",
+      "translationFrom: tutorials/video/wan/wan-dancer.mdx",
+      "---",
+      "",
+      "开头段落。",
+      "",
+      "## 模型亮点",
+      "",
+      "正文。",
+      "",
+    ].join("\n");
+    const once = syncChunkedHashes(EN, metaOnly, "heading_sections", EN_REL);
+    expect(once).not.toContain("---\n\ntranslationSourceHash");
+    expect(syncChunkedHashes(EN, once, "heading_sections", EN_REL)).toBe(once);
+  });
+
+  test("works when the target has no frontmatter at all", () => {
+    const bare = "开头段落。\n\n## 模型亮点\n\n正文。\n";
+    const once = syncChunkedHashes(EN, bare, "heading_sections", EN_REL);
+    expect(once.startsWith("---\n")).toBe(true);
+    expect(syncChunkedHashes(EN, once, "heading_sections", EN_REL)).toBe(once);
+  });
+});
+
+describe("computeSyncedContent reaches the unchanged branch", () => {
+  // syncOneFile reports "unchanged" only when the stored hash matches AND
+  // `output === targetContent`. The second condition was unreachable for every
+  // chunked file, which is what made --dry-run useless as a drift signal.
+  const CHUNKED_REL = "tutorials/partner-nodes/pricing.mdx"; // configured as heading_sections
+
+  test("a synced file is reported as producing identical output", () => {
+    const first = computeSyncedContent(EN, TARGET, CHUNKED_REL, EN_REL, false);
+    const second = computeSyncedContent(EN, first.output, CHUNKED_REL, EN_REL, false);
+    expect(second.output).toBe(first.output);
+    expect(second.expectedFileHash).toBe(first.expectedFileHash);
+  });
+
+  test("the synced file records the hash syncOneFile compares against", () => {
+    const { output, expectedFileHash } = computeSyncedContent(
+      EN,
+      TARGET,
+      CHUNKED_REL,
+      EN_REL,
+      false
+    );
+    expect(output).toContain(`translationSourceHash: ${expectedFileHash}`);
+  });
+});
+
+describe("syncPlainHashes idempotency", () => {
+  const PLAIN_TARGET = `---
+title: "登录"
+---
+
+正文内容。
+`;
+
+  test("page metadata round-trips", () => {
+    const once = syncPlainHashes(PLAIN_TARGET, EN, EN_REL, false);
+    expect(syncPlainHashes(once, EN, EN_REL, false)).toBe(once);
+    expect(blankLinesAfterFrontmatter(once)).toBe(1);
+  });
+
+  test("snippet comment round-trips", () => {
+    const snippet = "这是一个片段。\n";
+    const once = syncPlainHashes(snippet, EN, EN_REL, true);
+    expect(syncPlainHashes(once, EN, EN_REL, true)).toBe(once);
+  });
+});

--- a/.github/scripts/i18n/sync-hash-i18n.ts
+++ b/.github/scripts/i18n/sync-hash-i18n.ts
@@ -30,6 +30,7 @@ import {
   canonicalBlockLabelOrder,
   changelogLabelHash,
   documentBlockHashes,
+  frontmatterMetaPrefix,
   getSectionSyncStatus,
   parseDocument,
   parseFrontmatterAndBody,
@@ -79,7 +80,7 @@ function setTranslationMeta(content: string, hash: string, enPath: string): stri
   const [, open, body, close] = fmMatch;
   const rest = content.slice(fmMatch[0].length);
   const cleaned = stripTranslationMetaFromFrontmatter(body);
-  return `${open}${cleaned}\n${metaBlock}${close}${rest}`;
+  return `${frontmatterMetaPrefix(open, cleaned)}${metaBlock}${close}${rest}`;
 }
 
 function setSnippetHash(content: string, hash: string): string {
@@ -168,8 +169,14 @@ function syncChunkedHashes(
     strategy,
     enDoc.blocks.map((b) => b.label)
   );
+  // `frontmatter` already carries the newline that separates it from `body`
+  // (parseFrontmatterAndBody appends one and consumes the original), so
+  // `frontmatter + body` reconstructs the file exactly. Adding another "\n"
+  // here injected a blank line on every run, which made `output` differ from
+  // `targetContent` forever and left the `unchanged` branch in syncOneFile
+  // unreachable. See https://github.com/Comfy-Org/docs/issues/1358.
   const bodyText = body.endsWith("\n") ? body : `${body}\n`;
-  const raw = `${frontmatter}\n${bodyText}`;
+  const raw = `${frontmatter}${bodyText}`;
   return setChunkedTranslationMeta(raw, fileHash, enRel, enBlockHashes, labelOrder);
 }
 
@@ -434,7 +441,13 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Guarded so the module can be imported by tests without running a full sync
+// over the repo. Nothing else changes: `bun sync-hash-i18n.ts` still runs main().
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { computeSyncedContent, syncChunkedHashes, syncPlainHashes };

--- a/.github/scripts/i18n/translate-i18n.ts
+++ b/.github/scripts/i18n/translate-i18n.ts
@@ -95,6 +95,7 @@ import {
   resolveChunkStrategy,
   serializeChunkedDocument,
   splitOversizedBlock,
+  frontmatterMetaPrefix,
   stripTranslationMetaFromFrontmatter,
   syncUpdateBlockDescription,
   validateTranslatedBlock,
@@ -331,7 +332,7 @@ function setTranslationMeta(content: string, hash: string, enPath: string): stri
   const rest = content.slice(fmMatch[0].length);
   const cleaned = stripAndSanitizeTranslationMeta(body);
 
-  return `${open}${cleaned}\n${metaBlock}${close}${rest}`;
+  return `${frontmatterMetaPrefix(open, cleaned)}${metaBlock}${close}${rest}`;
 }
 
 /** Set hash on snippet files (no frontmatter) via HTML comment */

--- a/.github/workflows/i18n-scripts-test.yml
+++ b/.github/workflows/i18n-scripts-test.yml
@@ -1,0 +1,36 @@
+name: i18n Script Tests
+
+# The i18n scripts already ship bun:test suites
+# (.github/scripts/i18n/*.test.ts) but nothing ran them, so
+# https://github.com/Comfy-Org/docs/issues/1358 — sync-hash-i18n appending a
+# blank line on every run — was invisible to CI. This job runs them.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/scripts/i18n/**'
+      - '.github/workflows/i18n-scripts-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/scripts/i18n/**'
+      - '.github/workflows/i18n-scripts-test.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run i18n script tests
+        run: bun test ./.github/scripts/i18n/


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/docs/issues/1358.

## The bug

`syncChunkedHashes` reassembles each translated file as:

```ts
const { frontmatter, body } = parseFrontmatterAndBody(targetContent);
const bodyText = body.endsWith("\n") ? body : `${body}\n`;
const raw = `${frontmatter}\n${bodyText}`;
```

`parseFrontmatterAndBody` already appends the separating newline to `frontmatter` and consumes the original from `body`:

```ts
const match = content.match(/^(---\n[\s\S]*?\n---)\n?([\s\S]*)$/);
return { frontmatter: `${match[1]}\n`, body: match[2] };
```

So `frontmatter + body` reconstructs the file exactly, and the extra `\n` adds a blank line after the closing `---` on every pass.

The blank line lives in the body, so it changes no hash. That is why the tool kept reporting drift on files whose recorded hashes were already correct: `output === targetContent` in `syncOneFile` could never hold, so the `unchanged` branch was unreachable for every chunked file.

## Verified

Repeated full runs on a clean `main`, before:

| run | reported | cumulative diff |
| --- | --- | --- |
| 1 | 71 updated | 253 insertions |
| 2 | 17 updated | 270 insertions |
| 3 | 17 updated | 287 insertions |
| 4 | 17 updated | 304 insertions |
| 5 | 17 updated | 321 insertions |

Unbounded — 17 files never converged.

After:

| run | reported | cumulative diff |
| --- | --- | --- |
| 1 | 60 updated | 203 insertions |
| 2 | **0 updated** | 203 insertions |
| 3 | **0 updated** | 203 insertions |

`--dry-run` afterwards prints `Nothing to sync. Hashes already match English source.`

The 71 → 60 drop is the false positives disappearing; the remaining 60 are genuine English-source drift, which this PR does not write. The reproduction from the issue now reports the opposite of what it used to:

```
$ bun .github/scripts/i18n/sync-hash-i18n.ts --dry-run tutorials/image/qwen/qwen-image-layered.mdx
  [ja] already in sync: ja/tutorials/image/qwen/qwen-image-layered.mdx
  [zh] already in sync: zh/tutorials/image/qwen/qwen-image-layered.mdx
  [ko] already in sync: ko/tutorials/image/qwen/qwen-image-layered.mdx
Done: 0 updated, 3 already in sync, 0 missing target(s)
```

## A second instance of the same defect, found by the test

Writing the regression test surfaced a second non-idempotent path. When the frontmatter contains nothing but translation metadata, stripping it leaves `cleaned` empty and `${open}${cleaned}\n${metaBlock}` emits a blank first line *inside* the frontmatter:

```
run 0: "---\ntranslationSourceHash: aaaaaaaa\n…"
run 1: "---\n\ntranslationSourceHash: aaaaaaaa\n…"   ← gained a line
run 2: "---\n\ntranslationSourceHash: aaaaaaaa\n…"   ← stable from here
```

Bounded rather than unbounded, but still not idempotent, and it is live on `zh/custom-nodes/workflow_templates.mdx`. Fixed once as a shared `frontmatterMetaPrefix` helper and applied at all three call sites — `chunked-translate.ts`, `sync-hash-i18n.ts`, and `translate-i18n.ts`, which carried the identical code.

## Regression test

`sync-hash-i18n.test.ts`, 11 tests. The load-bearing ones:

- `running the sync twice is the same as running it once` — the invariant the issue asks for.
- `stays stable over repeated passes` — five passes, byte-identical.
- `does not insert a blank line after the frontmatter` — fails on the old code at pass 1.
- `leaves the body byte-for-byte untouched`.
- `preserves blank lines a previous buggy run already committed` — the fix must not add more, and must not reflow prose a human may have edited.
- `handles frontmatter that holds nothing but translation metadata` — the second bug above.
- `computeSyncedContent reaches the unchanged branch` — the branch that was dead.

To make the module importable without executing a repo-wide sync, `main()` is now behind `import.meta.main`. Running `bun .github/scripts/i18n/sync-hash-i18n.ts` is unchanged.

## Nothing ran the tests

`.github/scripts/i18n/` already shipped `chunked-translate.test.ts` and `repair-fences.test.ts`, and no workflow invoked them — which is the reason this was invisible to CI, and a regression test added without fixing that would have been decoration. `i18n-scripts-test.yml` runs `bun test ./.github/scripts/i18n/` on changes under that directory. All 31 tests (20 pre-existing + 11 new) pass.

## The blank lines already in the history — deliberately a separate PR

526 translated `.mdx` files carry blank lines this tool added. Attributed against `d56a77bd^`, the commit before the tool existed:

| | files |
| --- | --- |
| translated files with ≥2 blank lines after frontmatter today | 542 |
| grew since the tool landed | **526** |
| unchanged since before the tool existed (legitimate) | 4 |
| created after the tool landed | 12 |

Growth pattern: 498 went 1 → 2, 18 went 1 → 3, 6 went 1 → 4, 3 went 2 → 3, 1 went 0 → 2. Worst case is 9 blank lines (`zh/tutorials/video/minimax/minimax-h3.mdx`). `6a4aa997` (https://github.com/Comfy-Org/docs/pull/1228) is one of the commits that added them.

That cleanup is a mechanical whitespace diff across 526 files. Folding it in here would bury a four-line logic fix under an unreviewable diff, and it is only durable once this PR lands — before that, the next `translate:sync-hash` run puts the lines straight back. It is opened as a stacked follow-up rather than deferred: https://github.com/Comfy-Org/docs/pull/1361