### PR TITLE
docs(i18n/zh-frontend-glossary): Fix missing opening parenthesis in the VAE Encode (Tiled) translation，修复VAE编码分块翻译缺失的左括号

### DIFF
--- a/.github/scripts/i18n/glossary/frontend/zh.json
+++ b/.github/scripts/i18n/glossary/frontend/zh.json
@@ -2611,7 +2611,7 @@
   "vae decode audio (tiled)": "VAE解码音频（分块）",
   "vae encode": "VAE编码",
   "vae encode (for inpainting)": "VAE编码（局部重绘）",
-  "vae encode (tiled)": "VAE编码分块）",
+  "vae encode (tiled)": "VAE编码（分块）",
   "vae encode audio": "VAE编码（音频）",
   "vae precision": "VAE 精度",
   "vaedecodehunyuan3d": "VAE解码（Hunyuan3D）",


### PR DESCRIPTION
## Summary
This PR fixes the Chinese frontend glossary entry for `vae encode (tiled)` in `.github/scripts/i18n/glossary/frontend/zh.json`.

The translation is corrected to:

`VAE编码（分块）`

## Problem
The previous translation was missing the opening full-width parenthesis, which made the label inconsistent with nearby VAE-related glossary entries.

## Changes
- fix the Chinese translation for `vae encode (tiled)`
- restore the missing opening full-width parenthesis
- keep the wording consistent with related entries such as:
  - `vae decode (tiled)`
  - `vae encode (for inpainting)`

## Validation
- checked the updated glossary entry in `zh.json`
- compared nearby VAE glossary entries to confirm formatting consistency

## Impact
This is a docs/i18n-only change. There is no runtime or product behavior impact.

## 变更摘要
- 修复 `.github/scripts/i18n/glossary/frontend/zh.json` 中 `vae encode (tiled)` 的中文术语翻译
- 将词条修正为 `VAE编码（分块）`
- 统一与相邻 VAE 相关词条的括号与术语风格

## 变更原因
- 原翻译缺少全角左括号，显示不完整
- 与 `vae decode (tiled)`、`vae encode (for inpainting)` 等相邻词条风格不一致

## 验证情况
- 已检查目标词条当前值
- 已对照相邻 VAE 术语词条确认格式一致

## 影响范围
- 仅涉及文档国际化词表
- 不影响运行时逻辑或产品功能