### PR TITLE
docs: rewrite Cloud plan-change as in-app checkout

### DIFF
--- a/ja/support/subscription/canceling.mdx
+++ b/ja/support/subscription/canceling.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud サブスクリプションのキャンセル
 sidebarTitle: Comfy Cloud サブスクリプションをキャンセル
 description: Comfy Cloud サブスクリプションのキャンセル方法について学びます
-translationSourceHash: abe0525f
+translationSourceHash: 17db9ef5
 translationFrom: support/subscription/canceling.mdx
 ---
 
@@ -13,11 +13,8 @@ Comfy Cloud サブスクリプションをキャンセルするには:
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) にアクセスしてログインします
 2. 設定メニューへ移動します
 3. **Plan & Credits** に移動します
-4. **Manage subscription** をクリックします
-
-<img src="/images/support/subscription/subscription.jpg" alt="サブスクリプション設定メニュー" />
-
-5. Stripe の `Cancel subscription` ボタンをクリックしてサブスクリプションをキャンセルします
+4. **請求と請求書** をクリックします（一部のビルドでは **Manage subscription** のままです）
+5. Stripe の **Cancel subscription** をクリックしてサブスクリプションをキャンセルします
 
 <img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Stripe 請求ポータル" />
 

--- a/ja/support/subscription/canceling.mdx
+++ b/ja/support/subscription/canceling.mdx
@@ -1,8 +1,8 @@
 ---
 title: Comfy Cloud サブスクリプションのキャンセル
 sidebarTitle: Comfy Cloud サブスクリプションをキャンセル
-description: Comfy Cloud サブスクリプションのキャンセル方法について学びます
-translationSourceHash: 17db9ef5
+description: Plan & Credits から Comfy Cloud サブスクリプションをキャンセルします。現在の請求期間が終わるまで利用でき、いつでも再購読できます。
+translationSourceHash: 479a9b08
 translationFrom: support/subscription/canceling.mdx
 ---
 

--- a/ja/support/subscription/changing-plan.mdx
+++ b/ja/support/subscription/changing-plan.mdx
@@ -1,12 +1,12 @@
 ---
-title: 購読プランの変更
-sidebarTitle: 購読プランの変更
-description: Comfy Cloud 購読プランの変更方法について学びます
-translationSourceHash: 259c5665
+title: Comfy Cloud プランの変更
+sidebarTitle: Comfy Cloud プランの変更
+description: Comfy Cloud プランのアップグレードとダウングレード。Personal と Teams の切り替え、月額と年額、変更がいつ有効になるかを説明します。
+translationSourceHash: 7a3bfb23
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## プランの変更方法
+## Comfy Cloud プランの変更方法
 
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) にアクセスしてログインします。
 2. プロフィールメニューを開き、**Plan & Credits** をクリックします。
@@ -23,28 +23,28 @@ translationFrom: support/subscription/changing-plan.mdx
 請求を管理できるワークスペースメンバーだけがプランを変更できます。他のメンバーは現在のプランを見れますが、切り替えはできません。
 </Note>
 
-## Personal と Teams
+## Comfy Cloud の Personal と Teams
 
 **For Personal** と **For Teams** は、同じワークスペース上のプランスコープです。**Choose a Plan** 上部のトグルで切り替えます。
 
 - 個人プランは個人利用向けです。
 - チームプランは共同作業向けです。Team から Personal に切り替えると、余分なメンバーの削除を求められることがあります。
 
-## いつ有効になるか
+## Comfy Cloud プラン変更が有効になるタイミング
 
 確定前に Comfy Cloud が変更を分類します。プレビューには請求額（ある場合）と有効日が表示されます。
 
-### 即時（アップグレード）
+### 即時アップグレード
 
 同じ請求サイクルのまま上位ティアへ上げる変更（月額から月額、または年額から年額）はすぐに適用されます。本日、日割り差額を支払い、現在の期間の残りに対応するクレジットを受け取ります。
 
 月額から年額への切り替えも、すぐに新しい年額期間を開始します。月額プランの未使用期間は返金されません。
 
-### 期間終了時（ダウングレード）
+### 期間終了時のダウングレード
 
 下位ティア、短い請求サイクル、または少ない Team クレジット量への変更は、現在の請求期間の終了後に適用されます。それまでは現在のプランのままです。日割りの返金はありません。
 
-### 利用できない変更
+### 利用できないプラン変更
 
 - 年額プランを、月額課金の上位ティアへアップグレードすることはできません。年額の契約は期間終了まで残ります。
 - Founders Edition は一方通行です。他のプランから切り替えることはできません。

--- a/ja/support/subscription/changing-plan.mdx
+++ b/ja/support/subscription/changing-plan.mdx
@@ -2,7 +2,7 @@
 title: 購読プランの変更
 sidebarTitle: 購読プランの変更
 description: Comfy Cloud 購読プランの変更方法について学びます
-translationSourceHash: 34ed32ea
+translationSourceHash: 61d17cff
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
@@ -27,12 +27,10 @@ translationFrom: support/subscription/changing-plan.mdx
 
 ## Personal と Teams
 
-**For Personal** と **For Teams** は、同じワークスペース上のプランスコープです。地域の切り替えでも、別アカウントでもありません。**Choose a Plan** 上部のトグルで切り替えます。
+**For Personal** と **For Teams** は、同じワークスペース上のプランスコープです。**Choose a Plan** 上部のトグルで切り替えます。
 
 - 個人プランは個人利用向けです。
 - チームプランは共同作業向けです。Team から Personal に切り替えると、余分なメンバーの削除を求められることがあります。
-
-**Plan & Credits** に地域ピッカーはありません。チェックアウト時の支払い方法は所在地と通貨に依存します。請求通貨を変更するには、[支払い通貨](/ja/support/payment/payment-currency) を参照してください。
 
 ## いつ有効になるか
 

--- a/ja/support/subscription/changing-plan.mdx
+++ b/ja/support/subscription/changing-plan.mdx
@@ -2,11 +2,9 @@
 title: 購読プランの変更
 sidebarTitle: 購読プランの変更
 description: Comfy Cloud 購読プランの変更方法について学びます
-translationSourceHash: 61d17cff
+translationSourceHash: 259c5665
 translationFrom: support/subscription/changing-plan.mdx
 ---
-
-プラン変更は Stripe の請求ポータルではなく、Comfy Cloud アプリ内で行います。**請求と請求書** は支払い方法と請求書専用です。
 
 ## プランの変更方法
 

--- a/ja/support/subscription/changing-plan.mdx
+++ b/ja/support/subscription/changing-plan.mdx
@@ -2,50 +2,55 @@
 title: 購読プランの変更
 sidebarTitle: 購読プランの変更
 description: Comfy Cloud 購読プランの変更方法について学びます
-translationSourceHash: 1e4ea375
+translationSourceHash: 34ed32ea
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## 購読プランの変更方法
+プラン変更は Stripe の請求ポータルではなく、Comfy Cloud アプリ内で行います。**請求と請求書** は支払い方法と請求書専用です。
 
-Comfy Cloud 購読プランはいつでもアップグレードまたはダウングレードできます。プランを変更するには、以下の手順に従ってください。
+## プランの変更方法
 
-### ステップ 1：設定パネルを開く
+1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) にアクセスしてログインします。
+2. プロフィールメニューを開き、**Plan & Credits** をクリックします。
+3. **プランを変更** をクリックします（個人プランでは **プランをアップグレード** と表示される場合があります）。
+4. **Choose a Plan** でスコープを選びます。
+   - **For Personal**: Standard、Creator、Pro。毎月のクレジット量は固定です。
+   - **For Teams**: ワークスペースのチームプラン。スライダーで毎月のクレジット量を設定します。
+5. **Yearly** または **Monthly** を選びます。
+6. 目的のプランを選択します。アプリ内プレビュー（本日の請求額と、変更がいつ有効になるか）を確認して確定します。
 
-**Plan & Credits** メニューをクリックして、設定パネルを開きます。
+まだ有料プランでない場合は、**Subscribe** から同じ **Choose a Plan** ダイアログを開けます。[Comfy Cloud の購読](/ja/support/subscription/subscribing) を参照してください。
 
-<img src="/images/support/payment/billing-1-account.png" alt="Plan & Credits メニュー" />
+<Note>
+請求を管理できるワークスペースメンバーだけがプランを変更できます。他のメンバーは現在のプランを見れますが、切り替えはできません。
+</Note>
 
-### ステップ 2：購読管理にアクセス
+## Personal と Teams
 
-**Plan & Credits** パネルで、**Manage subscription** ボタンをクリックして購読設定を開きます。
+**For Personal** と **For Teams** は、同じワークスペース上のプランスコープです。地域の切り替えでも、別アカウントでもありません。**Choose a Plan** 上部のトグルで切り替えます。
 
-<img src="/images/support/subscription/subscription.jpg" alt="Manage subscription ボタン" />
+- 個人プランは個人利用向けです。
+- チームプランは共同作業向けです。Team から Personal に切り替えると、余分なメンバーの削除を求められることがあります。
 
-### ステップ 3：新しいプランを選択
+**Plan & Credits** に地域ピッカーはありません。チェックアウト時の支払い方法は所在地と通貨に依存します。請求通貨を変更するには、[支払い通貨](/ja/support/payment/payment-currency) を参照してください。
 
-任意のプランを選択し、**Change** ボタンをクリックします。
+## いつ有効になるか
 
-<img src="/images/support/subscription/subscribe.jpg" alt="購読プランの選択" />
+確定前に Comfy Cloud が変更を分類します。プレビューには請求額（ある場合）と有効日が表示されます。
 
-### ステップ 4：請求ポータルを開く
+### 即時（アップグレード）
 
-Comfy 請求ポータルが開いたら、**Update subscription** ボタンをクリックします。
+同じ請求サイクルのまま上位ティアへ上げる変更（月額から月額、または年額から年額）はすぐに適用されます。本日、日割り差額を支払い、現在の期間の残りに対応するクレジットを受け取ります。
 
-<img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Comfy 請求ポータル" />
+月額から年額への切り替えも、すぐに新しい年額期間を開始します。月額プランの未使用期間は返金されません。
 
-### ステップ 5：新しいプランを確認
+### 期間終了時（ダウングレード）
 
-希望するプランを選択し、**Continue** をクリックして選択を確定します。
+下位ティア、短い請求サイクル、または少ない Team クレジット量への変更は、現在の請求期間の終了後に適用されます。それまでは現在のプランのままです。日割りの返金はありません。
 
-<img src="/images/support/subscription/subscription-change-plan.jpg" alt="購読変更の確認" />
+### 利用できない変更
 
-## プラン変更の請求について
+- 年額プランを、月額課金の上位ティアへアップグレードすることはできません。年額の契約は期間終了まで残ります。
+- Founders Edition は一方通行です。他のプランから切り替えることはできません。
 
-### 価格の高いプランへのアップグレード
-
-現在の購読プランの価格が目標プランよりも低い場合、差額を支払う必要があります。差額に相当する分のクレジットが付与されます。
-
-### 価格の低いプランへのダウングレード
-
-現在の購読プランの価格が目標プランよりも高い場合、現在の請求サイクルが終了した後、購読が新しいプランに切り替わります。新しい購読は、新しい価格プランに基づきます。
+プラン価格とクレジット量は変わることがあります。**Choose a Plan** プレビューの金額を優先するか、[comfy.org/cloud/pricing](https://www.comfy.org/cloud/pricing) を確認してください。

--- a/ja/support/subscription/managing.mdx
+++ b/ja/support/subscription/managing.mdx
@@ -1,8 +1,8 @@
 ---
-title: Comfy Cloud サブスクリプションの管理
+title: Comfy Cloud の請求と請求書の管理
 sidebarTitle: Comfy Cloud サブスクリプションの管理
-description: Comfy Cloud サブスクリプションの管理方法について学びます
-translationSourceHash: ad2bf4d0
+description: Comfy Cloud の Plan & Credits から支払い方法を更新し、請求書をダウンロードして、サブスクリプションの請求を管理します。
+translationSourceHash: aa7bcb4a
 translationFrom: support/subscription/managing.mdx
 ---
 

--- a/ja/support/subscription/managing.mdx
+++ b/ja/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud サブスクリプションの管理
 sidebarTitle: Comfy Cloud サブスクリプションの管理
 description: Comfy Cloud サブスクリプションの管理方法について学びます
-translationSourceHash: f9e86d71
+translationSourceHash: ad2bf4d0
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -13,9 +13,6 @@ Comfy Cloud サブスクリプションを管理するには:
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) にアクセスしてログインします
 2. 設定メニューに移動します
 3. **Plan & Credits** に移動します
-
-<img src="/images/support/subscription/subscription.jpg" alt="サブスクリプション設定メニュー" />
-
 4. **請求と請求書** をクリックします（一部のビルドでは **Manage subscription** のままです）
 
 Stripe が開き、支払い方法と請求書を管理できます。プランを変更するには、代わりに **プランを変更** を使います。[購読プランの変更](/ja/support/subscription/changing-plan) を参照してください。

--- a/ja/support/subscription/managing.mdx
+++ b/ja/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud サブスクリプションの管理
 sidebarTitle: Comfy Cloud サブスクリプションの管理
 description: Comfy Cloud サブスクリプションの管理方法について学びます
-translationSourceHash: fcb66c1a
+translationSourceHash: f9e86d71
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -16,6 +16,6 @@ Comfy Cloud サブスクリプションを管理するには:
 
 <img src="/images/support/subscription/subscription.jpg" alt="サブスクリプション設定メニュー" />
 
-4. **Manage subscription** をクリックします
+4. **請求と請求書** をクリックします（一部のビルドでは **Manage subscription** のままです）
 
-これにより Stripe に移動し、そこでサブスクリプションの詳細を管理できます。
+Stripe が開き、支払い方法と請求書を管理できます。プランを変更するには、代わりに **プランを変更** を使います。[購読プランの変更](/ja/support/subscription/changing-plan) を参照してください。

--- a/ko/support/subscription/canceling.mdx
+++ b/ko/support/subscription/canceling.mdx
@@ -1,8 +1,8 @@
 ---
 title: Comfy Cloud 구독 취소하기
 sidebarTitle: Comfy Cloud 구독 취소하기
-description: "Comfy Cloud 구독을 취소하는 방법 알아보기"
-translationSourceHash: 17db9ef5
+description: "Plan & Credits에서 Comfy Cloud 구독을 취소하세요. 현재 결제 기간이 끝날 때까지 이용할 수 있으며, 언제든 다시 구독할 수 있습니다."
+translationSourceHash: 479a9b08
 translationFrom: support/subscription/canceling.mdx
 ---
 

--- a/ko/support/subscription/canceling.mdx
+++ b/ko/support/subscription/canceling.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud 구독 취소하기
 sidebarTitle: Comfy Cloud 구독 취소하기
 description: "Comfy Cloud 구독을 취소하는 방법 알아보기"
-translationSourceHash: abe0525f
+translationSourceHash: 17db9ef5
 translationFrom: support/subscription/canceling.mdx
 ---
 
@@ -13,11 +13,8 @@ Comfy Cloud 구독을 취소하려면:
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)에 접속하여 로그인하세요.
 2. 설정 메뉴로 이동하세요.
 3. **Plan & Credits**로 이동하세요.
-4. **구독 관리**를 클릭하세요.
-
-<img src="/images/support/subscription/subscription.jpg" alt="구독 설정 메뉴" />
-
-5. Stripe에서 `구독 취소` 버튼을 클릭하여 구독을 취소하세요.
+4. **결제 및 인보이스**를 클릭하세요(일부 빌드에는 여전히 **Manage subscription**으로 표시됩니다).
+5. Stripe에서 **Cancel subscription**을 클릭하여 구독을 취소하세요.
 
 <img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Stripe 결제 포털" />
 

--- a/ko/support/subscription/changing-plan.mdx
+++ b/ko/support/subscription/changing-plan.mdx
@@ -1,12 +1,12 @@
 ---
-title: 구독 플랜 변경하기
-sidebarTitle: 구독 플랜 변경하기
-description: "Comfy Cloud 구독 플랜을 변경하는 방법을 알아보세요"
-translationSourceHash: 259c5665
+title: Comfy Cloud 플랜 변경하기
+sidebarTitle: Comfy Cloud 플랜 변경하기
+description: "Comfy Cloud 플랜을 업그레이드하거나 다운그레이드하세요. Personal과 Teams 전환, 월간 또는 연간 결제, 변경이 적용되는 시점을 안내합니다."
+translationSourceHash: 7a3bfb23
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## 플랜을 변경하는 방법
+## Comfy Cloud 플랜을 변경하는 방법
 
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)에 방문해 로그인하세요.
 2. 프로필 메뉴를 열고 **Plan & Credits**를 클릭하세요.
@@ -23,28 +23,28 @@ translationFrom: support/subscription/changing-plan.mdx
 결제를 관리할 수 있는 워크스페이스 멤버만 플랜을 변경할 수 있습니다. 다른 멤버는 현재 플랜을 볼 수 있지만 전환할 수는 없습니다.
 </Note>
 
-## Personal vs Teams
+## Comfy Cloud Personal vs Teams
 
 **For Personal**과 **For Teams**는 같은 워크스페이스의 플랜 범위입니다. **Choose a Plan** 상단 토글로 전환하세요.
 
 - 개인 플랜은 개인 사용용입니다.
 - 팀 플랜은 협업용입니다. Team에서 Personal로 바꾸면 여분 멤버를 먼저 제거하라는 안내가 나올 수 있습니다.
 
-## 언제 적용되나요
+## Comfy Cloud 플랜 변경이 적용되는 시점
 
 확정 전에 Comfy Cloud가 변경을 분류합니다. 미리보기에 청구액(있는 경우)과 적용일이 표시됩니다.
 
-### 즉시 (업그레이드)
+### 즉시 업그레이드
 
 같은 결제 주기에서 더 높은 티어로 올리는 변경(월간→월간, 또는 연간→연간)은 바로 적용됩니다. 오늘 일할 차액을 내고, 현재 기간의 남은 시간에 맞는 크레딧을 받습니다.
 
 월간에서 연간으로 바꾸면 새 연간 기간도 즉시 시작됩니다. 월간 플랜의 남은 기간은 환불되지 않습니다.
 
-### 기간 종료 시 (다운그레이드)
+### 기간 종료 시 다운그레이드
 
 더 낮은 티어, 더 짧은 결제 주기, 또는 더 적은 Team 크레딧 양은 현재 결제 기간이 끝난 뒤에 적용됩니다. 그때까지는 현재 플랜을 유지합니다. 일할 환불은 없습니다.
 
-### 할 수 없는 변경
+### 할 수 없는 플랜 변경
 
 - 연간 플랜을 월간 청구의 더 높은 티어로 업그레이드할 수 없습니다. 연간 약정은 기간이 끝날 때까지 유지됩니다.
 - Founders Edition은 일방 통행입니다. 다른 플랜에서 이 플랜으로 전환할 수 없습니다.

--- a/ko/support/subscription/changing-plan.mdx
+++ b/ko/support/subscription/changing-plan.mdx
@@ -2,11 +2,9 @@
 title: 구독 플랜 변경하기
 sidebarTitle: 구독 플랜 변경하기
 description: "Comfy Cloud 구독 플랜을 변경하는 방법을 알아보세요"
-translationSourceHash: 61d17cff
+translationSourceHash: 259c5665
 translationFrom: support/subscription/changing-plan.mdx
 ---
-
-플랜 변경은 Stripe 결제 포털이 아니라 Comfy Cloud 앱에서 진행합니다. **결제 및 인보이스**는 결제 수단과 인보이스 전용입니다.
 
 ## 플랜을 변경하는 방법
 

--- a/ko/support/subscription/changing-plan.mdx
+++ b/ko/support/subscription/changing-plan.mdx
@@ -2,7 +2,7 @@
 title: 구독 플랜 변경하기
 sidebarTitle: 구독 플랜 변경하기
 description: "Comfy Cloud 구독 플랜을 변경하는 방법을 알아보세요"
-translationSourceHash: 34ed32ea
+translationSourceHash: 61d17cff
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
@@ -27,12 +27,10 @@ translationFrom: support/subscription/changing-plan.mdx
 
 ## Personal vs Teams
 
-**For Personal**과 **For Teams**는 같은 워크스페이스의 플랜 범위입니다. 지역 전환이나 별도 계정이 아닙니다. **Choose a Plan** 상단 토글로 전환하세요.
+**For Personal**과 **For Teams**는 같은 워크스페이스의 플랜 범위입니다. **Choose a Plan** 상단 토글로 전환하세요.
 
 - 개인 플랜은 개인 사용용입니다.
 - 팀 플랜은 협업용입니다. Team에서 Personal로 바꾸면 여분 멤버를 먼저 제거하라는 안내가 나올 수 있습니다.
-
-**Plan & Credits**에는 지역 선택기가 없습니다. 결제 시 사용 가능한 결제 수단은 위치와 통화에 따라 달라집니다. 청구 통화를 바꾸려면 [결제 통화](/ko/support/payment/payment-currency)를 참고하세요.
 
 ## 언제 적용되나요
 

--- a/ko/support/subscription/changing-plan.mdx
+++ b/ko/support/subscription/changing-plan.mdx
@@ -2,50 +2,55 @@
 title: 구독 플랜 변경하기
 sidebarTitle: 구독 플랜 변경하기
 description: "Comfy Cloud 구독 플랜을 변경하는 방법을 알아보세요"
-translationSourceHash: 1e4ea375
+translationSourceHash: 34ed32ea
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## 구독 플랜 변경 방법
+플랜 변경은 Stripe 결제 포털이 아니라 Comfy Cloud 앱에서 진행합니다. **결제 및 인보이스**는 결제 수단과 인보이스 전용입니다.
 
-Comfy Cloud 구독 플랜은 언제든지 업그레이드하거나 다운그레이드할 수 있습니다. 다음 단계에 따라 플랜을 변경하세요:
+## 플랜을 변경하는 방법
 
-### 1단계: 설정 패널 열기
+1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)에 방문해 로그인하세요.
+2. 프로필 메뉴를 열고 **Plan & Credits**를 클릭하세요.
+3. **요금제 변경**을 클릭하세요(개인 플랜에서는 **플랜 업그레이드**로 표시될 수 있습니다).
+4. **Choose a Plan**에서 범위를 고르세요.
+   - **For Personal**: Standard, Creator, Pro. 매월 크레딧 양은 고정입니다.
+   - **For Teams**: 워크스페이스 팀 플랜. 슬라이더로 월간 크레딧 양을 설정합니다.
+5. **Yearly** 또는 **Monthly**를 선택하세요.
+6. 원하는 플랜을 고르세요. 앱 미리보기(오늘 청구 금액과 변경이 적용되는 시점)를 확인한 뒤 확정하세요.
 
-**플랜 및 크레딧** 메뉴를 클릭하여 설정 패널을 엽니다.
+아직 유료 플랜이 아니라면 **Subscribe**에서 같은 **Choose a Plan** 대화상자를 열 수 있습니다. [Comfy Cloud 구독](/ko/support/subscription/subscribing)을 참고하세요.
 
-<img src="/images/support/payment/billing-1-account.png" alt="플랜 및 크레딧 메뉴" />
+<Note>
+결제를 관리할 수 있는 워크스페이스 멤버만 플랜을 변경할 수 있습니다. 다른 멤버는 현재 플랜을 볼 수 있지만 전환할 수는 없습니다.
+</Note>
 
-### 2단계: 구독 관리 접근하기
+## Personal vs Teams
 
-**플랜 및 크레딧** 패널에서 **구독 관리** 버튼을 클릭하여 구독 설정을 엽니다.
+**For Personal**과 **For Teams**는 같은 워크스페이스의 플랜 범위입니다. 지역 전환이나 별도 계정이 아닙니다. **Choose a Plan** 상단 토글로 전환하세요.
 
-<img src="/images/support/subscription/subscription.jpg" alt="구독 관리 버튼" />
+- 개인 플랜은 개인 사용용입니다.
+- 팀 플랜은 협업용입니다. Team에서 Personal로 바꾸면 여분 멤버를 먼저 제거하라는 안내가 나올 수 있습니다.
 
-### 3단계: 새로운 플랜 선택하기
+**Plan & Credits**에는 지역 선택기가 없습니다. 결제 시 사용 가능한 결제 수단은 위치와 통화에 따라 달라집니다. 청구 통화를 바꾸려면 [결제 통화](/ko/support/payment/payment-currency)를 참고하세요.
 
-원하는 플랜을 선택한 후, **변경** 버튼을 클릭하세요.
+## 언제 적용되나요
 
-<img src="/images/support/subscription/subscribe.jpg" alt="구독 플랜 선택" />
+확정 전에 Comfy Cloud가 변경을 분류합니다. 미리보기에 청구액(있는 경우)과 적용일이 표시됩니다.
 
-### 4단계: 청구 포털 열기
+### 즉시 (업그레이드)
 
-Comfy 청구 포털을 연 후, **구독 업데이트** 버튼을 클릭하세요.
+같은 결제 주기에서 더 높은 티어로 올리는 변경(월간→월간, 또는 연간→연간)은 바로 적용됩니다. 오늘 일할 차액을 내고, 현재 기간의 남은 시간에 맞는 크레딧을 받습니다.
 
-<img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Comfy 청구 포털" />
+월간에서 연간으로 바꾸면 새 연간 기간도 즉시 시작됩니다. 월간 플랜의 남은 기간은 환불되지 않습니다.
 
-### 5단계: 새 플랜 확인하기
+### 기간 종료 시 (다운그레이드)
 
-원하는 플랜을 선택한 후, **계속**을 클릭하여 선택을 확정하세요.
+더 낮은 티어, 더 짧은 결제 주기, 또는 더 적은 Team 크레딧 양은 현재 결제 기간이 끝난 뒤에 적용됩니다. 그때까지는 현재 플랜을 유지합니다. 일할 환불은 없습니다.
 
-<img src="/images/support/subscription/subscription-change-plan.jpg" alt="구독 변경 확인" />
+### 할 수 없는 변경
 
-## 플랜 변경에 따른 청구
+- 연간 플랜을 월간 청구의 더 높은 티어로 업그레이드할 수 없습니다. 연간 약정은 기간이 끝날 때까지 유지됩니다.
+- Founders Edition은 일방 통행입니다. 다른 플랜에서 이 플랜으로 전환할 수 없습니다.
 
-### 더 높은 가격의 플랜으로 업그레이드하기
-
-현재 구독 플랜의 가격이 목표 플랜보다 낮다면, 가격 차액을 결제해야 합니다. 이 경우, 가격 차액에 해당하는 크레딧이 제공됩니다.
-
-### 더 낮은 가격의 플랜으로 다운그레이드하기
-
-현재 구독 플랜의 가격이 목표 플랜보다 높다면, 현재 청구 주기가 끝난 후 구독이 새 플랜으로 전환됩니다. 새 구독은 새로운 요금제를 기반으로 하게 됩니다.
+플랜 가격과 크레딧 양은 바뀔 수 있습니다. **Choose a Plan** 미리보기의 금액을 따르거나 [comfy.org/cloud/pricing](https://www.comfy.org/cloud/pricing)을 확인하세요.

--- a/ko/support/subscription/managing.mdx
+++ b/ko/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud 구독 관리하기
 sidebarTitle: Comfy Cloud 구독 관리하기
 description: "Comfy Cloud 구독을 관리하는 방법을 알아보세요"
-translationSourceHash: f9e86d71
+translationSourceHash: ad2bf4d0
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -13,9 +13,6 @@ Comfy Cloud 구독을 관리하려면:
 1. [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)를 방문하여 로그인하세요.
 2. 설정 메뉴로 이동하세요.
 3. **요금제 및 크레딧**으로 이동하세요.
-
-<img src="/images/support/subscription/subscription.jpg" alt="구독 설정 메뉴" />
-
 4. **결제 및 인보이스**를 클릭하세요(일부 빌드에는 여전히 **Manage subscription**으로 표시됩니다).
 
 Stripe로 이동하며, 여기서 결제 수단과 인보이스를 관리할 수 있습니다. 플랜을 바꾸려면 **요금제 변경**을 사용하세요. [구독 플랜 변경하기](/ko/support/subscription/changing-plan)를 참고하세요.

--- a/ko/support/subscription/managing.mdx
+++ b/ko/support/subscription/managing.mdx
@@ -1,8 +1,8 @@
 ---
-title: Comfy Cloud 구독 관리하기
+title: Comfy Cloud 결제 및 인보이스 관리
 sidebarTitle: Comfy Cloud 구독 관리하기
-description: "Comfy Cloud 구독을 관리하는 방법을 알아보세요"
-translationSourceHash: ad2bf4d0
+description: "Comfy Cloud의 Plan & Credits에서 결제 수단을 업데이트하고, 인보이스를 다운로드하며, 구독 결제를 관리하세요."
+translationSourceHash: aa7bcb4a
 translationFrom: support/subscription/managing.mdx
 ---
 

--- a/ko/support/subscription/managing.mdx
+++ b/ko/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: Comfy Cloud 구독 관리하기
 sidebarTitle: Comfy Cloud 구독 관리하기
 description: "Comfy Cloud 구독을 관리하는 방법을 알아보세요"
-translationSourceHash: fcb66c1a
+translationSourceHash: f9e86d71
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -16,6 +16,6 @@ Comfy Cloud 구독을 관리하려면:
 
 <img src="/images/support/subscription/subscription.jpg" alt="구독 설정 메뉴" />
 
-4. **구독 관리**를 클릭하세요.
+4. **결제 및 인보이스**를 클릭하세요(일부 빌드에는 여전히 **Manage subscription**으로 표시됩니다).
 
-이렇게 하면 Stripe로 이동하게 되며, 여기서 구독 세부정보를 관리할 수 있습니다.
+Stripe로 이동하며, 여기서 결제 수단과 인보이스를 관리할 수 있습니다. 플랜을 바꾸려면 **요금제 변경**을 사용하세요. [구독 플랜 변경하기](/ko/support/subscription/changing-plan)를 참고하세요.

--- a/support/subscription/canceling.mdx
+++ b/support/subscription/canceling.mdx
@@ -1,7 +1,7 @@
 ---
-title: Canceling your Comfy Cloud subscription
+title: Cancel your Comfy Cloud subscription
 sidebarTitle: Cancel Comfy Cloud subscription
-description: Learn how to cancel your Comfy Cloud subscription
+description: Cancel a Comfy Cloud subscription from Plan & Credits. Access continues until the current billing period ends, and you can resubscribe anytime.
 ---
 
 ## How to cancel

--- a/support/subscription/canceling.mdx
+++ b/support/subscription/canceling.mdx
@@ -11,11 +11,8 @@ To cancel your Comfy Cloud subscription:
 1. Visit and log in to [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)
 2. Navigate to the settings menu
 3. Go to **Plan & Credits**
-4. Click **Manage subscription**
-
-<img src="/images/support/subscription/subscription.jpg" alt="Subscription settings menu" />
-
-5. Click `Cancel subscription` button in Stripe to cancel your subscription
+4. Click **Billing & invoices** (some builds still label this **Manage subscription**)
+5. In Stripe, click **Cancel subscription** to cancel your subscription
 
 <img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Stripe billing portal" />
 

--- a/support/subscription/changing-plan.mdx
+++ b/support/subscription/changing-plan.mdx
@@ -25,12 +25,10 @@ Only workspace members who can manage billing can change the plan. Other members
 
 ## Personal vs Teams
 
-**For Personal** and **For Teams** are plan scopes on the same workspace. They are not a region switch or a separate account. Use the toggle at the top of **Choose a Plan** to move between them.
+**For Personal** and **For Teams** are plan scopes on the same workspace. Use the toggle at the top of **Choose a Plan** to move between them.
 
 - Personal plans are for individual use.
 - Team plans are for collaboration. Switching from Team to Personal may ask you to remove extra members first.
-
-There is no region picker in **Plan & Credits**. Payment methods at checkout depend on your location and currency. To change billing currency, see [Payment currency](/support/payment/payment-currency).
 
 ## When the change takes effect
 

--- a/support/subscription/changing-plan.mdx
+++ b/support/subscription/changing-plan.mdx
@@ -1,10 +1,10 @@
 ---
-title: Changing your subscription plan
-sidebarTitle: Change subscription plan
-description: Learn how to change your Comfy Cloud subscription plan
+title: Change your Comfy Cloud plan
+sidebarTitle: Change Comfy Cloud plan
+description: Upgrade or downgrade a Comfy Cloud plan. Switch Personal or Teams, choose monthly or yearly billing, and see when the change takes effect.
 ---
 
-## How to change your plan
+## How to change a Comfy Cloud plan
 
 1. Visit [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) and log in.
 2. Open the profile menu and click **Plan & Credits**.
@@ -21,28 +21,28 @@ You can also open the same **Choose a Plan** dialog from **Subscribe** if you ar
 Only workspace members who can manage billing can change the plan. Other members can see the current plan, but they cannot switch it.
 </Note>
 
-## Personal vs Teams
+## Comfy Cloud Personal vs Teams
 
 **For Personal** and **For Teams** are plan scopes on the same workspace. Use the toggle at the top of **Choose a Plan** to move between them.
 
 - Personal plans are for individual use.
 - Team plans are for collaboration. Switching from Team to Personal may ask you to remove extra members first.
 
-## When the change takes effect
+## When a Comfy Cloud plan change takes effect
 
 Comfy Cloud classifies each change before you confirm. The preview shows the charge (if any) and the effective date.
 
-### Immediate (upgrade)
+### Immediate upgrades
 
 A higher tier with the same billing cycle (monthly to monthly, or yearly to yearly) applies now. You pay a prorated amount today and receive the matching credits for the rest of the current period.
 
 Switching from monthly to yearly also starts a new yearly period immediately. Unused time on the monthly plan is not refunded.
 
-### Scheduled (downgrade)
+### Scheduled downgrades
 
 A lower tier, a shorter billing cycle, or a smaller Team credit amount applies at the end of the current billing period. You keep the current plan until then. There is no proration refund.
 
-### Changes that are not available
+### Plan changes that are not available
 
 - You cannot upgrade an annual plan to a higher tier billed monthly. The annual commitment stays in place until the period ends.
 - Founders Edition is a one-way origin. Other plans cannot switch into it.

--- a/support/subscription/changing-plan.mdx
+++ b/support/subscription/changing-plan.mdx
@@ -4,46 +4,51 @@ sidebarTitle: Change subscription plan
 description: Learn how to change your Comfy Cloud subscription plan
 ---
 
-## How to change your subscription plan
+Plan changes happen in Comfy Cloud, not in the Stripe billing portal. Use **Billing & invoices** only for payment methods and invoices.
 
-You can upgrade or downgrade your Comfy Cloud subscription plan at any time. Follow these steps to change your plan:
+## How to change your plan
 
-### Step 1: Open the settings panel
+1. Visit [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) and log in.
+2. Open the profile menu and click **Plan & Credits**.
+3. Click **Change plan** (personal plans may show **Upgrade Plan** instead).
+4. In **Choose a Plan**, pick a scope:
+   - **For Personal**: Standard, Creator, or Pro, with a fixed monthly credit amount.
+   - **For Teams**: a workspace team plan. You set the monthly credit amount with a slider.
+5. Choose **Yearly** or **Monthly**.
+6. Select the plan you want. Review the in-app preview (amount due today, and when the change takes effect), then confirm.
 
-Click the **Plan & Credits** menu to open the settings panel.
+You can also open the same **Choose a Plan** dialog from **Subscribe** if you are not on a paid plan yet. See [Subscribe to Comfy Cloud](/support/subscription/subscribing).
 
-<img src="/images/support/payment/billing-1-account.png" alt="Plan & Credits menu" />
+<Note>
+Only workspace members who can manage billing can change the plan. Other members can see the current plan, but they cannot switch it.
+</Note>
 
-### Step 2: Access subscription management
+## Personal vs Teams
 
-In the **Plan & Credits** panel, click the **Manage subscription** button to open the subscription settings.
+**For Personal** and **For Teams** are plan scopes on the same workspace. They are not a region switch or a separate account. Use the toggle at the top of **Choose a Plan** to move between them.
 
-<img src="/images/support/subscription/subscription.jpg" alt="Manage subscription button" />
+- Personal plans are for individual use.
+- Team plans are for collaboration. Switching from Team to Personal may ask you to remove extra members first.
 
-### Step 3: Select a new plan
+There is no region picker in **Plan & Credits**. Payment methods at checkout depend on your location and currency. To change billing currency, see [Payment currency](/support/payment/payment-currency).
 
-Select any plan you want, then click the **Change** button.
+## When the change takes effect
 
-<img src="/images/support/subscription/subscribe.jpg" alt="Select subscription plan" />
+Comfy Cloud classifies each change before you confirm. The preview shows the charge (if any) and the effective date.
 
-### Step 4: Open the billing portal
+### Immediate (upgrade)
 
-After opening the Comfy billing portal, click the **Update subscription** button.
+A higher tier with the same billing cycle (monthly to monthly, or yearly to yearly) applies now. You pay a prorated amount today and receive the matching credits for the rest of the current period.
 
-<img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Comfy billing portal" />
+Switching from monthly to yearly also starts a new yearly period immediately. Unused time on the monthly plan is not refunded.
 
-### Step 5: Confirm your new plan
+### Scheduled (downgrade)
 
-Select the plan you want, then click **Continue** to confirm your selection.
+A lower tier, a shorter billing cycle, or a smaller Team credit amount applies at the end of the current billing period. You keep the current plan until then. There is no proration refund.
 
-<img src="/images/support/subscription/subscription-change-plan.jpg" alt="Confirm subscription change" />
+### Changes that are not available
 
-## Billing for plan changes
+- You cannot upgrade an annual plan to a higher tier billed monthly. The annual commitment stays in place until the period ends.
+- Founders Edition is a one-way origin. Other plans cannot switch into it.
 
-### Upgrading to a higher-priced plan
-
-If your current subscription plan price is lower than the target plan, you will need to pay the price difference. You will receive an equivalent credit amount corresponding to the price difference.
-
-### Downgrading to a lower-priced plan
-
-If your current subscription plan price is higher than the target plan, your subscription will switch to the new plan after the current billing cycle ends. The new subscription will be based on the new pricing plan.
+Plan prices and credit amounts can change. Trust the amounts in the **Choose a Plan** preview, or see [comfy.org/cloud/pricing](https://www.comfy.org/cloud/pricing).

--- a/support/subscription/changing-plan.mdx
+++ b/support/subscription/changing-plan.mdx
@@ -4,8 +4,6 @@ sidebarTitle: Change subscription plan
 description: Learn how to change your Comfy Cloud subscription plan
 ---
 
-Plan changes happen in Comfy Cloud, not in the Stripe billing portal. Use **Billing & invoices** only for payment methods and invoices.
-
 ## How to change your plan
 
 1. Visit [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) and log in.

--- a/support/subscription/managing.mdx
+++ b/support/subscription/managing.mdx
@@ -11,9 +11,6 @@ To manage your Comfy Cloud subscription:
 1. Visit and log in to [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)
 2. Navigate to the settings menu
 3. Go to **Plan & Credits**
-
-<img src="/images/support/subscription/subscription.jpg" alt="Subscription settings menu" />
-
 4. Click **Billing & invoices** (some builds still label this **Manage subscription**)
 
 This will take you to Stripe, where you can manage payment methods and invoices. To change your plan, use **Change plan** instead. See [Changing your subscription plan](/support/subscription/changing-plan).

--- a/support/subscription/managing.mdx
+++ b/support/subscription/managing.mdx
@@ -1,7 +1,7 @@
 ---
-title: Managing your Comfy Cloud subscription
+title: Manage Comfy Cloud billing and invoices
 sidebarTitle: Manage Comfy Cloud subscription
-description: Learn how to manage your Comfy Cloud subscription
+description: Open Plan & Credits on Comfy Cloud to update payment methods, download invoices, and manage billing for your subscription.
 ---
 
 ## Accessing subscription management

--- a/support/subscription/managing.mdx
+++ b/support/subscription/managing.mdx
@@ -14,6 +14,6 @@ To manage your Comfy Cloud subscription:
 
 <img src="/images/support/subscription/subscription.jpg" alt="Subscription settings menu" />
 
-4. Click **Manage subscription**
+4. Click **Billing & invoices** (some builds still label this **Manage subscription**)
 
-This will take you to Stripe, where you can manage your subscription details.
+This will take you to Stripe, where you can manage payment methods and invoices. To change your plan, use **Change plan** instead. See [Changing your subscription plan](/support/subscription/changing-plan).

--- a/zh/support/subscription/canceling.mdx
+++ b/zh/support/subscription/canceling.mdx
@@ -1,8 +1,8 @@
 ---
-title: 取消您的 Comfy Cloud 订阅
+title: 取消 Comfy Cloud 订阅
 sidebarTitle: 取消 Comfy Cloud 订阅
-description: 了解如何取消您的 Comfy Cloud 订阅
-translationSourceHash: 17db9ef5
+description: 从 Plan & Credits 取消 Comfy Cloud 订阅。当前计费周期结束前仍可使用，之后可随时重新订阅。
+translationSourceHash: 479a9b08
 translationFrom: support/subscription/canceling.mdx
 ---
 

--- a/zh/support/subscription/canceling.mdx
+++ b/zh/support/subscription/canceling.mdx
@@ -2,7 +2,7 @@
 title: 取消您的 Comfy Cloud 订阅
 sidebarTitle: 取消 Comfy Cloud 订阅
 description: 了解如何取消您的 Comfy Cloud 订阅
-translationSourceHash: abe0525f
+translationSourceHash: 17db9ef5
 translationFrom: support/subscription/canceling.mdx
 ---
 
@@ -13,11 +13,8 @@ translationFrom: support/subscription/canceling.mdx
 1. 访问并登录 [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)
 2. 导航到设置菜单
 3. 进入 **Plan & Credits**(计划与积分)
-4. 点击 **Manage subscription**(管理订阅)
-
-<img src="/images/support/subscription/subscription.jpg" alt="Subscription settings menu" />
-
-5. 在 Stripe 中点击 `Cancel subscription` 按钮来取消订阅
+4. 点击 **账单与发票**（部分版本仍显示 **Manage subscription**）
+5. 在 Stripe 中点击 **Cancel subscription** 来取消订阅
 
 <img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Stripe billing portal" />
 

--- a/zh/support/subscription/changing-plan.mdx
+++ b/zh/support/subscription/changing-plan.mdx
@@ -2,50 +2,55 @@
 title: 更改订阅计划
 sidebarTitle: 更改订阅计划
 description: 了解如何更改您的 Comfy Cloud 订阅计划
-translationSourceHash: 1e4ea375
+translationSourceHash: 34ed32ea
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## 如何更改订阅计划
+套餐变更在 Comfy Cloud 应用内完成，不在 Stripe 账单门户里。**账单与发票**只用于支付方式和发票。
 
-您可以随时升级或降级您的 Comfy Cloud 订阅计划。按照以下步骤更改您的计划：
+## 如何更改套餐
 
-### 步骤 1：打开设置面板
+1. 打开 [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) 并登录。
+2. 打开个人菜单，点击 **Plan & Credits**（计划与积分）。
+3. 点击 **更改套餐**（个人套餐上也可能显示 **升级订阅**）。
+4. 在 **Choose a Plan**（选择套餐）中选择范围：
+   - **个人使用**：Standard、Creator 或 Pro，每月积分固定。
+   - **团队使用**：工作区团队套餐。用滑块设置每月积分。
+5. 选择 **Yearly**（年付）或 **Monthly**（月付）。
+6. 选中目标套餐。查看应用内预览（今天应付金额，以及何时生效），然后确认。
 
-点击 **Plan & Credits**（计划与积分）菜单，打开设置面板。
+如果还没有付费套餐，也可以从 **Subscribe** 打开同一个 **Choose a Plan** 对话框。参见[订阅 Comfy Cloud](/zh/support/subscription/subscribing)。
 
-<img src="/images/support/payment/billing-1-account.png" alt="计划与积分菜单" />
+<Note>
+只有可以管理账单的工作区成员才能更改套餐。其他成员能看到当前套餐，但不能切换。
+</Note>
 
-### 步骤 2：访问订阅管理
+## 个人与团队
 
-在 **Plan & Credits**（计划与积分）面板中，点击 **Manage subscription**（管理订阅）按钮，打开订阅设置。
+**个人使用** 和 **团队使用** 是同一工作区上的套餐范围，不是地域切换，也不是另一个账号。用 **Choose a Plan** 顶部的切换开关在两者之间移动。
 
-<img src="/images/support/subscription/subscription.jpg" alt="管理订阅按钮" />
+- 个人套餐仅限个人使用。
+- 团队套餐用于协作。从团队切到个人时，可能需要先移除多余成员。
 
-### 步骤 3：选择新计划
+**Plan & Credits** 里没有地域选择器。结账时可用的支付方式取决于你的所在地和币种。要更改账单币种，参见[支付币种](/zh/support/payment/payment-currency)。
 
-选择您想要的任意计划，然后点击 **Change**（更改）按钮。
+## 何时生效
 
-<img src="/images/support/subscription/subscribe.jpg" alt="选择订阅计划" />
+确认前，Comfy Cloud 会先分类这次变更。预览会显示费用（如有）和生效日期。
 
-### 步骤 4：打开账单门户
+### 立即生效（升级）
 
-打开 Comfy 账单门户后，点击 **Update subscription**（更新订阅）按钮。
+同一计费周期内升到更高档位（月付到月付，或年付到年付）会立即生效。你今天支付按比例计算的差价，并获得当前周期剩余时间内对应的积分。
 
-<img src="/images/support/payment/comfyui-billing-portal.jpg" alt="Comfy 账单门户" />
+从月付改到年付也会立即开始一个新年付周期。月付套餐未用完的时间不会退款。
 
-### 步骤 5：确认新计划
+### 周期结束时生效（降级）
 
-选择您想要的计划，然后点击 **Continue**（继续）确认您的选择。
+更低档位、更短的计费周期，或更少的团队积分，会在当前计费周期结束后生效。在此之前你仍使用当前套餐。没有按比例退款。
 
-<img src="/images/support/subscription/subscription-change-plan.jpg" alt="确认订阅更改" />
+### 不可用的变更
 
-## 计划更改的计费说明
+- 不能把年付套餐升级到按月计费的更高档位。年付承诺会保留到周期结束。
+- Founders Edition 只能离开，不能从其他套餐切进去。
 
-### 升级到更高价格的计划
-
-如果您当前的订阅计划价格低于目标计划，您需要支付差价。您将获得与差价相对应的等额积分。
-
-### 降级到更低价格的计划
-
-如果您当前的订阅计划价格高于目标计划，您的订阅将在当前计费周期结束后切换到新计划。新订阅将基于新的定价计划。
+套餐价格和积分数量可能会变。以 **Choose a Plan** 预览中的金额为准，或查看 [comfy.org/cloud/pricing](https://www.comfy.org/cloud/pricing)。

--- a/zh/support/subscription/changing-plan.mdx
+++ b/zh/support/subscription/changing-plan.mdx
@@ -1,12 +1,12 @@
 ---
-title: 更改订阅计划
-sidebarTitle: 更改订阅计划
-description: 了解如何更改您的 Comfy Cloud 订阅计划
-translationSourceHash: 259c5665
+title: 更改 Comfy Cloud 套餐
+sidebarTitle: 更改 Comfy Cloud 套餐
+description: 升级或降级 Comfy Cloud 套餐。在个人与团队之间切换，选择月付或年付，并了解变更何时生效。
+translationSourceHash: 7a3bfb23
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
-## 如何更改套餐
+## 如何更改 Comfy Cloud 套餐
 
 1. 打开 [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs) 并登录。
 2. 打开个人菜单，点击 **Plan & Credits**（计划与积分）。
@@ -23,28 +23,28 @@ translationFrom: support/subscription/changing-plan.mdx
 只有可以管理账单的工作区成员才能更改套餐。其他成员能看到当前套餐，但不能切换。
 </Note>
 
-## 个人与团队
+## Comfy Cloud 个人与团队
 
 **个人使用** 和 **团队使用** 是同一工作区上的套餐范围。用 **Choose a Plan** 顶部的切换开关在两者之间移动。
 
 - 个人套餐仅限个人使用。
 - 团队套餐用于协作。从团队切到个人时，可能需要先移除多余成员。
 
-## 何时生效
+## Comfy Cloud 套餐何时生效
 
 确认前，Comfy Cloud 会先分类这次变更。预览会显示费用（如有）和生效日期。
 
-### 立即生效（升级）
+### 立即生效的升级
 
 同一计费周期内升到更高档位（月付到月付，或年付到年付）会立即生效。你今天支付按比例计算的差价，并获得当前周期剩余时间内对应的积分。
 
 从月付改到年付也会立即开始一个新年付周期。月付套餐未用完的时间不会退款。
 
-### 周期结束时生效（降级）
+### 周期结束时生效的降级
 
 更低档位、更短的计费周期，或更少的团队积分，会在当前计费周期结束后生效。在此之前你仍使用当前套餐。没有按比例退款。
 
-### 不可用的变更
+### 不可用的套餐变更
 
 - 不能把年付套餐升级到按月计费的更高档位。年付承诺会保留到周期结束。
 - Founders Edition 只能离开，不能从其他套餐切进去。

--- a/zh/support/subscription/changing-plan.mdx
+++ b/zh/support/subscription/changing-plan.mdx
@@ -2,7 +2,7 @@
 title: 更改订阅计划
 sidebarTitle: 更改订阅计划
 description: 了解如何更改您的 Comfy Cloud 订阅计划
-translationSourceHash: 34ed32ea
+translationSourceHash: 61d17cff
 translationFrom: support/subscription/changing-plan.mdx
 ---
 
@@ -27,12 +27,10 @@ translationFrom: support/subscription/changing-plan.mdx
 
 ## 个人与团队
 
-**个人使用** 和 **团队使用** 是同一工作区上的套餐范围，不是地域切换，也不是另一个账号。用 **Choose a Plan** 顶部的切换开关在两者之间移动。
+**个人使用** 和 **团队使用** 是同一工作区上的套餐范围。用 **Choose a Plan** 顶部的切换开关在两者之间移动。
 
 - 个人套餐仅限个人使用。
 - 团队套餐用于协作。从团队切到个人时，可能需要先移除多余成员。
-
-**Plan & Credits** 里没有地域选择器。结账时可用的支付方式取决于你的所在地和币种。要更改账单币种，参见[支付币种](/zh/support/payment/payment-currency)。
 
 ## 何时生效
 

--- a/zh/support/subscription/changing-plan.mdx
+++ b/zh/support/subscription/changing-plan.mdx
@@ -2,11 +2,9 @@
 title: 更改订阅计划
 sidebarTitle: 更改订阅计划
 description: 了解如何更改您的 Comfy Cloud 订阅计划
-translationSourceHash: 61d17cff
+translationSourceHash: 259c5665
 translationFrom: support/subscription/changing-plan.mdx
 ---
-
-套餐变更在 Comfy Cloud 应用内完成，不在 Stripe 账单门户里。**账单与发票**只用于支付方式和发票。
 
 ## 如何更改套餐
 

--- a/zh/support/subscription/managing.mdx
+++ b/zh/support/subscription/managing.mdx
@@ -1,8 +1,8 @@
 ---
-title: 管理您的 Comfy Cloud 订阅
+title: 管理 Comfy Cloud 账单与发票
 sidebarTitle: 管理 Comfy Cloud 订阅
-description: 了解如何管理您的 Comfy Cloud 订阅
-translationSourceHash: ad2bf4d0
+description: 在 Comfy Cloud 的 Plan & Credits 中更新支付方式、下载发票并管理订阅账单。
+translationSourceHash: aa7bcb4a
 translationFrom: support/subscription/managing.mdx
 ---
 

--- a/zh/support/subscription/managing.mdx
+++ b/zh/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: 管理您的 Comfy Cloud 订阅
 sidebarTitle: 管理 Comfy Cloud 订阅
 description: 了解如何管理您的 Comfy Cloud 订阅
-translationSourceHash: f9e86d71
+translationSourceHash: ad2bf4d0
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -13,9 +13,6 @@ translationFrom: support/subscription/managing.mdx
 1. 访问并登录 [cloud.comfy.org](https://cloud.comfy.org/?utm_source=docs)
 2. 导航到设置菜单
 3. 进入 **Plan & Credits**(计划与积分)
-
-<img src="/images/support/subscription/subscription.jpg" alt="订阅设置菜单" />
-
 4. 点击 **账单与发票**（部分版本仍显示 **Manage subscription**）
 
 这将打开 Stripe，用于管理支付方式和发票。要更改套餐，请改用 **更改套餐**。参见[更改订阅计划](/zh/support/subscription/changing-plan)。

--- a/zh/support/subscription/managing.mdx
+++ b/zh/support/subscription/managing.mdx
@@ -2,7 +2,7 @@
 title: 管理您的 Comfy Cloud 订阅
 sidebarTitle: 管理 Comfy Cloud 订阅
 description: 了解如何管理您的 Comfy Cloud 订阅
-translationSourceHash: fcb66c1a
+translationSourceHash: f9e86d71
 translationFrom: support/subscription/managing.mdx
 ---
 
@@ -16,6 +16,6 @@ translationFrom: support/subscription/managing.mdx
 
 <img src="/images/support/subscription/subscription.jpg" alt="订阅设置菜单" />
 
-4. 点击 **Manage subscription**(管理订阅)
+4. 点击 **账单与发票**（部分版本仍显示 **Manage subscription**）
 
-这将带您进入 Stripe,您可以在那里管理订阅详情。
+这将打开 Stripe，用于管理支付方式和发票。要更改套餐，请改用 **更改套餐**。参见[更改订阅计划](/zh/support/subscription/changing-plan)。


### PR DESCRIPTION
## Summary
- Rewrite [Changing your subscription plan](https://docs.comfy.org/support/subscription/changing-plan) to match current Cloud UI: **Change plan** / **Upgrade Plan** opens **Choose a Plan** in-app. Stripe is no longer the plan-change path (portal subscription-update is disabled).
- Document **For Personal** vs **For Teams**, yearly/monthly, and when upgrades vs downgrades take effect.
- Drop outdated screenshots (BETA picker, Founders Edition, **Manage subscription**, Stripe **Update subscription**). Align **Managing** / **Canceling** with **Billing & invoices**.

Verified against ComfyUI_frontend (`UnifiedPricingTable`, `useSubscriptionCheckout`) and cloud billing transitions (`transition.go`: immediate upgrade vs scheduled downgrade).

## Test plan
- [ ] Preview `/support/subscription/changing-plan` (en/zh/ja/ko): no screenshots, steps match Plan & Credits → Change plan → Choose a Plan
- [ ] Preview managing + canceling: Stripe portal only for invoices/cancel; plan change links to changing-plan
- [ ] Click through in-app on cloud.comfy.org and confirm button labels (**Change plan**, **Upgrade Plan**, **Billing & invoices**)