### PR TITLE
docs(mcp): local connection installs from PyPI — pip install comfy-mcp is live

### DIFF
--- a/agent-tools/mcp.mdx
+++ b/agent-tools/mcp.mdx
@@ -509,7 +509,7 @@ Unlike the cloud and partner servers, it talks to the ComfyUI running on **your 
 ### Requirements
 
 - **Python 3.10+**
-- **[comfy-cli](https://github.com/Comfy-Org/comfy-cli)** on your `PATH` (`pip install comfy-cli`) — the engine every tool wraps
+- **[comfy-cli](https://github.com/Comfy-Org/comfy-cli)** on your `PATH` (`pip install "comfy-cli>=1.14.0"`) — the engine every tool wraps
 - **A ComfyUI workspace** — create one with `comfy install` if you don't have one (an existing checkout works via `comfy set-default <path>`)
 - **A running ComfyUI for execution tools.** Start it with `comfy launch`, or call `launch_comfyui`. The server does not launch ComfyUI implicitly.
 
@@ -517,13 +517,13 @@ Unlike the cloud and partner servers, it talks to the ComfyUI running on **your 
 
 ### Installation
 
-From a checkout of the [repository](https://github.com/Comfy-Org/comfy-mcp):
+From [PyPI](https://pypi.org/project/comfy-mcp/):
 
 ```bash
-pip install .        # or `pip install -e .` for a working copy
+pip install comfy-mcp
 ```
 
-This puts a `comfy-mcp` console script on your `PATH` — that command is the MCP server (it speaks MCP over stdio). Point your AI client at it below.
+This puts a `comfy-mcp` console script on your `PATH` — that command is the MCP server (it speaks MCP over stdio). Point your AI client at it below. (Hacking on the server itself? `pip install -e .` from a checkout of the [repository](https://github.com/Comfy-Org/comfy-mcp) instead.)
 
 <Note>
   **`COMFY_BIN` (optional).** MCP clients launch the server with their own environment, which often does **not** include your shell's `PATH`. If `comfy` lives in a virtualenv or a non-standard location, set `COMFY_BIN` to its absolute path (for example `/path/to/venv/bin/comfy`). Every client example below shows where it goes; drop it if `comfy` is already on the environment your client launches the server with.
@@ -597,11 +597,9 @@ Zero to a generated image:
 <Steps>
   <Step title="Install the pieces">
     ```bash
-    git clone https://github.com/Comfy-Org/comfy-mcp
-    cd comfy-mcp
-    pip install comfy-cli     # the engine
-    comfy install             # create a ComfyUI workspace (skip if you have one)
-    pip install .             # this MCP server → the `comfy-mcp` command
+    pip install "comfy-cli>=1.14.0"  # the engine
+    comfy install                    # create a ComfyUI workspace (skip if you have one)
+    pip install comfy-mcp            # this MCP server → the `comfy-mcp` command
     ```
   </Step>
   <Step title="Launch ComfyUI and leave it running">

--- a/ja/agent-tools/mcp.mdx
+++ b/ja/agent-tools/mcp.mdx
@@ -532,7 +532,7 @@ Comfy Cloud MCP はアーリーリリースです。以下の制限は既知の�
 [リポジトリ](https://github.com/Comfy-Org/comfy-mcp) をチェックアウトした状態で:
 
 ```bash
-pip install .        # or `pip install -e .` for a working copy
+pip install comfy-mcp
 ```
 
 これにより `comfy-mcp` コンソールスクリプトが `PATH` 上に追加されます。そのコマンドが MCP サーバーです（stdio 経由で MCP を扱います）。下記で AI クライアントをそれに接続します。
@@ -611,9 +611,9 @@ pip install .        # or `pip install -e .` for a working copy
     ```bash
     git clone https://github.com/Comfy-Org/comfy-mcp
     cd comfy-mcp
-    pip install comfy-cli     # the engine
+    pip install "comfy-cli>=1.14.0"  # the engine
     comfy install             # create a ComfyUI workspace (skip if you have one)
-    pip install .             # this MCP server → the `comfy-mcp` command
+    pip install comfy-mcp            # this MCP server → the `comfy-mcp` command
     ```
   </Step>
   <Step title="ComfyUI を起動してそのまま実行">

--- a/ko/agent-tools/mcp.mdx
+++ b/ko/agent-tools/mcp.mdx
@@ -532,7 +532,7 @@ Comfy Cloud MCP는 초기 릴리스입니다. 다음과 같은 알려진 제한 
 [저장소](https://github.com/Comfy-Org/comfy-mcp)를 체크아웃한 후:
 
 ```bash
-pip install .        # or `pip install -e .` for a working copy
+pip install comfy-mcp
 ```
 
 이렇게 하면 `comfy-mcp` 콘솔 스크립트가 `PATH`에 추가됩니다. 이 명령이 MCP 서버이며(stdio를 통해 MCP 통신), AI 클라이언트가 아래에서 이 서버를 가리키도록 설정하세요.
@@ -611,9 +611,9 @@ pip install .        # or `pip install -e .` for a working copy
     ```bash
     git clone https://github.com/Comfy-Org/comfy-mcp
     cd comfy-mcp
-    pip install comfy-cli     # the engine
+    pip install "comfy-cli>=1.14.0"  # the engine
     comfy install             # create a ComfyUI workspace (skip if you have one)
-    pip install .             # this MCP server → the `comfy-mcp` command
+    pip install comfy-mcp            # this MCP server → the `comfy-mcp` command
     ```
   </Step>
   <Step title="ComfyUI 실행 후 실행 상태로 두기">

--- a/zh/agent-tools/mcp.mdx
+++ b/zh/agent-tools/mcp.mdx
@@ -532,7 +532,7 @@ Comfy Cloud MCP 是早期版本。以下是已知限制，正在改进中：
 从 [仓库](https://github.com/Comfy-Org/comfy-mcp) 的本地检出中：
 
 ```bash
-pip install .        # or `pip install -e .` for a working copy
+pip install comfy-mcp
 ```
 
 这将 `comfy-mcp` 控制台脚本添加到您的 `PATH` 中。该命令就是 MCP 服务器（它通过 stdio 使用 MCP 协议）。接下来将您的 AI 客户端指向它。
@@ -611,9 +611,9 @@ pip install .        # or `pip install -e .` for a working copy
     ```bash
     git clone https://github.com/Comfy-Org/comfy-mcp
     cd comfy-mcp
-    pip install comfy-cli     # the engine
+    pip install "comfy-cli>=1.14.0"  # the engine
     comfy install             # create a ComfyUI workspace (skip if you have one)
-    pip install .             # this MCP server → the `comfy-mcp` command
+    pip install comfy-mcp            # this MCP server → the `comfy-mcp` command
     ```
   </Step>
   <Step title="启动 ComfyUI 并保持运行">


### PR DESCRIPTION
## What

`comfy-mcp` 0.9.0 is now published to PyPI ([BE-5246](https://linear.app/comfyorg/issue/BE-5246/claim-the-comfy-mcp-name-on-pypi-before-announcing) claimed the name; the trusted-publishing workflow shipped the release), so the local-connection docs stop telling users to clone the repo:

- **Installation**: `pip install comfy-mcp` from PyPI; the checkout install (`pip install -e .`) stays as the contributor path.
- **Quickstart**: drops the `git clone` / `cd` steps.
- **Requirements**: pins `comfy-cli>=1.14.0` to match the server README's stated minimum.

English page only — translations follow via the i18n pipeline.

Pairs with the same change to the server README in Comfy-Org/comfy-mcp#210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)