### PR TITLE
docs: fix broken examples and cover serverless

### DIFF
--- a/api-reference/v2/overview.mdx
+++ b/api-reference/v2/overview.mdx
@@ -24,6 +24,7 @@ See [Design Notes](/development/api-development/sdks-design) for the reasoning b
 | Surface | URL | Authentication |
 |---------|-----|----------------|
 | Comfy Cloud | `https://cloud.comfy.org` | `Authorization: Bearer <api-key>` |
+| Serverless deployment | `https://{deployment}.run.comfy.app` | `Authorization: Bearer <api-key>` |
 | Self-hosted, via [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy) | `http://127.0.0.1:8189` | None by default, optional static bearer token |
 
 ## Endpoint Categories

--- a/development/api-development/overview.mdx
+++ b/development/api-development/overview.mdx
@@ -10,7 +10,7 @@ ComfyUI offers several API options depending on where you want to run your workf
 
 ## Start Here
 
-For a new integration, use the **Comfy SDKs** and the Comfy API v2 they call. v2 is a new, versioned HTTP interface. It coexists with the existing Cloud API and ComfyUI Server API. See the [Comfy API v2 Overview](/api-reference/v2/overview). The same code runs against Comfy Cloud and against your own machine.
+For a new integration, use the **Comfy SDKs** and the Comfy API v2 they call. v2 is a new, versioned HTTP interface. It coexists with the existing Cloud API and ComfyUI Server API. See the [Comfy API v2 Overview](/api-reference/v2/overview). The same code runs against Comfy Cloud, a serverless deployment, and your own machine.
 
 <Card title="Comfy SDKs" icon="code" href="/development/api-development/sdks">
   Official Python and TypeScript SDKs for running workflows from your own application. Currently in beta.
@@ -24,12 +24,12 @@ The other APIs below are still fully supported, and they cover surface the SDKs 
 
 | | Comfy API v2 + SDKs | Cloud API | ComfyUI Server API |
 |---|---|---|---|
-| **Where it runs** | Comfy Cloud, or your own machine via a local proxy | Comfy Cloud (managed GPUs) | Your own machine |
+| **Where it runs** | Comfy Cloud, a serverless deployment, or your own machine via a local proxy | Comfy Cloud (managed GPUs) | Your own machine |
 | **Compatibility** | Versioned, additive changes only within v2 | Experimental, may change without notice | No guarantee across releases |
 | **GPU management** | Depends on which surface you point it at | Handled for you | You manage your own hardware |
 | **Models** | Depends on which surface you point it at | Pre-installed and managed by Comfy | You download and manage locally |
 | **Authentication** | `Authorization: Bearer` on Cloud. Self-hosted: none by default, optional static bearer token | `X-API-Key` header (Comfy Cloud account) | None (local) or API key for Partner Nodes |
-| **Base URL** | `https://cloud.comfy.org` or `http://127.0.0.1:8189` | `https://cloud.comfy.org` | Your server URL (e.g. `http://localhost:8188`) |
+| **Base URL** | `https://cloud.comfy.org`, `https://<deployment>.run.comfy.app`, or `http://127.0.0.1:8189`, selected with the `COMFY_BASE_URL` environment variable | `https://cloud.comfy.org` | Your server URL (e.g. `http://localhost:8188`) |
 | **Official clients** | Python and TypeScript SDKs | None, call over HTTP | None, call over HTTP |
 | **Protocol** | REST + SSE | REST + WebSocket | REST + WebSocket |
 | **Scope** | Run a workflow and get results | Full Cloud surface, including models and account | Full local surface, including queue and node info |

--- a/development/api-development/sdks-design.mdx
+++ b/development/api-development/sdks-design.mdx
@@ -13,7 +13,7 @@ You can already drive ComfyUI over HTTP by calling `/prompt` and `/history`. Tho
 
 **A commitment.** v2 is versioned, documented, and supported. Changes within v2 are additive; anything breaking would ship as v3. New releases of ComfyUI will not break your integration.
 
-**Portability.** The same behavior against local ComfyUI, against Comfy Cloud, and against anything else we ship later. Same code, different base URL.
+**Portability.** The same behavior against local ComfyUI, against Comfy Cloud, and against a serverless deployment. Same code, different base URL.
 
 **A shape that survives production.** Durable job IDs, idempotent submission, typed errors, normalized outputs, and real backpressure, instead of every integration reinventing all five on top of `prompt_id` and `/history`.
 
@@ -44,7 +44,7 @@ Nothing is deprecated. `/prompt`, `/history`, `/ws`, and the rest keep working, 
 |---|---|---|
 | **Compatibility** | Versioned. Additive changes only within v2 | No compatibility guarantee across releases |
 | **Concurrency model** | Many jobs in flight, each with a durable ID | One instance, one workflow at a time |
-| **Runs against** | Comfy Cloud and self-hosted ComfyUI, same contract | Cloud API and ComfyUI Server API differ |
+| **Runs against** | Comfy Cloud, serverless deployments, and self-hosted ComfyUI, same contract | Cloud API and ComfyUI Server API differ |
 | **Official clients** | Python and TypeScript SDKs | None |
 | **Best for** | New integrations | Integrations that already work |
 

--- a/development/api-development/sdks.mdx
+++ b/development/api-development/sdks.mdx
@@ -81,14 +81,38 @@ Asset handles are lazy. `photo.png` is hashed locally and only uploaded if the s
 
 `run()` submits the job and waits for it to reach a terminal state. To do work while it executes, use `submit()` instead and watch the [event stream](#watching-a-job-run).
 
-To run against your own ComfyUI instead, change one line and drop the key: `Comfy("http://127.0.0.1:8189")`. See below.
+To run against your own ComfyUI instead, set `COMFY_BASE_URL` and drop the key. See below.
 
 ## Choosing a base URL
 
 | Surface | Base URL | API key |
 |---|---|---|
 | **Comfy Cloud** | `https://cloud.comfy.org` (the default) | Required |
+| **Serverless deployment** | `https://<deployment>.run.comfy.app` | Required |
 | **Your own ComfyUI** | `http://127.0.0.1:8189` (the local proxy) | None by default. Optional static bearer token |
+
+The base URL comes from the `COMFY_BASE_URL` environment variable, not a constructor argument:
+
+```bash
+export COMFY_BASE_URL="https://<deployment>.run.comfy.app"  # serverless
+export COMFY_BASE_URL="http://127.0.0.1:8189"               # self-hosted proxy
+```
+
+It is read each time a client is constructed, must be an `http(s)` URL, and unset or blank means Comfy Cloud. So the client itself is the same everywhere:
+
+<CodeGroup>
+```python Python
+client = Comfy(api_key="comfyui-...")
+```
+
+```typescript TypeScript
+const client = new Comfy({ apiKey: "comfyui-..." });
+```
+</CodeGroup>
+
+<Note>
+  Upgrading from an early build? `Comfy("<url>", "<key>")` is now `Comfy(api_key="<key>")` with `COMFY_BASE_URL` set. `api_key` is keyword-only, so the old positional call raises `TypeError` rather than quietly reading a URL as a key.
+</Note>
 
 ### Comfy Cloud
 
@@ -97,6 +121,12 @@ Works out of the box. Create an [API key](/development/api-development/getting-a
 <Note>
   API access requires a paid Comfy Cloud subscription. The free tier does not include it. How many jobs you can run at once depends on your tier. See [Cloud API Overview](/development/cloud/overview#parallel-execution-concurrent-jobs).
 </Note>
+
+### Serverless deployment
+
+A workflow you deployed through the [developer platform](https://platform.comfy.org) gets its own endpoint. Point `COMFY_BASE_URL` at it and use your API key, exactly as with Comfy Cloud. Everything in this guide works the same way.
+
+Serverless deployments run one pinned workflow, so `get_workflow()` returns the executed graph (`format: "api"`).
 
 ### Your own ComfyUI
 
@@ -109,7 +139,7 @@ comfy-api-proxy
 
 By default it proxies the ComfyUI on `127.0.0.1:8188` and serves the v2 API on `127.0.0.1:8189`. Use `--comfyui` and `--port` to change either.
 
-Then point the SDK at `http://127.0.0.1:8189`. Authentication is not required by default. If the proxy is configured with a static bearer token, pass that token as the SDK API key: `Comfy("http://127.0.0.1:8189", api_key="...")`. The proxy binds to loopback only by default. Run it with `--comfyui-base-dir /path/to/ComfyUI` if you also want to upload model files into your install.
+Then set `COMFY_BASE_URL="http://127.0.0.1:8189"`. Authentication is not required by default. If the proxy is configured with a static bearer token, pass that token as the SDK API key: `Comfy(api_key="...")`. The proxy binds to loopback only by default. Run it with `--comfyui-base-dir /path/to/ComfyUI` if you also want to upload model files into your install.
 
 The proxy is a stopgap. Once the v2 API stabilizes it moves into ComfyUI core and the proxy is no longer needed.
 

--- a/development/api-development/sdks.mdx
+++ b/development/api-development/sdks.mdx
@@ -170,7 +170,9 @@ result = job.result()
 ```typescript TypeScript
 const job = await client.submit(wf);
 
-for await (const event of job.events()) {
+// The label is required: a bare `break` inside a switch leaves the switch,
+// not the loop.
+eventLoop: for await (const event of job.events()) {
   switch (event.kind) {
     case "progress":
       console.log(event.value);
@@ -179,7 +181,7 @@ for await (const event of job.events()) {
       await event.output.toFile(`${event.output.name}`);
       break;
     case "statusChange":
-      if (event.status === "succeeded") break;
+      if (event.status === "succeeded") break eventLoop;
   }
 }
 ```

--- a/development/cloud/api-reference.mdx
+++ b/development/cloud/api-reference.mdx
@@ -558,6 +558,8 @@ Here's a full example that ties everything together:
 
 <CodeGroup>
 ```typescript TypeScript
+import { readFile, writeFile } from "fs/promises";
+
 const BASE_URL = "https://cloud.comfy.org";
 const API_KEY = process.env.COMFY_CLOUD_API_KEY!;
 
@@ -590,6 +592,9 @@ async function waitForCompletion(
     }, timeout);
 
     ws.onmessage = (event) => {
+      // Binary frames carry preview images, not JSON.
+      if (typeof event.data !== "string") return;
+
       const data = JSON.parse(event.data);
       if (data.data?.prompt_id !== promptId) return;
 

--- a/development/cloud/overview.mdx
+++ b/development/cloud/overview.mdx
@@ -299,7 +299,7 @@ The node ID (`"9"` in this example) corresponds to the SaveImage or other output
 <DownloadOutputs />
 
 <Info>
-  The `/api/view` endpoint returns a 302 redirect to a temporary signed URL. Your HTTP client must follow redirects to download the file.
+  The `/api/view` endpoint returns a 302 redirect to a temporary signed URL. Do not follow that redirect with your API key attached: the signed URL points at storage, carries its own authorization, and needs no header from you. Read the `Location` header and fetch it as a separate unauthenticated request, as the samples above do.
 </Info>
 
 ### Complete Example

--- a/snippets/cloud/complete-example.mdx
+++ b/snippets/cloud/complete-example.mdx
@@ -27,8 +27,10 @@ async function main() {
     });
     const { status } = await statusRes.json();
 
-    if (status === "completed") break;
-    if (["failed", "cancelled"].includes(status)) {
+    if (status === "success") break;
+    if (
+      ["error", "non_retryable_error", "lost", "cancelled"].includes(status)
+    ) {
       throw new Error(`Job ${status}`);
     }
     await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -98,9 +100,9 @@ def main():
         )
         status = status_res.json()["status"]
 
-        if status == "completed":
+        if status == "success":
             break
-        if status in ("failed", "cancelled"):
+        if status in ("error", "non_retryable_error", "lost", "cancelled"):
             raise RuntimeError(f"Job {status}")
         time.sleep(2)
 
@@ -120,13 +122,17 @@ def main():
                 "subfolder": file_info.get("subfolder", ""),
                 "type": "output"
             }
+            # Read the redirect instead of following it. requests keeps custom
+            # headers across hosts, which would send the key to storage.
             view_res = requests.get(
                 f"{BASE_URL}/api/view",
                 headers={"X-API-Key": API_KEY},
-                params=params
+                params=params,
+                allow_redirects=False
             )
+            file_res = requests.get(view_res.headers["Location"])
             with open(file_info["filename"], "wb") as f:
-                f.write(view_res.content)
+                f.write(file_res.content)
             print(f"Downloaded: {file_info['filename']}")
 
 if __name__ == "__main__":

--- a/snippets/cloud/download-outputs.mdx
+++ b/snippets/cloud/download-outputs.mdx
@@ -1,12 +1,18 @@
 <CodeGroup>
 ```bash curl
-# Download a single output file (follow 302 redirect with -L)
-curl -L "$BASE_URL/api/view?filename=output.png&subfolder=&type=output" \
-  -H "X-API-Key: $COMFY_CLOUD_API_KEY" \
-  -o output.png
+# Step 1: read the 302 target. Do not use -L here: following the redirect
+# would resend your API key to the storage host.
+SIGNED_URL=$(curl -s -o /dev/null -w '%{redirect_url}' \
+  "$BASE_URL/api/view?filename=output.png&subfolder=&type=output" \
+  -H "X-API-Key: $COMFY_CLOUD_API_KEY")
+
+# Step 2: the signed URL carries its own authorization, so send no headers.
+curl -s "$SIGNED_URL" -o output.png
 ```
 
 ```typescript TypeScript
+import { writeFile } from "fs/promises";
+
 async function downloadOutput(
   filename: string,
   subfolder: string = "",
@@ -69,13 +75,22 @@ def download_output(filename: str, subfolder: str = "", output_type: str = "outp
         "type": output_type
     }
 
+    # Do not follow the redirect. requests drops Authorization on a cross-host
+    # redirect but keeps custom headers, so X-API-Key would reach the storage
+    # host. The signed URL carries its own authorization.
     response = requests.get(
         f"{BASE_URL}/api/view",
         headers=get_headers(),
-        params=params
+        params=params,
+        allow_redirects=False
     )
-    response.raise_for_status()
-    return response.content
+    if response.status_code != 302:
+        raise RuntimeError(f"Expected a 302 redirect, got {response.status_code}")
+    signed_url = response.headers["Location"]
+
+    file_response = requests.get(signed_url)
+    file_response.raise_for_status()
+    return file_response.content
 
 def save_outputs(outputs: dict, output_dir: str = "."):
     """Save all outputs from a job to disk.

--- a/snippets/cloud/poll-job-completion.mdx
+++ b/snippets/cloud/poll-job-completion.mdx
@@ -4,11 +4,13 @@ The API returns one of the following status values:
 
 | Status | Description |
 |--------|-------------|
-| `pending` | Job is queued and waiting to start |
-| `in_progress` | Job is currently executing |
-| `completed` | Job finished successfully |
-| `failed` | Job encountered an error |
-| `cancelled` | Job was cancelled by user |
+| `success` | Job finished successfully. Terminal |
+| `error` | Job failed. Terminal |
+| `non_retryable_error` | Job failed and retrying will not help. Terminal |
+| `lost` | Job disappeared before it could finish. Terminal |
+| `cancelled` | Job was cancelled. Terminal |
+
+Those five are the terminal states. Everything else means the job is still in flight, including `submitted`, `queued_waiting`, `preparing`, `executing`, and transitional states such as `cancel_requested`. Poll until you see a terminal value rather than matching on the in-flight names.
 
 <CodeGroup>
 ```bash curl
@@ -17,11 +19,13 @@ curl -X GET "$BASE_URL/api/job/{prompt_id}/status" \
   -H "X-API-Key: $COMFY_CLOUD_API_KEY"
 
 # Response examples:
-# {"status": "pending"}      - Job is queued
-# {"status": "in_progress"}  - Job is currently running
-# {"status": "completed"}    - Job finished successfully
-# {"status": "failed"}       - Job encountered an error
-# {"status": "cancelled"}    - Job was cancelled
+# {"status": "queued_waiting"}       - Job is queued
+# {"status": "executing"}            - Job is currently running
+# {"status": "success"}              - Job finished successfully
+# {"status": "error"}                - Job encountered an error
+# {"status": "non_retryable_error"}  - Job failed, retrying will not help
+# {"status": "lost"}                 - Job disappeared before finishing
+# {"status": "cancelled"}            - Job was cancelled
 ```
 
 ```typescript TypeScript
@@ -47,9 +51,11 @@ async function pollForCompletion(
   while (Date.now() - startTime < timeout * 1000) {
     const { status } = await getJobStatus(promptId);
 
-    if (status === "completed") {
+    if (status === "success") {
       return;
-    } else if (["failed", "cancelled"].includes(status)) {
+    } else if (
+      ["error", "non_retryable_error", "lost", "cancelled"].includes(status)
+    ) {
       throw new Error(`Job failed with status: ${status}`);
     }
 
@@ -80,9 +86,9 @@ def poll_for_completion(prompt_id: str, timeout: int = 300, poll_interval: float
     while time.time() - start_time < timeout:
         status = get_job_status(prompt_id)
 
-        if status == "completed":
+        if status == "success":
             return
-        elif status in ("failed", "cancelled"):
+        elif status in ("error", "non_retryable_error", "lost", "cancelled"):
             raise RuntimeError(f"Job failed with status: {status}")
 
         time.sleep(poll_interval)

--- a/snippets/cloud/websocket-progress.mdx
+++ b/snippets/cloud/websocket-progress.mdx
@@ -15,6 +15,9 @@ async function listenForCompletion(
     }, timeout);
 
     ws.onmessage = (event) => {
+      // Binary frames carry preview images, not JSON.
+      if (typeof event.data !== "string") return;
+
       const data = JSON.parse(event.data);
       const msgType = data.type;
       const msgData = data.data ?? {};


### PR DESCRIPTION
An audit of the API and SDK pages against the actual sources found examples that fail when copied, one that leaks a credential, and a backend surface the docs never mention. Batched into one PR.

## The Quick Start never finishes

`snippets/cloud/poll-job-completion.mdx` and `snippets/cloud/complete-example.mdx` polled for a status of `completed`. **That state does not exist.** Terminal states are `success`, `error`, `non_retryable_error`, `lost`, `cancelled` (`common/jobstate/state.go:311-317`), and the handler passes the raw value through.

So a successful job never matched. One loop spun to its 300s timeout and threw; the other was a `while (true)`. These snippets render into both `cloud/overview.mdx` and `cloud/api-reference.mdx`, so this was the first thing a new Cloud user copied.

Both now key off the real states, with a note to wait for a terminal value rather than match in-flight names, since that endpoint emits 18 of them.

## The download samples sent the API key to Google Cloud Storage

The `curl` (`-L`) and Python (`requests` + custom header) samples followed a 302 to a signed storage URL with `X-API-Key` still attached. `requests` strips `Authorization` on cross-host redirect but **not** custom headers.

This was reproduced against a two-port mock: the old Python code delivered `X-API-Key: SECRET-KEY` to the storage host. Both now resolve the redirect and fetch the signed URL unauthenticated, matching the TypeScript sample in the same file that already did this and explained why. `cloud/overview.mdx` no longer instructs following the redirect with the key attached.

## Smaller breakages

- **`break` inside a `switch`** in the SDK event-loop example exited the switch, not the `for await`. Its Python twin exits correctly, so the two disagreed. Now a labelled `break eventLoop`.
- **Two missing `fs/promises` imports** in TypeScript samples that call `writeFile`, so they threw `ReferenceError`.
- **`JSON.parse(event.data)` unguarded** on binary WebSocket frames the same page documents. The Python variants already guarded.

## Serverless and COMFY_BASE_URL

The v2 contract publishes three servers, including `https://{deployment}.run.comfy.app`. The guide documented two and never mentioned `COMFY_BASE_URL`, while showing `Comfy("<url>")` construction that raises `TypeError` (the base URL moved to the env var and `api_key` is keyword-only).

Fixed across `sdks.mdx`, `api-development/overview.mdx`, `sdks-design.mdx`, and `api-reference/v2/overview.mdx`, so the prose agrees with the spec rendered beneath it.

## Verification

Samples were **run**, not just read: both polling loops against a mock returning each terminal state, the curl and Python downloads against a redirecting two-port server (confirming the leak first, then its absence), and the labelled break in Node. `tsc --noEmit --strict` on the changed TypeScript. `validate-links.py` and `mint broken-links` both clean. No `ja`/`ko`/`zh` file touched.

## Deliberately not fixed

Cloud error-code tables, deprecated cancel/interrupt endpoints, the workflow-format conversion recipe, and upload limits. Those need `openapi-cloud.yaml` corrected too, and the audit found the spec itself wrong in three places, so patching pages toward it would make things worse. Filing separately.

**Upstream root cause worth its own issue:** `services/ingest/openapi.yaml` declares the job-status enum as `[waiting_to_dispatch, pending, in_progress, completed, error, cancelled]`, but the handler casts `jobstate.State` straight through. Four declared values can never be emitted, and 16 emittable values are undeclared. Generated clients switching on that enum will mis-handle real responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)