### PR TITLE
docs: add v0.33.1 changelog and publish CMS release notes

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -623,6 +623,34 @@
         "zh"
       ],
       "published_at": "2026-08-12T15:49:27.833Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.33.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-14T03:31:13.599Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.33.1",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-14T03:30:21.194Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="August 13, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): Native text-to-music from caption and lyrics, up to 5 minutes
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Support Anima tunes checkpoints with extra blocks
+
+**Partner Node Updates**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Added Context IR prompt enhancer and Regenerate to 2K nodes
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Added Generative Fill, Eraser, Expand Image, and Increase Resolution nodes
+
+</Update>
+
 <Update label="v0.32.0" description="August 11, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 de agosto de 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): generación nativa de texto a música a partir de descripciones y letras, de hasta 5 minutos
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): soporte para checkpoints de Anima tunes con bloques adicionales
+
+**Actualizaciones de nodos de socios**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): se añadieron el potenciador de prompts Context IR y la función Regenerate a los nodos 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): se añadieron los nodos de Relleno Generativo, Borrador, Expandir Imagen y Aumentar Resolución
+
+</Update>
+
 <Update label="v0.32.0" description="11 de agosto de 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 août 2026">
+
+**Nouveau support de modèles open-source**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9) : Texte-vers-musique natif à partir d'une légende et de paroles, jusqu'à 5 minutes
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555) : Prise en charge des checkpoints Anima tunes avec blocs supplémentaires
+
+**Mises à jour des nœuds partenaires**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471) : Ajout de l'améliorateur de prompt Context IR et de Regenerate aux nœuds 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572) : Ajout des nœuds Generative Fill, Eraser, Expand Image et Increase Resolution
+
+</Update>
+
 <Update label="v0.32.0" description="11 août 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新規オープンソースモデルのサポート**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): キャプションと歌詞から最大5分の音楽をネイティブに生成
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 追加ブロックを持つAnima tunesチェックポイントをサポート
+
+**パートナーノードの更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2KノードにContext IRプロンプトエンハンサーとRegenerateを追加しました
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill、Eraser、Expand Image、Increase Resolutionノードを追加しました
+
+</Update>
+
 <Update label="v0.32.0" description="2026年8月11日">
 
 **新規オープンソースモデルサポート**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026년 8월 13일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): 캡션과 가사로부터 최대 5분 분량의 네이티브 텍스트-음악 생성 지원
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 추가 블록이 있는 Anima tunes 체크포인트 지원
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2K 노드에 Context IR 프롬프트 강화 및 Regenerate 추가
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill, 지우개, 이미지 확장, 해상도 향상 노드 추가
+
+</Update>
+
 <Update label="v0.32.0" description="2026년 8월 11일">
 
 **새로운 오픈소스 모델 지원**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 августа 2026">
+
+**Новая поддержка открытых моделей**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): Нативная генерация музыки по описанию и тексту песни, до 5 минут
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Поддержка чекпоинтов Anima tunes с дополнительными блоками
+
+**Обновления партнёрских узлов**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Добавлены улучшитель промптов Context IR и Regenerate для узлов 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Добавлены узлы Generative Fill, Eraser, Expand Image и Increase Resolution
+
+</Update>
+
 <Update label="v0.32.0" description="11 августа 2026 года">
 
 **Поддержка новых моделей с открытым исходным кодом**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -11,7 +11,7 @@ cmsStaging: true
 * [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Поддержка чекпоинтов Anima tunes с дополнительными блоками
 
 **Обновления партнёрских узлов**
-* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Добавлены улучшитель промптов Context IR и Regenerate для узлов 2K
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Добавлены улучшитель промптов Context IR и функция Regenerate для узлов 2K
 * [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Добавлены узлы Generative Fill, Eraser, Expand Image и Increase Resolution
 
 </Update>

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -8,7 +8,7 @@ cmsStaging: true
 
 **新增开源模型支持**
 * [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): 原生根据描述和歌词生成音乐，最长 5 分钟
-* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 支持带有额外块的 Anima tunes 模型
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 支持带有额外块的 Anima tunes 模型检查点
 
 **合作伙伴节点更新**
 * [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 为 2K 节点新增了 Context IR 提示词增强器和重新生成功能

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新增开源模型支持**
+* [**MiniMax Music 3**](https://links.comfy.org/4zgmIJ9): 原生根据描述和歌词生成音乐，最长 5 分钟
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 支持带有额外块的 Anima tunes 模型
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 为 2K 节点新增了 Context IR 提示词增强器和重新生成功能
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): 新增了生成式填充、橡皮擦、展开图像和提高分辨率节点
+
+</Update>
+
 <Update label="v0.32.0" description="2026年8月11日">
 
 **新增开源模型支持**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="August 13, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): Native text-to-music from caption and lyrics, up to 5 minutes
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Support Anima tunes checkpoints with extra blocks
+
+**Partner Node Updates**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Added Context IR prompt enhancer and Regenerate to 2K nodes
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Added Generative Fill, Eraser, Expand Image, and Increase Resolution nodes
+
+</Update>
+
 <Update label="v0.32.0" description="August 11, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 de agosto de 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): generación nativa de texto a música a partir de descripciones y letras, de hasta 5 minutos
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): soporte para checkpoints de Anima tunes con bloques adicionales
+
+**Actualizaciones de nodos de socios**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): se añadieron el potenciador de prompts Context IR y la función Regenerate a los nodos 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): se añadieron los nodos de Relleno Generativo, Borrador, Expandir Imagen y Aumentar Resolución
+
+</Update>
+
 <Update label="v0.32.0" description="11 de agosto de 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 août 2026">
+
+**Nouveau support de modèles open-source**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G) : Texte-vers-musique natif à partir d'une légende et de paroles, jusqu'à 5 minutes
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555) : Prise en charge des checkpoints Anima tunes avec blocs supplémentaires
+
+**Mises à jour des nœuds partenaires**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471) : Ajout de l'améliorateur de prompt Context IR et de Regenerate aux nœuds 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572) : Ajout des nœuds Generative Fill, Eraser, Expand Image et Increase Resolution
+
+</Update>
+
 <Update label="v0.32.0" description="11 août 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新規オープンソースモデルのサポート**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): キャプションと歌詞から最大5分の音楽をネイティブに生成
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 追加ブロックを持つAnima tunesチェックポイントをサポート
+
+**パートナーノードの更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2KノードにContext IRプロンプトエンハンサーとRegenerateを追加しました
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill、Eraser、Expand Image、Increase Resolutionノードを追加しました
+
+</Update>
+
 <Update label="v0.32.0" description="2026年8月11日">
 
 **新規オープンソースモデルサポート**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026년 8월 13일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): 캡션과 가사로부터 최대 5분 분량의 네이티브 텍스트-음악 생성 지원
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 추가 블록이 있는 Anima tunes 체크포인트 지원
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2K 노드에 Context IR 프롬프트 강화 및 Regenerate 추가
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill, 지우개, 이미지 확장, 해상도 향상 노드 추가
+
+</Update>
+
 <Update label="v0.32.0" description="2026년 8월 11일">
 
 **새로운 오픈소스 모델 지원**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="13 августа 2026">
+
+**Новая поддержка открытых моделей**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): Нативная генерация музыки по описанию и тексту песни, до 5 минут
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Поддержка чекпоинтов Anima tunes с дополнительными блоками
+
+**Обновления партнёрских узлов**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Добавлены улучшитель промптов Context IR и Regenerate для узлов 2K
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Добавлены узлы Generative Fill, Eraser, Expand Image и Increase Resolution
+
+</Update>
+
 <Update label="v0.32.0" description="11 августа 2026 года">
 
 **Поддержка новых моделей с открытым исходным кодом**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,18 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新增开源模型支持**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): 原生根据描述和歌词生成音乐，最长 5 分钟
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 支持带有额外块的 Anima tunes 模型
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 为 2K 节点新增了 Context IR 提示词增强器和重新生成功能
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): 新增了生成式填充、橡皮擦、展开图像和提高分辨率节点
+
+</Update>
+
 <Update label="v0.32.0" description="2026年8月11日">
 
 **新增开源模型支持**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,36 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.33.1" description="August 13, 2026">
+
+**New Open-Source Model Support**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): Native text-to-music support for songs up to 5 minutes from caption and lyrics
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): Support Anima tunes checkpoints with extra blocks
+
+**Partner Node Updates**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): Added Context IR prompt enhancer and Regenerate to 2K nodes
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Added Generative Fill, Eraser, Expand Image, and Increase Resolution nodes
+
+**New Nodes**
+* [**MiniMax Music3 Text Encode**](https://github.com/Comfy-Org/ComfyUI/pull/15570): Caption and lyrics text encoding for MiniMax Music 3
+* [**Empty MiniMax Music3 Latent Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15570): Empty audio latent for a requested duration
+
+**Performance & Stability**
+* [**CUDA Graphs**](https://github.com/Comfy-Org/ComfyUI/pull/15570): Native CUDA graph support interoperable with dynamic VRAM
+* [**WSL dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15562): Keep dynamic VRAM enabled on WSL
+* [**aotriton detection**](https://github.com/Comfy-Org/ComfyUI/pull/15412): Query PyTorch for aotriton support instead of scanning its lib directory
+* [**MiniMax Music VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15588): Fixed MiniMax Music on non-dynamic VRAM
+* [**MiniMax QKV detect**](https://github.com/Comfy-Org/ComfyUI/pull/15581): Early detect fused qkv vs separate q,k,v weights
+
+**Bug Fixes**
+* [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447): Fixed `add_noise` disabled on nested latents
+* [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513): Fixed non-ASCII escaping in dict and list previews
+* [**LTX decoder**](https://github.com/Comfy-Org/ComfyUI/pull/15516): Fixed float64 device in LTX diffusion decoder
+* [**Generate Text**](https://github.com/Comfy-Org/ComfyUI/pull/15278): Fixed `thinking=false` ignored on Gemma4 E2B/E4B
+* [**Llama path**](https://github.com/Comfy-Org/ComfyUI/pull/15580): Fixed non-local activation path between Llama blocks
+
+</Update>
+
 <Update label="v0.32.0" description="August 11, 2026">
 
 **New Open-Source Model Support**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 273eee60
+translationSourceHash: 7eb37332
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
   "v0.30.2": 799f6feb
@@ -116,6 +117,36 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新しいオープンソースモデルのサポート**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): キャプションと歌詞から最大5分の曲を生成する、ネイティブなtext-to-musicサポート
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 追加ブロックを持つAnima tunesチェックポイントをサポート
+
+**パートナーノードの更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2KノードにContext IRプロンプトエンハンサーとRegenerateを追加
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill、Eraser(消しゴム)、Expand Image(画像展開)、Increase Resolution(解像度向上)ノードを追加
+
+**新規ノード**
+* [**MiniMax Music3 Text Encode**](https://github.com/Comfy-Org/ComfyUI/pull/15570): MiniMax Music 3用のキャプションと歌詞のテキストエンコーディング
+* [**Empty MiniMax Music3 Latent Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15570): リクエストされた再生時間分の空のオーディオ潜在変数
+
+**パフォーマンスと安定性**
+* [**CUDA Graphs**](https://github.com/Comfy-Org/ComfyUI/pull/15570): 動的VRAMと相互運用可能なネイティブCUDAグラフサポート
+* [**WSL dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15562): WSLで動的VRAMを有効に維持
+* [**aotriton detection**](https://github.com/Comfy-Org/ComfyUI/pull/15412): libディレクトリをスキャンする代わりに、PyTorchにaotritonサポートを問い合わせる
+* [**MiniMax Music VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15588): 非動的VRAMでのMiniMax Musicを修正
+* [**MiniMax QKV detect**](https://github.com/Comfy-Org/ComfyUI/pull/15581): 融合qkvと個別のq、k、vウェイトの早期検出
+
+**バグ修正**
+* [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447): ネストされた潜在変数で`add_noise`が無効になる問題を修正
+* [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513): 辞書とリストのプレビューでの非ASCIIエスケープを修正
+* [**LTX decoder**](https://github.com/Comfy-Org/ComfyUI/pull/15516): LTX diffusionデコーダーでのfloat64デバイスを修正
+* [**TextGenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15278): Gemma4 E2B/E4Bで`thinking=false`が無視される問題を修正
+* [**Llama path**](https://github.com/Comfy-Org/ComfyUI/pull/15580): Llamaブロック間の非ローカルアクティベーションパスを修正
+
+</Update>
 
 <Update label="v0.32.0" description="2026年8月11日">
 

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -143,7 +143,7 @@ translationBlockHashes:
 * [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447): ネストされた潜在変数で`add_noise`が無効になる問題を修正
 * [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513): 辞書とリストのプレビューでの非ASCIIエスケープを修正
 * [**LTX decoder**](https://github.com/Comfy-Org/ComfyUI/pull/15516): LTX diffusionデコーダーでのfloat64デバイスを修正
-* [**TextGenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15278): Gemma4 E2B/E4Bで`thinking=false`が無視される問題を修正
+* [**Generate Text**](https://github.com/Comfy-Org/ComfyUI/pull/15278): Gemma4 E2B/E4Bで`thinking=false`が無視される問題を修正
 * [**Llama path**](https://github.com/Comfy-Org/ComfyUI/pull/15580): Llamaブロック間の非ローカルアクティベーションパスを修正
 
 </Update>

--- a/ja/custom-nodes/walkthrough.mdx
+++ b/ja/custom-nodes/walkthrough.mdx
@@ -73,7 +73,7 @@ class ImageSelector:
 
 <Info>カスタムノードの基本構造については、[こちら](/ja/custom-nodes/backend/server_overview) で詳しく説明されています。</Info>
 
-カスタムノードは Python クラスを使用して定義され、次の 4 つを含む必要があります：`CATEGORY`（カスタムノードが新規追加ノードメニューのどこに配置されるかを指定）、`INPUT_TYPES`（ノードが受け取る入力を定義するクラスメソッド。返される辞書の詳細は [後述](/ja/custom-nodes/backend/server_overview#input-types) を参照）、`RETURN_TYPES`（ノードが生成する出力を定義）、および `FUNCTION`（ノード実行時に呼び出される関数名）。
+カスタムノードは Python クラスを使用して定義され、次の 4 つを含む必要があります：`CATEGORY`（カスタムノードが新規追加ノードメニューのどこに配置されるかを指定）、`INPUT_TYPES`（ノードが受け取る入力を定義するクラスメソッド。返される辞書の詳細は [後述](/ja/custom-nodes/backend/server_overview#input_types) を参照）、`RETURN_TYPES`（ノードが生成する出力を定義）、および `FUNCTION`（ノード実行時に呼び出される関数名）。
 
 <Tip>入力と出力のデータタイプが `IMAGE`（単数形）であることに注意してください。画像バッチを受け取り、1 枚のみを返す場合でも同様です。Comfy では、`IMAGE` は画像バッチを意味し、単一の画像はサイズ 1 のバッチとして扱われます。</Tip>
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 273eee60
+translationSourceHash: 7eb37332
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
   "v0.30.2": 799f6feb
@@ -116,6 +117,36 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.1" description="2026년 8월 13일">
+
+**새로운 오픈소스 모델 지원**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G): 캡션과 가사로 최대 5분 길이의 노래를 생성하는 네이티브 텍스트-투-뮤직 지원
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555): 추가 블록이 포함된 Anima tunes 체크포인트 지원
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471): 2K 노드에 Context IR 프롬프트 강화 기능과 Regenerate 추가
+* [**Bria GenFill, 지우개, 확장 및 업스케일**](https://github.com/Comfy-Org/ComfyUI/pull/15572): Generative Fill, 지우개, 이미지 확장, 해상도 증가 노드 추가
+
+**새로운 노드**
+* [**MiniMax Music3 텍스트 인코드**](https://github.com/Comfy-Org/ComfyUI/pull/15570): MiniMax Music 3용 캡션 및 가사 텍스트 인코딩
+* [**빈 MiniMax Music3 잠재 오디오**](https://github.com/Comfy-Org/ComfyUI/pull/15570): 요청한 재생 시간만큼의 빈 오디오 잠재 데이터
+
+**성능 및 안정성**
+* [**CUDA 그래프**](https://github.com/Comfy-Org/ComfyUI/pull/15570): 동적 VRAM과 호환되는 네이티브 CUDA 그래프 지원
+* [**WSL 동적 VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15562): WSL에서 동적 VRAM 활성화 유지
+* [**aotriton 감지**](https://github.com/Comfy-Org/ComfyUI/pull/15412): lib 디렉터리 검색 대신 PyTorch에 aotriton 지원 여부 확인
+* [**MiniMax Music VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15588): 비동적 VRAM에서 MiniMax Music 문제 수정
+* [**MiniMax QKV 감지**](https://github.com/Comfy-Org/ComfyUI/pull/15581): 융합된 qkv와 분리된 q,k,v 가중치 조기 감지
+
+**버그 수정**
+* [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447): 중첩된 잠재 데이터에서 `add_noise`가 비활성화되던 문제 수정
+* [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513): dict 및 list 미리보기에서 비ASCII 문자가 이스케이프되던 문제 수정
+* [**LTX 디코더**](https://github.com/Comfy-Org/ComfyUI/pull/15516): LTX diffusion 디코더의 float64 디바이스 문제 수정
+* [**텍스트 생성**](https://github.com/Comfy-Org/ComfyUI/pull/15278): Gemma4 E2B/E4B에서 `thinking=false`가 무시되던 문제 수정
+* [**Llama 경로**](https://github.com/Comfy-Org/ComfyUI/pull/15580): Llama 블록 간 비로컬 활성화 경로 문제 수정
+
+</Update>
 
 <Update label="v0.32.0" description="2026년 8월 11일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 273eee60
+translationSourceHash: 7eb37332
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
   "v0.30.2": 799f6feb
@@ -116,6 +117,36 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.1" description="2026年8月13日">
+
+**新增开源模型支持**
+* [**MiniMax Music 3**](https://links.comfy.org/4zmDV3G)：原生文本转音乐支持，可根据描述和歌词生成最长 5 分钟的歌曲
+* [**Anima tunes**](https://github.com/Comfy-Org/ComfyUI/pull/15555)：支持带有额外模块的 Anima tunes 模型
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Context IR & Regenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15471)：为 2K 节点添加了 Context IR 提示词增强器和 Regenerate 功能
+* [**Bria GenFill, Eraser, Expand & Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15572)：新增生成式填充、橡皮擦、展开图像和提升分辨率节点
+
+**新增节点**
+* [**MiniMax Music3 Text Encode**](https://github.com/Comfy-Org/ComfyUI/pull/15570)：MiniMax Music 3 的描述和歌词文本编码
+* [**Empty MiniMax Music3 Latent Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15570)：创建指定时长的空音频 Latent
+
+**性能与稳定性**
+* [**CUDA Graphs**](https://github.com/Comfy-Org/ComfyUI/pull/15570)：原生 CUDA Graphs 支持，可与动态 VRAM 互操作
+* [**WSL dynamic VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15562)：在 WSL 上保持启用动态 VRAM
+* [**aotriton detection**](https://github.com/Comfy-Org/ComfyUI/pull/15412)：改为向 PyTorch 查询 aotriton 支持，而不是扫描其 lib 目录
+* [**MiniMax Music VRAM**](https://github.com/Comfy-Org/ComfyUI/pull/15588)：修复了 MiniMax Music 在非动态 VRAM 上的问题
+* [**MiniMax QKV detect**](https://github.com/Comfy-Org/ComfyUI/pull/15581)：提前检测融合的 qkv 权重与分离的 q、k、v 权重
+
+**Bug 修复**
+* [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447)：修复了嵌套 Latent 上 `add_noise` 被禁用的问题
+* [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513)：修复了字典和列表预览中的非 ASCII 转义问题
+* [**LTX decoder**](https://github.com/Comfy-Org/ComfyUI/pull/15516)：修复了 LTX 扩散解码器中的 float64 设备问题
+* [**TextGenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15278)：修复了 Gemma4 E2B/E4B 上 `thinking=false` 被忽略的问题
+* [**Llama path**](https://github.com/Comfy-Org/ComfyUI/pull/15580)：修复了 Llama 模块之间的非局部激活路径问题
+
+</Update>
 
 <Update label="v0.32.0" description="2026年8月11日">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -143,7 +143,7 @@ translationBlockHashes:
 * [**KSamplerAdvanced**](https://github.com/Comfy-Org/ComfyUI/pull/15447)：修复了嵌套 Latent 上 `add_noise` 被禁用的问题
 * [**PreviewAny**](https://github.com/Comfy-Org/ComfyUI/pull/15513)：修复了字典和列表预览中的非 ASCII 转义问题
 * [**LTX decoder**](https://github.com/Comfy-Org/ComfyUI/pull/15516)：修复了 LTX 扩散解码器中的 float64 设备问题
-* [**TextGenerate**](https://github.com/Comfy-Org/ComfyUI/pull/15278)：修复了 Gemma4 E2B/E4B 上 `thinking=false` 被忽略的问题
+* [**Generate Text**](https://github.com/Comfy-Org/ComfyUI/pull/15278)：修复了 Gemma4 E2B/E4B 上 `thinking=false` 被忽略的问题
 * [**Llama path**](https://github.com/Comfy-Org/ComfyUI/pull/15580)：修复了 Llama 模块之间的非局部激活路径问题
 
 </Update>

--- a/zh/development/cloud/overview.mdx
+++ b/zh/development/cloud/overview.mdx
@@ -39,7 +39,7 @@ API 请求消耗的是与 Comfy Cloud 网页端相同的月度积分配额：不
 https://cloud.comfy.org
 ```
 
-这也是 SDK 的默认目标，因此使用 Comfy Cloud 时无需对其进行配置。若要将同一代码指向 Serverless 部署或你自己的 ComfyUI，请设置 `COMFY_BASE_URL`。请参阅[选择基础 URL](/zh/development/api-development/sdks#choosing-a-base-url)。
+这也是 SDK 的默认目标，因此使用 Comfy Cloud 时无需对其进行配置。若要将同一代码指向 Serverless 部署或你自己的 ComfyUI，请设置 `COMFY_BASE_URL`。请参阅[选择基础 URL](/zh/development/api-development/sdks#选择基础-url)。
 
 ## 身份验证
 
@@ -107,12 +107,12 @@ SDK 只做一件事：运行工作流并取回结果。云端其余功能仅能�
 
 | 功能 | 端点 | 参考 |
 |---|---|---|
-| 队列状态、运行中和待定的任务 | `GET /api/queue` | [队列管理](/zh/development/cloud/api-reference#queue-management) |
-| 中断当前执行 | `POST /api/interrupt` | [队列管理](/zh/development/cloud/api-reference#queue-management) |
-| 节点定义和输入规范 | `GET /api/object_info` | [对象信息](/zh/development/cloud/api-reference#object-info) |
+| 队列状态、运行中和待定的任务 | `GET /api/queue` | [队列管理](/zh/development/cloud/api-reference#队列管理) |
+| 中断当前执行 | `POST /api/interrupt` | [队列管理](/zh/development/cloud/api-reference#队列管理) |
+| 节点定义和输入规范 | `GET /api/object_info` | [对象信息](/zh/development/cloud/api-reference#对象信息) |
 | 浏览可用模型 | 模型端点 | [Cloud API 参考](/zh/development/cloud/api-reference) |
 | 账户和用户信息 | `GET /api/user` | [Cloud API 参考](/zh/development/cloud/api-reference) |
-| 引用现有图像的遮罩上传 | `POST /api/upload/mask` | [上传输入](/zh/development/cloud/api-reference#uploading-inputs) |
+| 引用现有图像的遮罩上传 | `POST /api/upload/mask` | [上传输入](/zh/development/cloud/api-reference#上传输入) |
 
 两种方式都支持取消任务：SDK 可取消你持有句柄的任务，`POST /api/queue` 则按 ID 取消。
 
@@ -120,12 +120,12 @@ SDK 只做一件事：运行工作流并取回结果。云端其余功能仅能�
 
 | 类别 | 描述 |
 |------|------|
-| [工作流](/zh/development/cloud/api-reference#running-workflows) | 提交工作流，检查状态 |
-| [任务](/zh/development/cloud/api-reference#checking-job-status) | 监控任务状态和队列 |
-| [输入](/zh/development/cloud/api-reference#uploading-inputs) | 上传图像、遮罩和其他输入 |
-| [输出](/zh/development/cloud/api-reference#downloading-outputs) | 下载已生成的内容 |
-| [WebSocket](/zh/development/cloud/api-reference#websocket-for-real-time-progress) | 实时进度更新 |
-| [对象信息](/zh/development/cloud/api-reference#object-info) | 可用的节点及其定义 |
+| [工作流](/zh/development/cloud/api-reference#运行工作流) | 提交工作流，检查状态 |
+| [任务](/zh/development/cloud/api-reference#检查任务状态) | 监控任务状态和队列 |
+| [输入](/zh/development/cloud/api-reference#上传输入) | 上传图像、遮罩和其他输入 |
+| [输出](/zh/development/cloud/api-reference#下载输出) | 下载已生成的内容 |
+| [WebSocket](/zh/development/cloud/api-reference#实时进度-websocket) | 实时进度更新 |
+| [对象信息](/zh/development/cloud/api-reference#对象信息) | 可用的节点及其定义 |
 
 ## 错误处理
 
@@ -141,7 +141,7 @@ REST 端点返回标准 HTTP 状态码：
 
 SDK 会改为将这些错误作为类型化异常抛出，包括 `Unauthorized`、`InvalidWorkflow`、`InsufficientCredits`、`QueueFull` 和 `JobFailed`，它们都继承自 `ComfyError`。
 
-执行失败与 HTTP 错误是分开的。有关执行期间传递的 `exception_type` 值，请参阅[错误处理](/zh/development/cloud/api-reference#error-handling)。
+执行失败与 HTTP 错误是分开的。有关执行期间传递的 `exception_type` 值，请参阅[错误处理](/zh/development/cloud/api-reference#错误处理)。
 
 ## 后续步骤
 


### PR DESCRIPTION
## Summary
- Add ComfyUI **v0.33.1** release notes to the docs changelog (EN + zh/ja/ko)
- Prepare and publish CMS popup copy for **comfyui** and **cloud** (en/zh/ja/ko/fr/ru/es)
- Tracking shortlinks: comfyui `4zmDV3G`, cloud `4zgmIJ9` for MiniMax Music 3

## Test plan
- [ ] Preview `changelog/index.mdx` and zh/ja/ko blocks for v0.33.1
- [ ] Confirm Strapi shows published comfyui + cloud v0.33.1 across locales
- [ ] Spot-check MiniMax Music 3 shortlinks resolve correctly per project