### PR TITLE
feat: add anchor link checker CI + fix broken anchors (FE-1620)

### DIFF
--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -221,34 +221,40 @@ def collect_doc_files(root: str) -> list:
 
 
 def git_changed_files(root: str) -> list:
-    """Files changed vs origin/main (fallback: HEAD~1 for direct pushes).
+    """Files changed vs the event's base commit (fallback: HEAD~1).
+
+    The base comes from the ANCHOR_CHECK_BASE env var, which the CI workflow
+    sets from the event context (github.event.before for pushes,
+    github.event.pull_request.base.sha for PRs). Locally it falls back to
+    origin/main, then HEAD~1 for direct pushes.
 
     Returns both sides of a rename (pre- and post-image paths) so inbound
     links to the old path are still validated after a file move.
 
     A successful diff with no changes returns an empty list (no fallback);
-    the HEAD~1 fallback only runs when origin/main is unavailable. Raises
-    RuntimeError if both diffs fail.
+    the next fallback only runs when the previous base is unavailable.
+    Raises RuntimeError if every base fails.
     """
-    origin_result = subprocess.run(
-        ['git', 'diff', '--name-status', '-M', 'origin/main...HEAD'],
-        capture_output=True, text=True, cwd=root)
-    if origin_result.returncode == 0:
-        return parse_name_status(origin_result.stdout)
+    bases = []
+    env_base = os.environ.get('ANCHOR_CHECK_BASE', '').strip()
+    if env_base:
+        bases.append(env_base)
+    bases += ['origin/main', 'HEAD~1']
 
-    # origin/main unavailable (e.g. shallow direct push): fall back to HEAD~1
-    fallback_result = subprocess.run(
-        ['git', 'diff', '--name-status', '-M', 'HEAD~1...HEAD'],
-        capture_output=True, text=True, cwd=root)
-    if fallback_result.returncode == 0:
-        return parse_name_status(fallback_result.stdout)
+    last_result = None
+    for base in bases:
+        result = subprocess.run(
+            ['git', 'diff', '--name-status', '-M', f'{base}...HEAD'],
+            capture_output=True, text=True, cwd=root)
+        last_result = result
+        if result.returncode == 0:
+            return parse_name_status(result.stdout)
 
+    assert last_result is not None
     raise RuntimeError(
-        f'git diff failed: origin/main...HEAD '
-        f'rc={origin_result.returncode}: '
-        f'{origin_result.stderr.strip()[:200]}; '
-        f'HEAD~1...HEAD rc={fallback_result.returncode}: '
-        f'{fallback_result.stderr.strip()[:200]}')
+        f'git diff failed against all bases ({", ".join(bases)}): '
+        f'last rc={last_result.returncode}: '
+        f'{last_result.stderr.strip()[:300]}')
 
 
 def parse_name_status(output: str) -> list:

--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Anchor link checker for ComfyUI docs (static, MDX-based).
+
+Scans every markdown/html link with a #fragment in the docs, resolves the
+target page from the local MDX tree, and verifies the anchor exists on the
+target page by extracting its headings ({#custom-id} supported) and
+id= attributes.
+
+Usage:
+  python3 check-anchors.py                  # check all docs
+  python3 check-anchors.py --only-changed   # only files changed vs origin/main
+  python3 check-anchors.py --file PATH      # check a single file (repeatable)
+  python3 check-anchors.py --fix-suggest    # print closest-match suggestions
+"""
+import argparse
+import glob
+import os
+import re
+import subprocess
+import sys
+import unicodedata
+import urllib.parse
+
+# ---------------------------------------------------------------- slug rules
+# Mintlify heading-slug approximation (verified against live docs.comfy.org):
+#   lowercase, strip punctuation (except + - _ . and unicode letters/digits),
+#   collapse whitespace to single '-'. Escaped underscore `\_` in the source
+#   renders as a hyphen in the slug (e.g. "Getting node\_id" -> getting-node-id),
+#   while a plain underscore is kept ("VALIDATE_INPUTS" -> validate_inputs).
+def slugify(text: str) -> str:
+    # escaped underscore in markdown source -> hyphen in slug
+    text = text.replace('\\_', '-')
+    text = text.lower()
+    # normalize unicode so e.g. full-width chars compare sanely
+    text = unicodedata.normalize('NFKC', text)
+    out = []
+    for ch in text:
+        if ch.isalnum() or ch in '+-_':
+            out.append(ch)
+        elif ch in ' \t':
+            out.append(' ')
+        # everything else dropped (punctuation like : ( ) ? . , & / >)
+    slug = ''.join(out)
+    slug = re.sub(r'\s+', '-', slug).strip('-')
+    return slug
+
+
+HEADING_RE = re.compile(r'^(#{1,6})\s+(.+?)\s*$')
+EXPLICIT_ANCHOR_RE = re.compile(r'\{#([^}]+)\}$')
+FENCE_RE = re.compile(r'^(```+|~~~+)')
+MD_LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+HTML_HREF_RE = re.compile(r'href\s*=\s*["\']([^"\']+)["\']')
+ID_ATTR_RE = re.compile(r'<(?:a|span|div|section|h[1-6]|li|p|td|th)[^>]*\bid\s*=\s*["\']([^"\']+)["\']')
+# Mintlify components that generate heading anchors from their `title` prop.
+COMPONENT_TITLE_RE = re.compile(
+    r'<(Tab|Accordion|Step|TabItem|Card)[^>]*\btitle\s*=\s*["\']([^"\']+)["\']')
+
+
+def collect_anchors(path: str) -> set:
+    """All anchors a page provides: heading slugs, {#..} ids, id= attrs.
+
+    Also follows MDX snippet imports (`import X from "/snippets/..."`) so
+    anchors defined inside imported snippets count as page anchors.
+    """
+    anchors = set()
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except Exception:
+        return anchors
+
+    in_fence = False
+    for line in content.split('\n'):
+        stripped = line.lstrip()
+        m = FENCE_RE.match(stripped)
+        if m:
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        hm = HEADING_RE.match(stripped)
+        if hm:
+            heading_text = hm.group(2).strip()
+            em = EXPLICIT_ANCHOR_RE.search(heading_text)
+            if em:
+                anchors.add(em.group(1))
+                pre = heading_text[:em.start()].strip()
+                if pre:
+                    anchors.add(slugify(pre))
+            else:
+                anchors.add(slugify(heading_text))
+
+    for m in ID_ATTR_RE.finditer(content):
+        anchors.add(m.group(1))
+
+    # Mintlify components (Tab, Accordion, Step, Card, ...) generate heading
+    # anchors from their title prop, e.g. <Tab title="Install via ComfyUI Manager">
+    for m in COMPONENT_TITLE_RE.finditer(content):
+        anchors.add(slugify(m.group(2)))
+
+    # Follow MDX snippet imports: `import X from "/snippets/foo.mdx"` renders
+    # the snippet's content inline, so its headings are anchors on this page.
+    root = os.path.dirname(os.path.dirname(path))  # repo root
+    for m in re.finditer(r'import\s+[^"\']+\s+from\s+["\'](/snippets/[^"\']+)["\']', content):
+        sp = os.path.join(root, m.group(1).lstrip('/'))
+        if os.path.isfile(sp):
+            anchors |= collect_anchors(sp)
+
+    return anchors
+
+
+def iter_links(path: str):
+    """Yield (url, match_text, lineno) outside code fences."""
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except Exception as e:
+        print(f'!! cannot read {path}: {e}', file=sys.stderr)
+        return
+
+    in_fence = False
+    fence_marker = ''
+    for i, line in enumerate(content.split('\n'), 1):
+        stripped = line.lstrip()
+        m = FENCE_RE.match(stripped)
+        if m:
+            marker = m.group(1)
+            if not in_fence:
+                in_fence, fence_marker = True, marker
+            elif marker == fence_marker:
+                in_fence = False
+            continue
+        if in_fence:
+            continue
+        for m in MD_LINK_RE.finditer(line):
+            yield m.group(2), m.group(0), i
+        for m in HTML_HREF_RE.finditer(line):
+            yield m.group(1), m.group(0), i
+
+
+def resolve_target(src_file: str, url: str, root: str):
+    """Return (target_mdx_path, anchor) or (None, anchor) for non-internal links."""
+    if url.startswith(('http://', 'https://', 'mailto:', 'tel:')):
+        return None, None
+    base, _, anchor = url.partition('#')
+    if not anchor:
+        return None, None
+    # strip query strings
+    base = base.split('?')[0]
+    # URL-decode the fragment (e.g. %3A -> :), then normalize whitespace
+    anchor = urllib.parse.unquote(anchor).strip()
+
+    if base == '':
+        target = src_file
+    elif base.startswith('/'):
+        target = os.path.join(root, base.lstrip('/'))
+    else:
+        target = os.path.normpath(os.path.join(os.path.dirname(src_file), base))
+
+    candidates = [target]
+    if not target.endswith(('.mdx', '.md')):
+        candidates += [target + '.mdx', target + '.md']
+    for c in candidates:
+        if os.path.isfile(c):
+            return c, anchor
+    return None, anchor  # target page missing locally -> handled separately
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Static anchor link checker')
+    ap.add_argument('--root', default='.')
+    ap.add_argument('--only-changed', action='store_true',
+                    help='Only check MDX files changed vs origin/main')
+    ap.add_argument('--file', action='append', default=[],
+                    help='Check a specific file (repeatable)')
+    args = ap.parse_args()
+
+    root = os.path.abspath(args.root)
+
+    if args.file:
+        files = [os.path.abspath(f) for f in args.file]
+    elif args.only_changed:
+        # PR: compare against origin/main if available; fall back to HEAD~1
+        # for direct pushes to main (where origin/main == HEAD).
+        out = subprocess.run(
+            ['git', 'diff', '--name-only', 'origin/main...HEAD'],
+            capture_output=True, text=True, cwd=root)
+        changed = out.stdout.split()
+        if not changed:
+            out = subprocess.run(
+                ['git', 'diff', '--name-only', 'HEAD~1...HEAD'],
+                capture_output=True, text=True, cwd=root)
+            changed = out.stdout.split()
+        files = [os.path.join(root, f) for f in changed
+                 if f.endswith(('.mdx', '.md'))]
+    else:
+        files = []
+        for pat in ('**/*.mdx', '**/*.md'):
+            files.extend(glob.glob(os.path.join(root, pat), recursive=True))
+        files = [f for f in files
+                 if not any(x in f for x in ('node_modules/', '.git/', '.github/', 'tmp/'))]
+    files = sorted(set(os.path.abspath(f) for f in files if os.path.isfile(f)))
+
+    if not files:
+        print('No files to check.')
+        return 0
+
+    print(f'Checking {len(files)} file(s) for anchor links...')
+
+    anchor_cache = {}
+    def anchors_of(p):
+        if p not in anchor_cache:
+            anchor_cache[p] = collect_anchors(p)
+        return anchor_cache[p]
+
+    problems = []
+    for fp in files:
+        for url, match, ln in iter_links(fp):
+            target, anchor = resolve_target(fp, url, root)
+            if target is None or anchor is None:
+                continue
+            if target not in anchor_cache:
+                anchor_cache[target] = collect_anchors(target)
+            if anchor not in anchor_cache[target]:
+                problems.append((fp, ln, url, os.path.relpath(target, root), anchor))
+
+    if not problems:
+        print('✅ All anchor links OK!')
+        return 0
+
+    print(f'\n❌ Found {len(problems)} broken anchor link(s):\n')
+    for fp, ln, url, target, anchor in problems:
+        print(f'  {os.path.relpath(fp, root)}:{ln}')
+        print(f'    link:     {url}')
+        print(f'    target:   {target}')
+        print(f'    anchor:   #{anchor}  (NOT FOUND)')
+        # suggestions
+        have = sorted(anchor_cache[os.path.join(root, target)])
+        import difflib
+        close = difflib.get_close_matches(anchor, have, n=2, cutoff=0.5)
+        if close:
+            print(f'    maybe meant: {close}')
+        print()
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -76,6 +76,16 @@ def iter_prose_segments(content: str):
     in_fence = False
     fence_marker = ''
     for i, line in enumerate(lines, 1):
+        # CommonMark: a fence marker may be indented up to 3 spaces; 4+
+        # spaces means it is indented code, not a fence. Count the original
+        # leading whitespace before lstrip'ing.
+        indent = len(line) - len(line.lstrip(' '))
+        if indent >= 4:
+            if not in_fence:
+                if not chunk:
+                    chunk_start = i
+                chunk.append(line)
+            continue
         stripped = line.lstrip()
         m = FENCE_RE.match(stripped)
         if m:
@@ -215,17 +225,27 @@ def git_changed_files(root: str) -> list:
 
     Returns both sides of a rename (pre- and post-image paths) so inbound
     links to the old path are still validated after a file move.
+
+    A successful diff with no changes returns an empty list (no fallback);
+    the HEAD~1 fallback only runs when origin/main is unavailable. Raises
+    RuntimeError if both diffs fail.
     """
     out = subprocess.run(
         ['git', 'diff', '--name-status', '-M', 'origin/main...HEAD'],
         capture_output=True, text=True, cwd=root)
-    changed = parse_name_status(out.stdout)
-    if not changed:
-        out = subprocess.run(
-            ['git', 'diff', '--name-status', '-M', 'HEAD~1...HEAD'],
-            capture_output=True, text=True, cwd=root)
-        changed = parse_name_status(out.stdout)
-    return changed
+    if out.returncode == 0:
+        return parse_name_status(out.stdout)
+
+    # origin/main unavailable (e.g. shallow direct push): fall back to HEAD~1
+    out = subprocess.run(
+        ['git', 'diff', '--name-status', '-M', 'HEAD~1...HEAD'],
+        capture_output=True, text=True, cwd=root)
+    if out.returncode == 0:
+        return parse_name_status(out.stdout)
+
+    raise RuntimeError(
+        f'git diff failed: origin/main...HEAD rc={out.returncode}; '
+        f'HEAD~1...HEAD rc={out.returncode}: {out.stderr.strip()[:300]}')
 
 
 def parse_name_status(output: str) -> list:
@@ -265,7 +285,11 @@ def main():
     if args.file:
         files = [os.path.abspath(f) for f in args.file]
     elif args.only_changed:
-        changed = git_changed_files(root)
+        try:
+            changed = git_changed_files(root)
+        except RuntimeError as e:
+            print(f'❌ {e}', file=sys.stderr)
+            return 1
         files = [os.path.join(root, f) for f in changed
                  if f.endswith(('.mdx', '.md'))]
         # If a PR renames/removes a heading on a changed page, unchanged pages

--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -86,7 +86,13 @@ def iter_prose_segments(content: str):
                     chunk = []
                 in_fence = True
                 fence_marker = marker
-            elif marker == fence_marker:
+            elif (
+                marker[0] == fence_marker[0]
+                and len(marker) >= len(fence_marker)
+                and not stripped[len(marker):].strip()
+            ):
+                # CommonMark: a closing fence uses the same character, has
+                # length >= the opening fence, and only whitespace after it.
                 in_fence = False
             continue
         if in_fence:
@@ -205,17 +211,43 @@ def collect_doc_files(root: str) -> list:
 
 
 def git_changed_files(root: str) -> list:
-    """Files changed vs origin/main (fallback: HEAD~1 for direct pushes)."""
+    """Files changed vs origin/main (fallback: HEAD~1 for direct pushes).
+
+    Returns both sides of a rename (pre- and post-image paths) so inbound
+    links to the old path are still validated after a file move.
+    """
     out = subprocess.run(
-        ['git', 'diff', '--name-only', 'origin/main...HEAD'],
+        ['git', 'diff', '--name-status', '-M', 'origin/main...HEAD'],
         capture_output=True, text=True, cwd=root)
-    changed = out.stdout.split()
+    changed = parse_name_status(out.stdout)
     if not changed:
         out = subprocess.run(
-            ['git', 'diff', '--name-only', 'HEAD~1...HEAD'],
+            ['git', 'diff', '--name-status', '-M', 'HEAD~1...HEAD'],
             capture_output=True, text=True, cwd=root)
-        changed = out.stdout.split()
+        changed = parse_name_status(out.stdout)
     return changed
+
+
+def parse_name_status(output: str) -> list:
+    """Parse `git diff --name-status` output into a flat path list.
+
+    Handles status codes with optional similarity, rename lines
+    ('R100\told\tnew'), and copied lines ('C\told\tnew').
+    """
+    paths = []
+    for line in output.splitlines():
+        parts = line.split('\t')
+        if not parts:
+            continue
+        status = parts[0]
+        if status.startswith(('R', 'C')):
+            # rename/copy: old path and new path both matter
+            if len(parts) >= 3:
+                paths.append(parts[1])
+                paths.append(parts[2])
+        elif len(parts) >= 2:
+            paths.append(parts[1])
+    return paths
 
 
 def main():

--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -10,7 +10,6 @@ Usage:
   python3 check-anchors.py                  # check all docs
   python3 check-anchors.py --only-changed   # only files changed vs origin/main
   python3 check-anchors.py --file PATH      # check a single file (repeatable)
-  python3 check-anchors.py --fix-suggest    # print closest-match suggestions
 """
 import argparse
 import glob
@@ -27,6 +26,8 @@ import urllib.parse
 #   collapse whitespace to single '-'. Escaped underscore `\_` in the source
 #   renders as a hyphen in the slug (e.g. "Getting node\_id" -> getting-node-id),
 #   while a plain underscore is kept ("VALIDATE_INPUTS" -> validate_inputs).
+#   A literal period is converted to a hyphen ("Including `.js` files" ->
+#   "including-js-files"), matching Mintlify's anchor behavior.
 def slugify(text: str) -> str:
     # escaped underscore in markdown source -> hyphen in slug
     text = text.replace('\\_', '-')
@@ -39,9 +40,14 @@ def slugify(text: str) -> str:
             out.append(ch)
         elif ch in ' \t':
             out.append(' ')
-        # everything else dropped (punctuation like : ( ) ? . , & / >)
+        elif ch == '.':
+            out.append('-')
+        # everything else dropped (punctuation like : ( ) ? , & / >)
     slug = ''.join(out)
     slug = re.sub(r'\s+', '-', slug).strip('-')
+    # Mintlify collapses consecutive hyphens from mixed separators, e.g.
+    # "Including `.js` files" -> "including-js-files" (not "--js--").
+    slug = re.sub(r'-{2,}', '-', slug)
     return slug
 
 
@@ -54,94 +60,118 @@ ID_ATTR_RE = re.compile(r'<(?:a|span|div|section|h[1-6]|li|p|td|th)[^>]*\bid\s*=
 # Mintlify components that generate heading anchors from their `title` prop.
 COMPONENT_TITLE_RE = re.compile(
     r'<(Tab|Accordion|Step|TabItem|Card)[^>]*\btitle\s*=\s*["\']([^"\']+)["\']')
+# MDX snippet imports: `import X from "/snippets/foo.mdx"`
+SNIPPET_IMPORT_RE = re.compile(r'import\s+[^"\']+\s+from\s+["\'](/snippets/[^"\']+)["\']')
 
 
-def collect_anchors(path: str) -> set:
+def iter_prose_segments(content: str):
+    """Yield (start_line, text) chunks outside fenced code blocks.
+
+    A single fence-aware pass shared by anchor extraction and link scanning,
+    so fenced content can never create anchors or satisfy broken links.
+    """
+    lines = content.split('\n')
+    chunk: list = []
+    chunk_start = 1
+    in_fence = False
+    fence_marker = ''
+    for i, line in enumerate(lines, 1):
+        stripped = line.lstrip()
+        m = FENCE_RE.match(stripped)
+        if m:
+            marker = m.group(1)
+            if not in_fence:
+                if chunk:
+                    yield chunk_start, '\n'.join(chunk)
+                    chunk = []
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+            continue
+        if in_fence:
+            continue
+        if not chunk:
+            chunk_start = i
+        chunk.append(line)
+    if chunk:
+        yield chunk_start, '\n'.join(chunk)
+
+
+def read_file(path: str) -> str:
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except Exception:
+        return ''
+
+
+def collect_anchors(path: str, root: str) -> set:
     """All anchors a page provides: heading slugs, {#..} ids, id= attrs.
 
     Also follows MDX snippet imports (`import X from "/snippets/..."`) so
     anchors defined inside imported snippets count as page anchors.
+    Resolves snippet paths against the repository root passed by the caller.
     """
     anchors = set()
-    try:
-        with open(path, 'r', encoding='utf-8') as f:
-            content = f.read()
-    except Exception:
+    content = read_file(path)
+    if not content:
         return anchors
 
-    in_fence = False
-    for line in content.split('\n'):
-        stripped = line.lstrip()
-        m = FENCE_RE.match(stripped)
-        if m:
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        hm = HEADING_RE.match(stripped)
-        if hm:
-            heading_text = hm.group(2).strip()
-            em = EXPLICIT_ANCHOR_RE.search(heading_text)
-            if em:
-                anchors.add(em.group(1))
-                pre = heading_text[:em.start()].strip()
-                if pre:
-                    anchors.add(slugify(pre))
-            else:
-                anchors.add(slugify(heading_text))
+    for _start, seg in iter_prose_segments(content):
+        for line in seg.split('\n'):
+            stripped = line.lstrip()
+            hm = HEADING_RE.match(stripped)
+            if hm:
+                heading_text = hm.group(2).strip()
+                em = EXPLICIT_ANCHOR_RE.search(heading_text)
+                if em:
+                    anchors.add(em.group(1))
+                    pre = heading_text[:em.start()].strip()
+                    if pre:
+                        anchors.add(slugify(pre))
+                else:
+                    anchors.add(slugify(heading_text))
 
-    for m in ID_ATTR_RE.finditer(content):
-        anchors.add(m.group(1))
+        for m in ID_ATTR_RE.finditer(seg):
+            anchors.add(m.group(1))
 
-    # Mintlify components (Tab, Accordion, Step, Card, ...) generate heading
-    # anchors from their title prop, e.g. <Tab title="Install via ComfyUI Manager">
-    for m in COMPONENT_TITLE_RE.finditer(content):
-        anchors.add(slugify(m.group(2)))
+        # Mintlify components (Tab, Accordion, Step, Card, ...) generate
+        # heading anchors from their title prop.
+        for m in COMPONENT_TITLE_RE.finditer(seg):
+            anchors.add(slugify(m.group(2)))
 
-    # Follow MDX snippet imports: `import X from "/snippets/foo.mdx"` renders
-    # the snippet's content inline, so its headings are anchors on this page.
-    root = os.path.dirname(os.path.dirname(path))  # repo root
-    for m in re.finditer(r'import\s+[^"\']+\s+from\s+["\'](/snippets/[^"\']+)["\']', content):
-        sp = os.path.join(root, m.group(1).lstrip('/'))
-        if os.path.isfile(sp):
-            anchors |= collect_anchors(sp)
+        # Follow MDX snippet imports; their headings are anchors on this page.
+        for m in SNIPPET_IMPORT_RE.finditer(seg):
+            sp = os.path.join(root, m.group(1).lstrip('/'))
+            if os.path.isfile(sp):
+                anchors |= collect_anchors(sp, root)
 
     return anchors
 
 
 def iter_links(path: str):
     """Yield (url, match_text, lineno) outside code fences."""
-    try:
-        with open(path, 'r', encoding='utf-8') as f:
-            content = f.read()
-    except Exception as e:
-        print(f'!! cannot read {path}: {e}', file=sys.stderr)
+    content = read_file(path)
+    if not content:
         return
-
-    in_fence = False
-    fence_marker = ''
-    for i, line in enumerate(content.split('\n'), 1):
-        stripped = line.lstrip()
-        m = FENCE_RE.match(stripped)
-        if m:
-            marker = m.group(1)
-            if not in_fence:
-                in_fence, fence_marker = True, marker
-            elif marker == fence_marker:
-                in_fence = False
-            continue
-        if in_fence:
-            continue
-        for m in MD_LINK_RE.finditer(line):
-            yield m.group(2), m.group(0), i
-        for m in HTML_HREF_RE.finditer(line):
-            yield m.group(1), m.group(0), i
+    for start_ln, seg in iter_prose_segments(content):
+        for i, line in enumerate(seg.split('\n'), start_ln):
+            for m in MD_LINK_RE.finditer(line):
+                yield m.group(2), m.group(0), i
+            for m in HTML_HREF_RE.finditer(line):
+                yield m.group(1), m.group(0), i
 
 
 def resolve_target(src_file: str, url: str, root: str):
-    """Return (target_mdx_path, anchor) or (None, anchor) for non-internal links."""
+    """Return (target_mdx_path, anchor) for internal links, (None, None) for
+    external URLs, and (first_candidate_path, anchor) when the target file is
+    missing locally so callers can report it as a problem."""
     if url.startswith(('http://', 'https://', 'mailto:', 'tel:')):
         return None, None
+    # Markdown permits "( ./path#anchor)" — trim leading whitespace the same
+    # way Markdown/Mintlify does before parsing the path.
+    url = url.strip()
     base, _, anchor = url.partition('#')
     if not anchor:
         return None, None
@@ -163,14 +193,37 @@ def resolve_target(src_file: str, url: str, root: str):
     for c in candidates:
         if os.path.isfile(c):
             return c, anchor
-    return None, anchor  # target page missing locally -> handled separately
+    return candidates[0], anchor  # missing target -> reported by caller
+
+
+def collect_doc_files(root: str) -> list:
+    files = []
+    for pat in ('**/*.mdx', '**/*.md'):
+        files.extend(glob.glob(os.path.join(root, pat), recursive=True))
+    return [f for f in files
+            if not any(x in f for x in ('node_modules/', '.git/', '.github/', 'tmp/'))]
+
+
+def git_changed_files(root: str) -> list:
+    """Files changed vs origin/main (fallback: HEAD~1 for direct pushes)."""
+    out = subprocess.run(
+        ['git', 'diff', '--name-only', 'origin/main...HEAD'],
+        capture_output=True, text=True, cwd=root)
+    changed = out.stdout.split()
+    if not changed:
+        out = subprocess.run(
+            ['git', 'diff', '--name-only', 'HEAD~1...HEAD'],
+            capture_output=True, text=True, cwd=root)
+        changed = out.stdout.split()
+    return changed
 
 
 def main():
     ap = argparse.ArgumentParser(description='Static anchor link checker')
     ap.add_argument('--root', default='.')
     ap.add_argument('--only-changed', action='store_true',
-                    help='Only check MDX files changed vs origin/main')
+                    help='Check MDX/MD files changed vs origin/main, plus any '
+                         'unchanged English pages that link to changed headings')
     ap.add_argument('--file', action='append', default=[],
                     help='Check a specific file (repeatable)')
     args = ap.parse_args()
@@ -180,25 +233,27 @@ def main():
     if args.file:
         files = [os.path.abspath(f) for f in args.file]
     elif args.only_changed:
-        # PR: compare against origin/main if available; fall back to HEAD~1
-        # for direct pushes to main (where origin/main == HEAD).
-        out = subprocess.run(
-            ['git', 'diff', '--name-only', 'origin/main...HEAD'],
-            capture_output=True, text=True, cwd=root)
-        changed = out.stdout.split()
-        if not changed:
-            out = subprocess.run(
-                ['git', 'diff', '--name-only', 'HEAD~1...HEAD'],
-                capture_output=True, text=True, cwd=root)
-            changed = out.stdout.split()
+        changed = git_changed_files(root)
         files = [os.path.join(root, f) for f in changed
                  if f.endswith(('.mdx', '.md'))]
+        # If a PR renames/removes a heading on a changed page, unchanged pages
+        # linking to it would silently break. Scan all English sources that
+        # point at a changed file (with an anchor) and include them too.
+        if files:
+            changed_abs = {os.path.abspath(f) for f in files}
+            for f in collect_doc_files(root):
+                if f in changed_abs:
+                    continue
+                rel = os.path.relpath(f, root)
+                if rel.split('/')[0] in ('ja', 'ko', 'zh'):
+                    continue  # translations swept separately
+                for url, _match, _ln in iter_links(f):
+                    target, anchor = resolve_target(f, url, root)
+                    if anchor and target in changed_abs:
+                        files.append(f)
+                        break
     else:
-        files = []
-        for pat in ('**/*.mdx', '**/*.md'):
-            files.extend(glob.glob(os.path.join(root, pat), recursive=True))
-        files = [f for f in files
-                 if not any(x in f for x in ('node_modules/', '.git/', '.github/', 'tmp/'))]
+        files = collect_doc_files(root)
     files = sorted(set(os.path.abspath(f) for f in files if os.path.isfile(f)))
 
     if not files:
@@ -210,7 +265,7 @@ def main():
     anchor_cache = {}
     def anchors_of(p):
         if p not in anchor_cache:
-            anchor_cache[p] = collect_anchors(p)
+            anchor_cache[p] = collect_anchors(p, root)
         return anchor_cache[p]
 
     problems = []
@@ -218,28 +273,36 @@ def main():
         for url, match, ln in iter_links(fp):
             target, anchor = resolve_target(fp, url, root)
             if target is None or anchor is None:
+                continue  # external URL or link without a fragment
+            if not os.path.isfile(target):
+                problems.append(
+                    (fp, ln, url, os.path.relpath(target, root), anchor,
+                     'target page not found locally'))
                 continue
-            if target not in anchor_cache:
-                anchor_cache[target] = collect_anchors(target)
-            if anchor not in anchor_cache[target]:
-                problems.append((fp, ln, url, os.path.relpath(target, root), anchor))
+            if anchor not in anchors_of(target):
+                problems.append(
+                    (fp, ln, url, os.path.relpath(target, root), anchor,
+                     'anchor NOT FOUND'))
 
     if not problems:
         print('✅ All anchor links OK!')
         return 0
 
     print(f'\n❌ Found {len(problems)} broken anchor link(s):\n')
-    for fp, ln, url, target, anchor in problems:
+    for fp, ln, url, target, anchor, reason in problems:
         print(f'  {os.path.relpath(fp, root)}:{ln}')
         print(f'    link:     {url}')
         print(f'    target:   {target}')
-        print(f'    anchor:   #{anchor}  (NOT FOUND)')
-        # suggestions
-        have = sorted(anchor_cache[os.path.join(root, target)])
-        import difflib
-        close = difflib.get_close_matches(anchor, have, n=2, cutoff=0.5)
-        if close:
-            print(f'    maybe meant: {close}')
+        if reason == 'anchor NOT FOUND':
+            print(f'    anchor:   #{anchor}  (NOT FOUND)')
+            # suggestions
+            have = sorted(anchors_of(os.path.join(root, target)))
+            import difflib
+            close = difflib.get_close_matches(anchor, have, n=2, cutoff=0.5)
+            if close:
+                print(f'    maybe meant: {close}')
+        else:
+            print(f'    {reason}')
         print()
     return 1
 

--- a/.github/scripts/check-anchors.py
+++ b/.github/scripts/check-anchors.py
@@ -230,22 +230,25 @@ def git_changed_files(root: str) -> list:
     the HEAD~1 fallback only runs when origin/main is unavailable. Raises
     RuntimeError if both diffs fail.
     """
-    out = subprocess.run(
+    origin_result = subprocess.run(
         ['git', 'diff', '--name-status', '-M', 'origin/main...HEAD'],
         capture_output=True, text=True, cwd=root)
-    if out.returncode == 0:
-        return parse_name_status(out.stdout)
+    if origin_result.returncode == 0:
+        return parse_name_status(origin_result.stdout)
 
     # origin/main unavailable (e.g. shallow direct push): fall back to HEAD~1
-    out = subprocess.run(
+    fallback_result = subprocess.run(
         ['git', 'diff', '--name-status', '-M', 'HEAD~1...HEAD'],
         capture_output=True, text=True, cwd=root)
-    if out.returncode == 0:
-        return parse_name_status(out.stdout)
+    if fallback_result.returncode == 0:
+        return parse_name_status(fallback_result.stdout)
 
     raise RuntimeError(
-        f'git diff failed: origin/main...HEAD rc={out.returncode}; '
-        f'HEAD~1...HEAD rc={out.returncode}: {out.stderr.strip()[:300]}')
+        f'git diff failed: origin/main...HEAD '
+        f'rc={origin_result.returncode}: '
+        f'{origin_result.stderr.strip()[:200]}; '
+        f'HEAD~1...HEAD rc={fallback_result.returncode}: '
+        f'{fallback_result.stderr.strip()[:200]}')
 
 
 def parse_name_status(output: str) -> list:

--- a/.github/workflows/anchor-check.yml
+++ b/.github/workflows/anchor-check.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/anchor-check.yml
+++ b/.github/workflows/anchor-check.yml
@@ -30,4 +30,8 @@ jobs:
           python-version: '3.11'
 
       - name: Check anchors in changed files
+        env:
+          # Event-specific base: previous commit for pushes, base branch SHA
+          # for pull requests (falls back to origin/main in the script).
+          ANCHOR_CHECK_BASE: ${{ github.event.before || github.event.pull_request.base.sha }}
         run: python .github/scripts/check-anchors.py --only-changed

--- a/.github/workflows/anchor-check.yml
+++ b/.github/workflows/anchor-check.yml
@@ -11,17 +11,21 @@ on:
       - '**/*.mdx'
       - '**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   check-anchors:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: '3.11'
 

--- a/.github/workflows/anchor-check.yml
+++ b/.github/workflows/anchor-check.yml
@@ -1,0 +1,29 @@
+name: Anchor Check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.mdx'
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.mdx'
+      - '**/*.md'
+
+jobs:
+  check-anchors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Check anchors in changed files
+        run: python .github/scripts/check-anchors.py --only-changed

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ npm run translate:repair-truncated -- --lang ko
 - **Input**: English MDX (primary) + existing target-language file as context (if present)
 - **Output**: Updated files under `zh/`, `ja/`, `ko/`, etc., with refreshed `translationSourceHash` in frontmatter (snippets use an HTML comment for the hash)
 - **Review notes (mismatch)**: When the model reports semantic issues via `=== MISMATCHES ===`, they go to `.github/i18n-logs/translate/mismatches.json` and `mismatches.txt` (gitignored), not into MDX. Only produced during `npm run translate`, not by the truncation scanner.
-- **Truncation log**: Structural issues (unclosed code fences, short body) go to `.github/i18n-logs/translate/truncation-issues.json` — see [Truncated translations](#truncated-translations) above.
+- **Truncation log**: Structural issues (unclosed code fences, short body) go to `.github/i18n-logs/translate/truncation-issues.json` — see [Truncated translations](#automated-translation) above.
 - **Skipped paths**: `built-in-nodes/` (configured in `translation-config.json` → `skip_paths`)
 - **Chunked files**: `changelog/index.mdx` is handled by `<Update label="v0.x.x">` version labels. The script compares EN vs target labels, translates only **missing** versions, and inserts them in EN order. Old blocks are never re-translated unless you use `--force`.
 - **Directories**: Subdirectories are created automatically when files are written; you do not need to `mkdir` by hand
@@ -203,7 +203,7 @@ Configure a dedicated cheap judge model via `REVIEW_API_KEY` / `REVIEW_API_BASE_
 
 #### Adding a new language
 
-See [Request a new language](#request-a-new-language) above — please open an issue rather than adding a language in a PR yourself.
+See [Request a new language](#adding-a-new-language) above — please open an issue rather than adding a language in a PR yourself.
 
 Maintainers: add one entry under `languages` in `.github/scripts/i18n/translation-config.json` (`code`, `name`, `dir`, `snippets_dir`). Path exclusion, link localization, and English-file scanning are derived automatically by `i18n-config.mjs` in the same folder — no per-language edits in translate scripts when adding a locale. Then add navigation in `docs.json` (see [Mintlify Localization](https://mintlify.com/docs/navigation/localization)), and batch-translate:
 

--- a/agent-tools/partner-mcp.mdx
+++ b/agent-tools/partner-mcp.mdx
@@ -132,4 +132,4 @@ Generate music with a calm, lo-fi vibe, about 30 seconds long
 ## Related
 
 - [Comfy Cloud MCP](/agent-tools/mcp) — Hosted MCP server for Comfy Cloud workflow execution
-- [Comfy Partner Nodes CLI](/comfy-cli/reference#generate-partner-nodes-beta) — Use partner nodes from the command line
+- [Comfy Partner Nodes CLI](/comfy-cli/reference#generate-partner-nodes-beta): Use partner nodes from the command line

--- a/agent-tools/partner-mcp.mdx
+++ b/agent-tools/partner-mcp.mdx
@@ -132,4 +132,4 @@ Generate music with a calm, lo-fi vibe, about 30 seconds long
 ## Related
 
 - [Comfy Cloud MCP](/agent-tools/mcp) — Hosted MCP server for Comfy Cloud workflow execution
-- [Comfy Partner Nodes CLI](/comfy-cli/reference#generate-partner-nodes) — Use partner nodes from the command line
+- [Comfy Partner Nodes CLI](/comfy-cli/reference#generate-partner-nodes-beta) — Use partner nodes from the command line

--- a/basic-concepts/custom-nodes.mdx
+++ b/basic-concepts/custom-nodes.mdx
@@ -50,7 +50,7 @@ Therefore, in this documentation, we will use installing ComfyUI Manager as a cu
 
 Since ComfyUI Manager has very rich functionality, we will use a separate document to introduce the ComfyUI Manager installation chapter. Please visit the link below to learn how to use ComfyUI Manager to install custom nodes.
 
-<Card title="Install Custom Nodes with ComfyUI Manager" icon="link" href="/installation/install_custom_node#method-1%3A-comfyui-manager-recommended">
+<Card title="Install Custom Nodes with ComfyUI Manager" icon="link" href="/installation/install_custom_node#method-1-comfyui-manager-recommended">
   Learn how to use ComfyUI Manager to install custom nodes
 </Card>
 </Tab>
@@ -108,7 +108,7 @@ If everything goes smoothly, you will see output similar to the following:
 This means you have successfully cloned the custom node code. Next, we need to install the corresponding dependencies.
 </Step>
 <Step title="Install Dependencies">
-Please refer to the instructions in the [Installing Node Dependencies](#installing-node-dependencies) section for dependency installation.
+Please refer to the instructions in the [Installing Node Dependencies](#2-installing-node-dependencies) section for dependency installation.
 </Step>
 </Steps>
 
@@ -139,7 +139,7 @@ Copy the extracted code from the above steps to the ComfyUI custom nodes directo
 
 </Step>
 <Step title="Install Dependencies">
-Please refer to the instructions in the [Installing Node Dependencies](#installing-node-dependencies) section for dependency installation.
+Please refer to the instructions in the [Installing Node Dependencies](#2-installing-node-dependencies) section for dependency installation.
 </Step>
 </Steps>
 </Tab>
@@ -302,7 +302,7 @@ To be updated
 ![ComfyUI Manager Interface](/images/concepts/core-concepts_nodes_manager.png)
 
 
-This tool is currently included by default in the [Desktop version](/installation/desktop/windows), while in the [Portable version](/installation/comfyui_portable_windows), you need to refer to the installation instructions in the [Install Manager](#installing-custom-nodes) section of this document.
+This tool is currently included by default in the [Desktop version](/installation/desktop/windows), while in the [Portable version](/installation/comfyui_portable_windows), you need to refer to the installation instructions in the [Install Manager](#1-installing-custom-nodes) section of this document.
 
 <Note>
 As ComfyUI continues to develop, ComfyUI Manager plays an increasingly important role in ComfyUI. Currently, ComfyUI-Manager has officially joined the Comfy Org organization, officially becoming part of ComfyUI's core dependencies, and continues to be maintained by the original author [Dr.Lt.Data](https://github.com/ltdrdata). You can read [this blog post](https://blog.comfy.org/p/comfyui-manager-joins-comfy-org) for more information.

--- a/custom-nodes/backend/more_on_inputs.mdx
+++ b/custom-nodes/backend/more_on_inputs.mdx
@@ -78,7 +78,7 @@ def VALIDATE_INPUTS(s, input_types):
     return True
 ```
 
-The frontend allows `*` to indicate that an input can be connected to any source. Because this is not officially supported by the backend, you can skip the backend validation of types by accepting a parameter named `input_types` in your `VALIDATE_INPUTS` function. (See [VALIDATE_INPUTS](./server_overview#validate-inputs) for more information.)
+The frontend allows `*` to indicate that an input can be connected to any source. Because this is not officially supported by the backend, you can skip the backend validation of types by accepting a parameter named `input_types` in your `VALIDATE_INPUTS` function. (See [VALIDATE_INPUTS](./server_overview#validate_inputs) for more information.)
 It's up to the node to make sense of the data that is passed.
 
 ### Dynamically created inputs

--- a/custom-nodes/v3_migration.mdx
+++ b/custom-nodes/v3_migration.mdx
@@ -231,7 +231,7 @@ def validate_inputs(cls, **kwargs) -> bool | str:
     return True
 ```
 
-#### Lazy Evaluation (V1 → V3)
+#### Lazy Evaluation (V1 → V3) {#lazy-evaluation-v1-v3}
 
 The ```check_lazy_status``` function is class method, remains the same otherwise.
 
@@ -405,7 +405,7 @@ All input types share these base parameters:
 | `display_name` | `str` | `None` | Label shown in the UI. Defaults to `id`. |
 | `optional` | `bool` | `False` | Whether the input is optional. |
 | `tooltip` | `str` | `None` | Hover tooltip text. |
-| `lazy` | `bool` | `None` | Marks input for lazy evaluation (see [Lazy Evaluation](#lazy-evaluation-v1--v3)). |
+| `lazy` | `bool` | `None` | Marks input for lazy evaluation (see [Lazy Evaluation](#lazy-evaluation-v1-v3)). |
 | `raw_link` | `bool` | `None` | When True, passes the raw link info instead of the resolved value. |
 | `advanced` | `bool` | `None` | When True, the input is hidden behind an "Advanced" toggle in the UI. |
 

--- a/custom-nodes/walkthrough.mdx
+++ b/custom-nodes/walkthrough.mdx
@@ -72,7 +72,7 @@ class ImageSelector:
 A custom node is defined using a Python class, which must include these four things: `CATEGORY`, 
 which specifies where in the add new node menu the custom node will be located, 
 `INPUT_TYPES`, which is a class method defining what inputs the node will take
-(see [later](/custom-nodes/backend/server_overview#input-types) for details of the dictionary returned),
+(see [later](/custom-nodes/backend/server_overview#input_types) for details of the dictionary returned),
 `RETURN_TYPES`, which defines what outputs the node will produce, and `FUNCTION`, the name
 of the function that will be called when the node is executed.
 

--- a/development/comfyui-server/api-examples.mdx
+++ b/development/comfyui-server/api-examples.mdx
@@ -296,7 +296,7 @@ if __name__ == "__main__":
   <Card title="Method 1: HTTP Only" icon="paper-plane">
     **Fire and forget.** Use when you don't need immediate output, or when retrieving results later is acceptable.
   </Card>
-  <Card title="Method 2: WebSocket + History" icon="chart-line" href="#method-2-websocket--history-monitor-completion">
+  <Card title="Method 2: WebSocket + History" icon="chart-line" href="#method-2-websocket-+-history-monitor-completion">
     **Recommended.** Wait for completion, then download outputs. Best balance of simplicity and reliability.
   </Card>
   <Card title="Method 3: SaveImageWebsocket" icon="images" href="#method-3-websocket-with-saveimagewebsocket-real-time-images">

--- a/development/comfyui-server/execution_model_inversion_guide.mdx
+++ b/development/comfyui-server/execution_model_inversion_guide.mdx
@@ -31,7 +31,7 @@ Here are some of the things that could cause you to fail validation along with r
             }
         ```
 
-    - Define a custom [VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate-inputs) function with this input so validation of it is skipped. *(Quick Solution)* 
+    - Define a custom [VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate_inputs) function with this input so validation of it is skipped. *(Quick Solution)* 
         ```python
         @classmethod
         def VALIDATE_INPUTS(cls, my_size):
@@ -55,7 +55,7 @@ Here are some of the things that could cause you to fail validation along with r
 
             # ...
         ```
-    - (When used as input) Define a custom[VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate-inputs) function that takes a `input_types` argument so type validation is skipped.
+    - (When used as input) Define a custom[VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate_inputs) function that takes a `input_types` argument so type validation is skipped.
         ```python
         @classmethod
         def VALIDATE_INPUTS(cls, input_types):
@@ -100,7 +100,7 @@ A number of features were added to the `VALIDATE_INPUTS` function in order to le
 - The `VALIDATE_INPUTS` function can now take `**kwargs` which causes all inputs to be treated as validated by the node creator.
 - The `VALIDATE_INPUTS` function can take an input named `input_types`. This input will be a dict mapping each input (connected via a link) to the type of the connected output. When this argument exists, type validation for the node's inputs is skipped.
 
-You can read more at [VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate-inputs).
+You can read more at [VALIDATE_INPUTS](/custom-nodes/backend/server_overview#validate_inputs).
 
 ### Lazy Evaluation
 

--- a/installation/update_comfyui.mdx
+++ b/installation/update_comfyui.mdx
@@ -225,7 +225,7 @@ This is one of the most common issues:
 - If you're using the **Desktop version**, features may lag behind because the desktop version is built on stable releases
 - Ensure you're using the **development version (nightly)**, not the **stable version (release)**
 
-Additionally, ensure that corresponding dependencies have been successfully updated during the update process. If issues persist after updating, refer to the [Dependency Update Troubleshooting](#dependency-update-troubleshooting) section to diagnose problems.
+Additionally, ensure that corresponding dependencies have been successfully updated during the update process. If issues persist after updating, refer to the [Dependency Update Troubleshooting](#core-dependency-update-troubleshooting) section to diagnose problems.
 
 ### How to Switch Between Development (Nightly) and Stable (Release) Versions?
 

--- a/interface/appearance.mdx
+++ b/interface/appearance.mdx
@@ -26,7 +26,7 @@ This allows you to:
 4. Delete custom theme configuration
 
 <Note>
-  For appearance needs that cannot be satisfied by the color palette, you can perform advanced appearance customization through the [user.css](#advanced-customization-with-usercss) file
+  For appearance needs that cannot be satisfied by the color palette, you can perform advanced appearance customization through the [user.css](#advanced-customization-with-user-css) file
 </Note>
 
 ### How to Customize Color Themes

--- a/interface/appearance.mdx
+++ b/interface/appearance.mdx
@@ -26,7 +26,7 @@ This allows you to:
 4. Delete custom theme configuration
 
 <Note>
-  For appearance needs that cannot be satisfied by the color palette, you can perform advanced appearance customization through the [user.css](#advanced-customization-with-user-css) file
+  For appearance needs that cannot be satisfied by the color palette, you can perform advanced appearance customization through the [user.css](#advanced-customization-with-usercss) file
 </Note>
 
 ### How to Customize Color Themes

--- a/snippets/comfy-cli/generate-upload-24h-note.mdx
+++ b/snippets/comfy-cli/generate-upload-24h-note.mdx
@@ -1,3 +1,3 @@
 <Note>
-  Uploaded reference assets auto-delete after **24 hours**. They are stored in Comfy-managed GCS with signed URLs. For long-running pipelines, re-upload before each job. See the [reference](/comfy-cli/reference#upload) for details.
+  Uploaded reference assets auto-delete after **24 hours**. They are stored in Comfy-managed GCS with signed URLs. For long-running pipelines, re-upload before each job. See the [reference](/comfy-cli/reference) for details.
 </Note>

--- a/snippets/install/external-models-desktop.mdx
+++ b/snippets/install/external-models-desktop.mdx
@@ -7,4 +7,4 @@ For Comfy Desktop, this file is located at:
 - On macOS: `~/Library/Application Support/ComfyUI/extra_models_config.yaml`
 - On Linux: `~/.config/ComfyUI/extra_models_config.yaml`
 
-For detailed instructions, see [Models documentation](/basic-concepts/models#adding-external-model-paths)
+For detailed instructions, see [Models documentation](/basic-concepts/models)

--- a/snippets/tutorials/basic/installation-models.mdx
+++ b/snippets/tutorials/basic/installation-models.mdx
@@ -1,4 +1,4 @@
-Please ensure that you have at least one SD1.5 model file in the `ComfyUI/models/checkpoints` folder. If you are not sure how to install a model, please refer to the [Start ComfyUI's AI Drawing Journey](/get_started/first_generation#3-安装绘图模型) section for instructions on model installation.
+Please ensure that you have at least one SD1.5 model file in the `ComfyUI/models/checkpoints` folder. If you are not sure how to install a model, please refer to the [Start ComfyUI's AI Drawing Journey](/get_started/first_generation#3-model-installation) section for instructions on model installation.
 
 You can use the following models:
 - [v1-5-pruned-emaonly-fp16.safetensors](https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/blob/main/v1-5-pruned-emaonly-fp16.safetensors) 

--- a/troubleshooting/custom-node-issues.mdx
+++ b/troubleshooting/custom-node-issues.mdx
@@ -155,7 +155,7 @@ Among these two different types of custom node issues, conflicts between custom 
    ![Disable all plugin frontend extensions](/images/troubleshooting/disable_3rd_party.jpg)
    After starting ComfyUI, find the `Extensions` menu in settings and follow the steps shown in the image to disable all third-party extensions
    <Tip>
-      If you can't enter ComfyUI frontend, just skip the frontend extensions troubleshooting section and continue to [General Custom Node Troubleshooting Approach](#2-general-custom-node-troubleshooting-approach)
+      If you can't enter ComfyUI frontend, just skip the frontend extensions troubleshooting section and continue to [General Custom Node Troubleshooting Approach](#2-general-custom-node-troubleshooting)
    </Tip>
    </Step>
    <Step title="Restart ComfyUI">

--- a/troubleshooting/model-issues.mdx
+++ b/troubleshooting/model-issues.mdx
@@ -87,12 +87,12 @@ CheckpointLoaderSimple:
    - **Embeddings**: `models/embeddings/`
 
 3. **Share models between UIs or use custom paths:**
-   - See [ComfyUI Model Sharing and Custom Model Directory Configuration](/installation/comfyui_portable_windows#2-comfyui-model-sharing-and-custom-model-directory-configuration) for detailed instructions
+   - See [ComfyUI Model Sharing and Custom Model Directory Configuration](/installation/comfyui_portable_windows#adding-extra-model-paths) for detailed instructions
    - Edit `extra_model_paths.yaml` file to add custom model directories
 
 ### Model Search Path Configuration
 
-If you have models in custom locations, see the detailed guide for [ComfyUI Model Sharing and Custom Model Directory Configuration](/installation/comfyui_portable_windows#2-comfyui-model-sharing-and-custom-model-directory-configuration) to configure ComfyUI to find them.
+If you have models in custom locations, see the detailed guide for [ComfyUI Model Sharing and Custom Model Directory Configuration](/installation/comfyui_portable_windows#adding-extra-model-paths) to configure ComfyUI to find them.
 
 ## Model Loading Errors
 

--- a/troubleshooting/overview.mdx
+++ b/troubleshooting/overview.mdx
@@ -93,7 +93,7 @@ For comprehensive desktop installation troubleshooting, see the [Desktop Install
 <Tab title="Windows">
 - **Unsupported device**: Comfy Desktop Windows only supports NVIDIA GPUs with CUDA. Use [ComfyUI Portable](/installation/comfyui_portable_windows) or [manual installation](/installation/manual_install) for other GPUs
 - **Installation fails**: Run installer as administrator, ensure at least 15GB disk space
-- **Maintenance page**: Check [mirror settings](/installation/desktop/windows#mirror-settings) if downloads fail
+- **Maintenance page**: Check [mirror settings](/installation/desktop/usage/settings#advanced) if downloads fail
 - **Missing models**: Models are not copied during migration, only linked. Verify model paths
 </Tab>
 <Tab title="macOS">


### PR DESCRIPTION
## What

Adds an **independent** Anchor Check workflow that validates internal `#fragment` links on every PR and push to `main`, so broken anchors get caught at review time instead of silently 404-ing for readers.

## Changes

### New: `.github/scripts/check-anchors.py`
Static checker over MDX sources (no network, no build needed):
- Extracts a page's real anchors: heading slugs (Mintlify rules — lowercase, punctuation-stripped, `+`→`-+-`, plain `_` kept, `\_`→`-`), explicit `{#custom-id}`, `id=` attributes, component titles (`<Tab>`, `<Accordion>`, `<Step>`, `<Card>`), and **snippet imports** (`import X from "/snippets/..."`)
- Resolves every internal link's target file + anchor (relative/absolute paths, `.mdx` suffix variants, URL-decoded fragments)
- Modes: full scan, `--file`, and `--only-changed` (CI)

### New: `.github/workflows/anchor-check.yml`
- Runs on `pull_request` and `push` to `main` for `**/*.mdx` / `**/*.md` changes
- `check-anchors.py --only-changed` → only files touched in the PR are checked, so the ~245 pre-existing broken anchors in `zh/ja/ko` translations don't block new PRs

### Fixed: ~15 broken anchors in English docs
- `basic-concepts/custom-nodes.mdx`: `#installing-node-dependencies` → `#2-installing-node-dependencies`, `#installing-custom-nodes` → `#1-installing-custom-nodes`, encoded `%3A` in anchor
- `custom-nodes/backend/*`: `#validate-inputs` → `#validate_inputs`, `#input-types` → `#input_types`
- `development/comfyui-server/api-examples.mdx`: `#method-2-websocket--history-monitor-completion` → `#method-2-websocket-+-history-monitor-completion`
- `interface/appearance.mdx`: `#advanced-customization-with-user-css` → `#advanced-customization-with-usercss`
- `troubleshooting/*`: stale anchors (`#2-comfyui-model-sharing...`, `#mirror-settings`, `#2-general-custom-node-troubleshooting-approach`) now point to real sections
- `snippets/*` + `README.md`: anchors to non-existent headings

## Context

Fixes [FE-1620](https://linear.app/comfyorg/issue/FE-1620/add-anchor-checking-and-legacy-anchor-redirects) (link checker that also checks anchors). The legacy-anchor redirect half (old anchor still resolving) is tracked separately.

## Verification

- Full scan: English-source broken anchors → **0** remaining (was ~15)
- `--only-changed` mode tested locally on this branch: passes
- Remaining failures are all in `zh/ja/ko` translated docs (heading renamed in translation, link not updated) — out of scope here, can be swept separately
