### PR TITLE
docs: surface the SDK as the one-click path for running workflows, and split "developing with" from "extending" ComfyUI

### DIFF
--- a/development/api-development/sdks.mdx
+++ b/development/api-development/sdks.mdx
@@ -38,6 +38,18 @@ npm i @comfyorg/sdk
 
 Python 3.10 or newer. Node 22 or newer.
 
+## Concepts
+
+Four terms the Quickstart below assumes.
+
+**Workflow.** A graph of nodes. Each node performs one operation, such as loading a model, encoding a prompt, sampling, or saving an image, and passes its result to the next node. A workflow is the whole graph.
+
+**Node ID.** Every node in a workflow has a numeric ID, unique within that workflow. You set inputs and read outputs by ID rather than by name, because names are not unique.
+
+**API format.** The SDKs take a workflow exported in API format, which is not what `File → Save` produces. In the ComfyUI frontend choose `File → Export Workflow (API)`. The result is a JSON object keyed by node ID, where each entry carries a `class_type` naming the kind of node it is. See [Workflow API format](/development/api-development/workflow-api-format).
+
+**Asset.** A piece of content the server needs in order to run your workflow, such as an input image, video, or audio. An asset is **bytes, not necessarily a file on disk**. `assets.from_file("photo.png")` is one way to make one, and you can equally build an asset from raw bytes, a stream, or a URL. What you get back is a handle you pass to `set_input`.
+
 ## Quickstart
 
 Upload an input image, run a workflow, and write the results to disk.
@@ -75,9 +87,11 @@ await job.getOutputs("9")[0].toFile("out.png");
 ```
 </CodeGroup>
 
-`workflow_api.json` is a workflow saved in [API format](/development/api-development/workflow-api-format). `"10"` and `"9"` are node IDs from that file: the node the input image feeds into, and the output node whose results you want.
+`workflow_api.json` is a workflow exported in [API format](/development/api-development/workflow-api-format). `"10"` and `"9"` are node IDs from that file: `"10"` is the node the input image feeds into, for example a `LoadImage`, and `"9"` is the output node whose results you want, for example a `SaveImage`.
 
-Asset handles are lazy. `photo.png` is hashed locally and only uploaded if the server does not already have those bytes, so re-running with the same input costs nothing.
+**These two numbers are specific to that workflow, and yours will be different.** To find the IDs in your own file, open the exported JSON and match on `class_type`. The key of the matching entry is the node ID.
+
+`client.assets.from_file("photo.png")` is the file-on-disk constructor, one of several. Whatever the source, what the server receives is bytes. Asset handles are lazy: the bytes are hashed locally and sent only if the server does not already have them, so re-running with the same input does not upload it twice.
 
 `run()` submits the job and waits for it to reach a terminal state. To do work while it executes, use `submit()` instead and watch the [event stream](#watching-a-job-run).
 
@@ -130,14 +144,48 @@ Serverless deployments run one pinned workflow, so `get_workflow()` returns the 
 
 ### Your own ComfyUI
 
-During the beta, the v2 API is served by [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy), a small open-source service that runs alongside your ComfyUI:
+This path assumes you already have ComfyUI installed. If you do not, start with [Install ComfyUI](/installation/system_requirements) and come back here once it runs.
 
-```bash
+During the beta you run **two processes**:
+
+1. **ComfyUI itself**, serving on `127.0.0.1:8188`. How you start it depends on how you installed it.
+2. **The v2 proxy**, serving on `127.0.0.1:8189`. The v2 API is served by [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy), a small open-source service that runs alongside ComfyUI.
+
+**Starting ComfyUI on 8188**
+
+<Tabs>
+  <Tab title="ComfyUI Desktop">
+    Launch the Desktop app. It starts the server for you on `8188`.
+
+    Desktop has its own launcher, so the `python main.py` commands below **do not apply** to a Desktop install. If you followed a manual-install guide and `python main.py` is not found, this is why.
+  </Tab>
+  <Tab title="Manual or portable install">
+    Run `python main.py` from your ComfyUI directory. To keep it from opening a browser, use:
+
+    ```bash
+    python main.py --disable-auto-launch
+    ```
+
+    See [Server Overview](/development/comfyui-server/comms_overview) for the full set of startup flags.
+  </Tab>
+</Tabs>
+
+**Then start the proxy on 8189**
+
+<CodeGroup>
+```bash uvx
+uvx comfy-api-proxy
+```
+
+```bash pip
 pip install comfy-api-proxy
 comfy-api-proxy
 ```
+</CodeGroup>
 
-By default it proxies the ComfyUI on `127.0.0.1:8188` and serves the v2 API on `127.0.0.1:8189`. Use `--comfyui` and `--port` to change either.
+`uvx` fetches and runs the latest published version without installing it, so you do not end up pinned to whatever you installed weeks ago. Use `pip` if you prefer a managed environment.
+
+By default it proxies the ComfyUI on `127.0.0.1:8188` and serves the v2 API on `127.0.0.1:8189`. Use `--comfyui` and `--port` to change either. The SDK talks to the proxy on `8189`, not to ComfyUI on `8188`.
 
 Then set `COMFY_BASE_URL="http://127.0.0.1:8189"`. Authentication is not required by default. If the proxy is configured with a static bearer token, pass that token as the SDK API key: `Comfy(api_key="...")`. The proxy binds to loopback only by default. Run it with `--comfyui-base-dir /path/to/ComfyUI` if you also want to upload model files into your install.
 

--- a/development/comfyui-server/comms_overview.mdx
+++ b/development/comfyui-server/comms_overview.mdx
@@ -3,7 +3,17 @@ title: "Server Overview"
 description: "Run ComfyUI as a server and interact with it programmatically via REST and WebSocket APIs"
 ---
 
-ComfyUI runs as an HTTP server on your machine by default. You can call it programmatically to submit workflows, upload files, download outputs, and monitor progress — all without opening the browser.
+ComfyUI runs as an HTTP server on your machine by default. You can call it programmatically to submit workflows, upload files, download outputs, and monitor progress, all without opening the browser.
+
+If you are building an application that runs workflows, start with the [Comfy SDKs](/development/api-development/sdks) instead. They sit on the versioned [Comfy API v2](/api-reference/v2/overview), and the same code runs against the ComfyUI on this page, Comfy Cloud, or a serverless deployment. Only the base URL changes.
+
+<Card title="Comfy SDKs" icon="code" href="/development/api-development/sdks">
+  Python and TypeScript SDKs for submitting a workflow, uploading assets, and downloading outputs. Currently in beta.
+</Card>
+
+During the beta, the v2 API for a self-hosted ComfyUI is served by `comfy-api-proxy`, a small service that runs alongside it. You start ComfyUI on `8188` as described below, then the proxy on `8189`. Once v2 stabilizes it moves into ComfyUI core and the proxy is no longer needed. See [Your own ComfyUI](/development/api-development/sdks#your-own-comfyui) for the setup.
+
+This page documents ComfyUI's own HTTP and WebSocket API. Reach for it when you need the full local surface, such as queue control, node definitions, or direct control over execution. See [APIs Overview](/development/api-development/overview) to compare the options.
 
 ## Starting the Server
 

--- a/development/overview.mdx
+++ b/development/overview.mdx
@@ -3,91 +3,91 @@ title: "Overview"
 description: "Using ComfyUI as a Developer"
 ---
 
-ComfyUI is a modular GenAI inference engine that can be run as a server, accessed via API, extended with custom nodes, and managed from the command line. Choose your path below.
+ComfyUI is a modular GenAI inference engine. There are two different jobs developers come here for, and they use different APIs.
 
-## Build on ComfyUI
+**Developing with ComfyUI** means running workflows from your own code: automation, batch pipelines, plugins, and backend services. ComfyUI is something your application calls. Start with [Run Workflows](#run-workflows).
 
-Run ComfyUI workflows from your own application and get the results back. The official SDKs sit on a versioned HTTP API, and the same code works against Comfy Cloud or a ComfyUI instance you host yourself.
+**Extending ComfyUI** means adding new capability inside ComfyUI itself, with a Python backend and a JavaScript interface. Your code runs as part of ComfyUI. Start with [Build Custom Nodes](#build-custom-nodes).
+
+---
+
+## Run Workflows
+
+Run ComfyUI workflows from your own application and get the results back. The official SDKs sit on a versioned HTTP API, and the same code works against Comfy Cloud or a ComfyUI you host yourself. Only the base URL changes.
 
 <Card title="Comfy SDKs" icon="code" href="/development/api-development/sdks">
   Install the Python or TypeScript SDK, submit a workflow, and download the outputs. Currently in beta.
 </Card>
 
-See also: [Design Notes](/development/api-development/sdks-design) · [Comfy API v2 Reference](/api-reference/v2/overview) · [APIs Overview](/development/api-development/overview)
+Not sure which interface you need? [APIs Overview](/development/api-development/overview) compares the SDKs, the Cloud API, and the ComfyUI Server API, and says which one to reach for.
 
-## Deploy ComfyUI as a Server
+### Choose where it runs
 
-Run ComfyUI in your own environment and expose it as an API endpoint. Learn about the WebSocket message protocol, available routes, and execution modes.
+<CardGroup cols={2}>
+  <Card title="Self-Hosted Server" icon="server" href="/development/comfyui-server/comms_overview">
+    Run ComfyUI on your own hardware and call it over REST and WebSocket. Covers startup flags, routes, and the message protocol.
+  </Card>
+  <Card title="Comfy Cloud" icon="cloud" href="/development/cloud/overview">
+    Run on Comfy's managed GPUs with no setup. Covers API keys, credits, and concurrency limits.
+  </Card>
+</CardGroup>
 
-<Card title="ComfyUI Server API" icon="server" href="/development/comfyui-server/comms_overview">
-  Run ComfyUI as a server on your own machine. Start, configure, and call it via REST and WebSocket APIs.
-</Card>
+See also: [Getting an API Key](/development/api-development/getting-an-api-key) · [API Examples](/development/comfyui-server/api-examples) · [Startup Flags](/development/comfyui-server/startup-flags) · [Cloud API Reference](/development/cloud/api-reference)
 
-See also: [API Examples](/development/comfyui-server/api-examples) · [Partner Node API Integration](/development/comfyui-server/api-key-integration)
+### Prepare a workflow
 
-## Cloud API
+The SDKs take a workflow exported in API format, which is not what `File → Save` produces. Use `File → Export Workflow (API)` in the ComfyUI frontend.
 
-Run workflows programmatically on Comfy Cloud without managing your own hardware. Use the REST API, browse the OpenAPI spec, and integrate Partner Nodes via API Key.
+See also: [Workflow API format](/development/api-development/workflow-api-format) · [Workflow metadata](/development/api-development/workflow-metadata)
 
-<Card title="Cloud API Overview" icon="cloud" href="/development/cloud/overview">
-  Learn how to authenticate, submit jobs, check status, and download results from Comfy Cloud.
-</Card>
+### Reference and deeper reading
 
-See also: [API Reference](/development/cloud/api-reference) · [OpenAPI Specification](/development/cloud/openapi) · [Getting an API Key](/development/api-development/getting-an-api-key) · [APIs Overview](/development/api-development/overview)
+See also: [Comfy API v2](/api-reference/v2/overview) · [SDK design notes](/development/api-development/sdks-design) · [Partner Node API Integration](/development/comfyui-server/api-key-integration)
 
-## Agent Tools / MCP
+### From the terminal
 
-Connect AI agents to ComfyUI via the Model Context Protocol (MCP). Start with the hosted Cloud MCP, or use Local MCP and Comfy CLI for other setups.
-
-<Card title="MCP Overview" icon="robot" href="/agent-tools">
-  Compare Cloud MCP, Local MCP, and Comfy CLI, and find the right setup for your AI agent integration.
-</Card>
-
-See also: [Comfy MCP](/agent-tools/mcp) — cloud and local connections
-
-## Comfy CLI
-
-Manage your ComfyUI installation, custom nodes, and workflows from the command line. Install, update, configure, and automate with ease.
-
-<Card title="CLI Getting Started" icon="terminal" href="/comfy-cli/getting-started">
-  Learn how to install, update, and manage ComfyUI from the terminal.
+<Card title="Comfy CLI" icon="terminal" href="/comfy-cli/getting-started">
+  Run workflows, manage an installation, and call partner nodes from the command line.
 </Card>
 
 See also: [CLI Reference](/comfy-cli/reference) · [Troubleshooting](/comfy-cli/troubleshooting)
 
-## Develop Custom Nodes
+---
 
-Custom nodes let you extend ComfyUI with your own Python backends, JavaScript UI widgets, and integrations. This is one of the most powerful ways to contribute to the ecosystem.
+## Build Custom Nodes
+
+Custom nodes extend ComfyUI with your own Python backends, JavaScript UI widgets, and integrations. This is one of the most powerful ways to contribute to the ecosystem.
 
 <CardGroup cols={2}>
   <Card title="Getting Started" icon="compass" href="/custom-nodes/overview">
-    New to custom nodes? Learn the anatomy of a node, how to publish it, and best practices.
+    New to custom nodes? Learn the anatomy of a node and how to build your first one.
     <br /><br />
-    Key pages: <a href="/custom-nodes/walkthrough">Walkthrough</a> · <a href="/custom-nodes/v3_migration">v3 Migration Guide</a>
+    Key pages: <a href="/custom-nodes/walkthrough">Walkthrough</a> · <a href="/custom-nodes/i18n">Internationalization</a>
   </Card>
 
   <Card title="Backend (Python)" icon="python" href="/custom-nodes/backend/server_overview">
-    Build the server-side of your custom node. Covers data types, image &amp; mask handling, lazy evaluation, tensors, and more.
+    Build the server side of your node. Covers data types, image and mask handling, lazy evaluation, and tensors.
     <br /><br />
-    Key pages: <a href="/custom-nodes/backend/datatypes">Data Types</a> · <a href="/custom-nodes/backend/images_and_masks">Images &amp; Masks</a> · <a href="/custom-nodes/backend/lazy_evaluation">Lazy Evaluation</a> · <a href="/custom-nodes/backend/expansion">Node Expansion</a>
+    Key pages: <a href="/custom-nodes/backend/datatypes">Data Types</a> · <a href="/custom-nodes/backend/images_and_masks">Images and Masks</a> · <a href="/custom-nodes/backend/lazy_evaluation">Lazy Evaluation</a>
   </Card>
 
   <Card title="Frontend (JavaScript)" icon="js" href="/custom-nodes/js/javascript_overview">
-    Add custom UI widgets, sidebar tabs, keybindings, and dialogs to your nodes. Full control over the ComfyUI frontend.
+    Add custom widgets, sidebar tabs, keybindings, and dialogs. Full control over the ComfyUI frontend.
     <br /><br />
-    Key pages: <a href="/custom-nodes/js/javascript_hooks">Hooks</a> · <a href="/custom-nodes/js/javascript_sidebar_tabs">Sidebar Tabs</a> · <a href="/custom-nodes/js/javascript_commands_keybindings">Commands &amp; Keybindings</a> · <a href="/custom-nodes/js/javascript_examples">Examples</a>
+    Key pages: <a href="/custom-nodes/js/javascript_hooks">Hooks</a> · <a href="/custom-nodes/js/javascript_sidebar_tabs">Sidebar Tabs</a> · <a href="/custom-nodes/js/javascript_examples">Examples</a>
   </Card>
 
+  <Card title="Package and Publish" icon="box" href="/custom-nodes/help_page">
+    Document your node, ship workflow templates, and publish to the Comfy Registry with versioning and CI.
+    <br /><br />
+    Key pages: <a href="/registry/overview">Registry Overview</a> · <a href="/registry/publishing">Publishing Tutorial</a> · <a href="/custom-nodes/workflow_templates">Workflow Templates</a>
+  </Card>
 </CardGroup>
 
-See also: <a href="/custom-nodes/i18n">Internationalization (i18n)</a>
+See also: [Migration Guides](/custom-nodes/v3_migration) · [Workflow JSON spec](/specs/workflow_json) · [Node definition spec](/specs/nodedef_json)
 
-## Registry
+---
 
-Publish and manage your custom nodes through the Comfy Registry. The Registry provides versioning, security scanning, and discovery for the community.
+## Related
 
-<Card title="Publishing Overview" icon="puzzle-piece" href="/registry/overview">
-  Register as a publisher, publish your first node, claim existing ones, and set up CI/CD for automated releases.
-</Card>
-
-See also: [Publishing Tutorial](/registry/publishing) · [Standards](/registry/standards) · [CI/CD](/registry/cicd) · [Specifications](/registry/specifications)
+**Connecting an AI agent to ComfyUI?** [Agent Tools](/agent-tools) covers the Model Context Protocol servers that let an agent run workflows on your behalf. That is a different job from building against the API, so it lives outside this section.

--- a/docs.json
+++ b/docs.json
@@ -2760,25 +2760,7 @@
                 "group": "Run Workflows",
                 "pages": [
                   "development/api-development/overview",
-                  "development/api-development/getting-an-api-key",
                   "development/api-development/sdks",
-                  "api-reference/v2/overview",
-                  {
-                    "group": "Comfy API v2 Reference",
-                    "openapi": {
-                      "source": "openapi-v2.yaml",
-                      "directory": "api-reference/v2"
-                    }
-                  },
-                  "development/api-development/sdks-design",
-                  {
-                    "group": "Comfy Cloud",
-                    "pages": [
-                      "development/cloud/overview",
-                      "development/cloud/api-reference",
-                      "development/cloud/openapi"
-                    ]
-                  },
                   {
                     "group": "Self-Hosted Server",
                     "pages": [
@@ -2790,13 +2772,32 @@
                     ]
                   },
                   {
+                    "group": "Comfy Cloud",
+                    "pages": [
+                      "development/cloud/overview",
+                      "development/api-development/getting-an-api-key",
+                      "development/cloud/api-reference",
+                      "development/cloud/openapi"
+                    ]
+                  },
+                  {
                     "group": "Workflow Formats",
                     "pages": [
                       "development/api-development/workflow-api-format",
                       "development/api-development/workflow-metadata"
                     ]
                   },
-                  "development/comfyui-server/api-key-integration"
+                  "api-reference/v2/overview",
+                  "development/api-development/sdks-design",
+                  "development/comfyui-server/api-key-integration",
+                  {
+                    "group": "Comfy CLI",
+                    "pages": [
+                      "comfy-cli/getting-started",
+                      "comfy-cli/reference",
+                      "comfy-cli/troubleshooting"
+                    ]
+                  }
                 ]
               },
               {
@@ -2841,53 +2842,45 @@
                   },
                   "custom-nodes/i18n",
                   {
+                    "group": "Package & Publish",
+                    "pages": [
+                      "custom-nodes/help_page",
+                      "custom-nodes/workflow_templates",
+                      "custom-nodes/subgraph_blueprints",
+                      "registry/overview",
+                      "registry/publishing",
+                      "registry/claim-my-node",
+                      "registry/standards",
+                      "registry/cicd",
+                      "registry/specifications",
+                      "registry/api-reference/overview",
+                      {
+                        "group": "Specifications",
+                        "pages": [
+                          {
+                            "group": "Workflow JSON",
+                            "pages": [
+                              "specs/workflow_json",
+                              "specs/workflow_json_0.4"
+                            ]
+                          },
+                          {
+                            "group": "Node Definitions",
+                            "pages": [
+                              "specs/nodedef_json",
+                              "specs/nodedef_json_1_0"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "Migration Guides",
                     "pages": [
                       "custom-nodes/v3_migration",
                       "custom-nodes/js/context-menu-migration",
                       "custom-nodes/backend/node-replacement"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Package & Publish",
-                "pages": [
-                  "custom-nodes/help_page",
-                  "custom-nodes/workflow_templates",
-                  "custom-nodes/subgraph_blueprints",
-                  "registry/overview",
-                  "registry/publishing",
-                  "registry/claim-my-node",
-                  "registry/standards",
-                  "registry/cicd",
-                  "registry/specifications",
-                  "registry/api-reference/overview"
-                ]
-              },
-              {
-                "group": "Comfy CLI",
-                "pages": [
-                  "comfy-cli/getting-started",
-                  "comfy-cli/reference",
-                  "comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "Specifications",
-                "pages": [
-                  {
-                    "group": "Workflow JSON",
-                    "pages": [
-                      "specs/workflow_json",
-                      "specs/workflow_json_0.4"
-                    ]
-                  },
-                  {
-                    "group": "Node Definitions",
-                    "pages": [
-                      "specs/nodedef_json",
-                      "specs/nodedef_json_1_0"
                     ]
                   }
                 ]
@@ -2952,11 +2945,18 @@
             ]
           },
           {
+            "tab": "Comfy API v2 Reference",
+            "openapi": {
+              "source": "openapi-v2.yaml",
+              "directory": "api-reference/v2"
+            }
+          },
+          {
             "tab": "Registry API Reference",
             "openapi": "https://api.comfy.org/openapi"
           },
           {
-            "tab": "Cloud API Reference",
+            "tab": "Cloud API Reference (Legacy)",
             "openapi": {
               "source": "openapi-cloud.yaml",
               "directory": "api-reference/cloud"
@@ -5731,25 +5731,7 @@
                 "group": "运行工作流",
                 "pages": [
                   "zh/development/api-development/overview",
-                  "zh/development/api-development/getting-an-api-key",
                   "zh/development/api-development/sdks",
-                  "zh/api-reference/v2/overview",
-                  {
-                    "group": "Comfy API v2 参考文档",
-                    "openapi": {
-                      "source": "openapi-v2.yaml",
-                      "directory": "zh/api-reference/v2"
-                    }
-                  },
-                  "zh/development/api-development/sdks-design",
-                  {
-                    "group": "Comfy Cloud",
-                    "pages": [
-                      "zh/development/cloud/overview",
-                      "zh/development/cloud/api-reference",
-                      "zh/development/cloud/openapi"
-                    ]
-                  },
                   {
                     "group": "自托管服务器",
                     "pages": [
@@ -5761,13 +5743,32 @@
                     ]
                   },
                   {
+                    "group": "Comfy Cloud",
+                    "pages": [
+                      "zh/development/cloud/overview",
+                      "zh/development/api-development/getting-an-api-key",
+                      "zh/development/cloud/api-reference",
+                      "zh/development/cloud/openapi"
+                    ]
+                  },
+                  {
                     "group": "工作流格式",
                     "pages": [
                       "zh/development/api-development/workflow-api-format",
                       "zh/development/api-development/workflow-metadata"
                     ]
                   },
-                  "zh/development/comfyui-server/api-key-integration"
+                  "zh/api-reference/v2/overview",
+                  "zh/development/api-development/sdks-design",
+                  "zh/development/comfyui-server/api-key-integration",
+                  {
+                    "group": "Comfy CLI",
+                    "pages": [
+                      "zh/comfy-cli/getting-started",
+                      "zh/comfy-cli/reference",
+                      "zh/comfy-cli/troubleshooting"
+                    ]
+                  }
                 ]
               },
               {
@@ -5812,53 +5813,45 @@
                   },
                   "zh/custom-nodes/i18n",
                   {
+                    "group": "打包与发布",
+                    "pages": [
+                      "zh/custom-nodes/help_page",
+                      "zh/custom-nodes/workflow_templates",
+                      "zh/custom-nodes/subgraph_blueprints",
+                      "zh/registry/overview",
+                      "zh/registry/publishing",
+                      "zh/registry/claim-my-node",
+                      "zh/registry/standards",
+                      "zh/registry/cicd",
+                      "zh/registry/specifications",
+                      "zh/registry/api-reference/overview",
+                      {
+                        "group": "规范",
+                        "pages": [
+                          {
+                            "group": "Workflow JSON",
+                            "pages": [
+                              "zh/specs/workflow_json",
+                              "zh/specs/workflow_json_0.4"
+                            ]
+                          },
+                          {
+                            "group": "节点定义",
+                            "pages": [
+                              "zh/specs/nodedef_json",
+                              "zh/specs/nodedef_json_1_0"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "迁移指南",
                     "pages": [
                       "zh/custom-nodes/v3_migration",
                       "zh/custom-nodes/js/context-menu-migration",
                       "zh/custom-nodes/backend/node-replacement"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "打包与发布",
-                "pages": [
-                  "zh/custom-nodes/help_page",
-                  "zh/custom-nodes/workflow_templates",
-                  "zh/custom-nodes/subgraph_blueprints",
-                  "zh/registry/overview",
-                  "zh/registry/publishing",
-                  "zh/registry/claim-my-node",
-                  "zh/registry/standards",
-                  "zh/registry/cicd",
-                  "zh/registry/specifications",
-                  "zh/registry/api-reference/overview"
-                ]
-              },
-              {
-                "group": "Comfy CLI",
-                "pages": [
-                  "zh/comfy-cli/getting-started",
-                  "zh/comfy-cli/reference",
-                  "zh/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "规范",
-                "pages": [
-                  {
-                    "group": "Workflow JSON",
-                    "pages": [
-                      "zh/specs/workflow_json",
-                      "zh/specs/workflow_json_0.4"
-                    ]
-                  },
-                  {
-                    "group": "节点定义",
-                    "pages": [
-                      "zh/specs/nodedef_json",
-                      "zh/specs/nodedef_json_1_0"
                     ]
                   }
                 ]
@@ -5921,6 +5914,13 @@
                 ]
               }
             ]
+          },
+          {
+            "tab": "Comfy API v2 参考文档",
+            "openapi": {
+              "source": "openapi-v2.yaml",
+              "directory": "zh/api-reference/v2"
+            }
           },
           {
             "tab": "Registry API Reference",
@@ -8702,25 +8702,7 @@
                 "group": "ワークフローの実行",
                 "pages": [
                   "ja/development/api-development/overview",
-                  "ja/development/api-development/getting-an-api-key",
                   "ja/development/api-development/sdks",
-                  "ja/api-reference/v2/overview",
-                  {
-                    "group": "Comfy API v2リファレンス",
-                    "openapi": {
-                      "source": "openapi-v2.yaml",
-                      "directory": "ja/api-reference/v2"
-                    }
-                  },
-                  "ja/development/api-development/sdks-design",
-                  {
-                    "group": "Comfy Cloud",
-                    "pages": [
-                      "ja/development/cloud/overview",
-                      "ja/development/cloud/api-reference",
-                      "ja/development/cloud/openapi"
-                    ]
-                  },
                   {
                     "group": "セルフホストサーバー",
                     "pages": [
@@ -8732,13 +8714,32 @@
                     ]
                   },
                   {
+                    "group": "Comfy Cloud",
+                    "pages": [
+                      "ja/development/cloud/overview",
+                      "ja/development/api-development/getting-an-api-key",
+                      "ja/development/cloud/api-reference",
+                      "ja/development/cloud/openapi"
+                    ]
+                  },
+                  {
                     "group": "ワークフロー形式",
                     "pages": [
                       "ja/development/api-development/workflow-api-format",
                       "ja/development/api-development/workflow-metadata"
                     ]
                   },
-                  "ja/development/comfyui-server/api-key-integration"
+                  "ja/api-reference/v2/overview",
+                  "ja/development/api-development/sdks-design",
+                  "ja/development/comfyui-server/api-key-integration",
+                  {
+                    "group": "Comfy CLI",
+                    "pages": [
+                      "ja/comfy-cli/getting-started",
+                      "ja/comfy-cli/reference",
+                      "ja/comfy-cli/troubleshooting"
+                    ]
+                  }
                 ]
               },
               {
@@ -8783,53 +8784,45 @@
                   },
                   "ja/custom-nodes/i18n",
                   {
+                    "group": "パッケージと公開",
+                    "pages": [
+                      "ja/custom-nodes/help_page",
+                      "ja/custom-nodes/workflow_templates",
+                      "ja/custom-nodes/subgraph_blueprints",
+                      "ja/registry/overview",
+                      "ja/registry/publishing",
+                      "ja/registry/claim-my-node",
+                      "ja/registry/standards",
+                      "ja/registry/cicd",
+                      "ja/registry/specifications",
+                      "ja/registry/api-reference/overview",
+                      {
+                        "group": "仕様",
+                        "pages": [
+                          {
+                            "group": "Workflow JSON",
+                            "pages": [
+                              "ja/specs/workflow_json",
+                              "ja/specs/workflow_json_0.4"
+                            ]
+                          },
+                          {
+                            "group": "ノード定義",
+                            "pages": [
+                              "ja/specs/nodedef_json",
+                              "ja/specs/nodedef_json_1_0"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "移行ガイド",
                     "pages": [
                       "ja/custom-nodes/v3_migration",
                       "ja/custom-nodes/js/context-menu-migration",
                       "ja/custom-nodes/backend/node-replacement"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "パッケージと公開",
-                "pages": [
-                  "ja/custom-nodes/help_page",
-                  "ja/custom-nodes/workflow_templates",
-                  "ja/custom-nodes/subgraph_blueprints",
-                  "ja/registry/overview",
-                  "ja/registry/publishing",
-                  "ja/registry/claim-my-node",
-                  "ja/registry/standards",
-                  "ja/registry/cicd",
-                  "ja/registry/specifications",
-                  "ja/registry/api-reference/overview"
-                ]
-              },
-              {
-                "group": "Comfy CLI",
-                "pages": [
-                  "ja/comfy-cli/getting-started",
-                  "ja/comfy-cli/reference",
-                  "ja/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "仕様",
-                "pages": [
-                  {
-                    "group": "Workflow JSON",
-                    "pages": [
-                      "ja/specs/workflow_json",
-                      "ja/specs/workflow_json_0.4"
-                    ]
-                  },
-                  {
-                    "group": "ノード定義",
-                    "pages": [
-                      "ja/specs/nodedef_json",
-                      "ja/specs/nodedef_json_1_0"
                     ]
                   }
                 ]
@@ -8892,6 +8885,13 @@
                 ]
               }
             ]
+          },
+          {
+            "tab": "Comfy API v2リファレンス",
+            "openapi": {
+              "source": "openapi-v2.yaml",
+              "directory": "ja/api-reference/v2"
+            }
           },
           {
             "tab": "Registry APIリファレンス",
@@ -11630,25 +11630,7 @@
                 "group": "워크플로 실행",
                 "pages": [
                   "ko/development/api-development/overview",
-                  "ko/development/api-development/getting-an-api-key",
                   "ko/development/api-development/sdks",
-                  "ko/api-reference/v2/overview",
-                  {
-                    "group": "Comfy API v2 참조",
-                    "openapi": {
-                      "source": "openapi-v2.yaml",
-                      "directory": "ko/api-reference/v2"
-                    }
-                  },
-                  "ko/development/api-development/sdks-design",
-                  {
-                    "group": "Comfy Cloud",
-                    "pages": [
-                      "ko/development/cloud/overview",
-                      "ko/development/cloud/api-reference",
-                      "ko/development/cloud/openapi"
-                    ]
-                  },
                   {
                     "group": "자체 호스팅 서버",
                     "pages": [
@@ -11660,13 +11642,32 @@
                     ]
                   },
                   {
+                    "group": "Comfy Cloud",
+                    "pages": [
+                      "ko/development/cloud/overview",
+                      "ko/development/api-development/getting-an-api-key",
+                      "ko/development/cloud/api-reference",
+                      "ko/development/cloud/openapi"
+                    ]
+                  },
+                  {
                     "group": "워크플로 형식",
                     "pages": [
                       "ko/development/api-development/workflow-api-format",
                       "ko/development/api-development/workflow-metadata"
                     ]
                   },
-                  "ko/development/comfyui-server/api-key-integration"
+                  "ko/api-reference/v2/overview",
+                  "ko/development/api-development/sdks-design",
+                  "ko/development/comfyui-server/api-key-integration",
+                  {
+                    "group": "Comfy CLI",
+                    "pages": [
+                      "ko/comfy-cli/getting-started",
+                      "ko/comfy-cli/reference",
+                      "ko/comfy-cli/troubleshooting"
+                    ]
+                  }
                 ]
               },
               {
@@ -11711,53 +11712,45 @@
                   },
                   "ko/custom-nodes/i18n",
                   {
+                    "group": "패키지 및 게시",
+                    "pages": [
+                      "ko/custom-nodes/help_page",
+                      "ko/custom-nodes/workflow_templates",
+                      "ko/custom-nodes/subgraph_blueprints",
+                      "ko/registry/overview",
+                      "ko/registry/publishing",
+                      "ko/registry/claim-my-node",
+                      "ko/registry/standards",
+                      "ko/registry/cicd",
+                      "ko/registry/specifications",
+                      "ko/registry/api-reference/overview",
+                      {
+                        "group": "스펙",
+                        "pages": [
+                          {
+                            "group": "Workflow JSON",
+                            "pages": [
+                              "ko/specs/workflow_json",
+                              "ko/specs/workflow_json_0.4"
+                            ]
+                          },
+                          {
+                            "group": "노드 정의",
+                            "pages": [
+                              "ko/specs/nodedef_json",
+                              "ko/specs/nodedef_json_1_0"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "마이그레이션 가이드",
                     "pages": [
                       "ko/custom-nodes/v3_migration",
                       "ko/custom-nodes/js/context-menu-migration",
                       "ko/custom-nodes/backend/node-replacement"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "패키지 및 게시",
-                "pages": [
-                  "ko/custom-nodes/help_page",
-                  "ko/custom-nodes/workflow_templates",
-                  "ko/custom-nodes/subgraph_blueprints",
-                  "ko/registry/overview",
-                  "ko/registry/publishing",
-                  "ko/registry/claim-my-node",
-                  "ko/registry/standards",
-                  "ko/registry/cicd",
-                  "ko/registry/specifications",
-                  "ko/registry/api-reference/overview"
-                ]
-              },
-              {
-                "group": "Comfy CLI",
-                "pages": [
-                  "ko/comfy-cli/getting-started",
-                  "ko/comfy-cli/reference",
-                  "ko/comfy-cli/troubleshooting"
-                ]
-              },
-              {
-                "group": "스펙",
-                "pages": [
-                  {
-                    "group": "Workflow JSON",
-                    "pages": [
-                      "ko/specs/workflow_json",
-                      "ko/specs/workflow_json_0.4"
-                    ]
-                  },
-                  {
-                    "group": "노드 정의",
-                    "pages": [
-                      "ko/specs/nodedef_json",
-                      "ko/specs/nodedef_json_1_0"
                     ]
                   }
                 ]
@@ -11820,6 +11813,13 @@
                 ]
               }
             ]
+          },
+          {
+            "tab": "Comfy API v2 참조",
+            "openapi": {
+              "source": "openapi-v2.yaml",
+              "directory": "ko/api-reference/v2"
+            }
           },
           {
             "tab": "Registry API 참조",

--- a/get_started/cloud.mdx
+++ b/get_started/cloud.mdx
@@ -141,8 +141,16 @@ Cloud sessions only bill you while the GPU is actively running. When you close t
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Cloud API" icon="code" href="/development/cloud/overview">
-    Programmatically run workflows via the Cloud API
+  <Card title="Run workflows from code" icon="code" href="/development/api-development/sdks">
+    Automate this workflow from Python or TypeScript with the Comfy SDKs
+  </Card>
+
+  <Card title="Get an API key" icon="key" href="/development/api-development/getting-an-api-key">
+    Create the key your application needs to call Comfy Cloud
+  </Card>
+
+  <Card title="Cloud API details" icon="cloud" href="/development/cloud/overview">
+    Credits, concurrency limits, and what is specific to Comfy Cloud
   </Card>
   
   <Card title="Tutorials" icon="book" href="/tutorials/basic/text-to-image">

--- a/index.mdx
+++ b/index.mdx
@@ -54,6 +54,34 @@ mode: "frame"
 The most powerful open source node-based application for generative AI
 </p>
 
+{/* Persona Gateway Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">Choose your path</h2>
+  <CardGroup cols={3}>
+    <Card
+      title="Use ComfyUI"
+      icon="rocket"
+      href="/get_started/first_generation"
+    >
+      Install ComfyUI and run your first generation. Start here to create images, video, audio, or 3D.
+    </Card>
+    <Card
+      title="Develop against ComfyUI"
+      icon="code"
+      href="/development/api-development/sdks"
+    >
+      Already have a workflow? Run it from Python or TypeScript with the Comfy SDKs, on Comfy Cloud or a ComfyUI you host yourself.
+    </Card>
+    <Card
+      title="Build extensions"
+      icon="puzzle-piece"
+      href="/custom-nodes/overview"
+    >
+      Add your own nodes to ComfyUI in Python and JavaScript, then publish them to the Registry.
+    </Card>
+  </CardGroup>
+</div>
+
 {/* Getting Started Section */}
 <div className="mb-12">
   <h2 className="text-2xl font-bold mb-6 text-center">Getting Started</h2>
@@ -145,44 +173,51 @@ The most powerful open source node-based application for generative AI
   </CardGroup>
 </div>
 
-{/* Development Section */}
+{/* Developing with ComfyUI Section */}
 <div className="mb-12">
-  <h2 className="text-2xl font-bold mb-6 text-center">Development & Extension</h2>
+  <h2 className="text-2xl font-bold mb-6 text-center">Developing with ComfyUI</h2>
   <CardGroup cols={3}>
     <Card
-      title="Development Guide"
+      title="Comfy SDKs"
       icon="code"
-      href="/development/overview"
+      href="/development/api-development/sdks"
     >
-      Contribute to ComfyUI development
+      Run workflows from Python or TypeScript. The same code targets Comfy Cloud, a serverless deployment, or your own machine.
     </Card>
+    <Card
+      title="Run Workflows"
+      icon="play"
+      href="/development/api-development/overview"
+    >
+      Compare the SDKs, the Cloud API, and the ComfyUI Server API, then pick the one that fits where you run.
+    </Card>
+    <Card
+      title="Comfy API v2"
+      icon="book"
+      href="/api-reference/v2/overview"
+    >
+      The versioned HTTP API behind the SDKs
+    </Card>
+  </CardGroup>
+</div>
+
+{/* Extending ComfyUI Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">Extending ComfyUI</h2>
+  <CardGroup cols={3}>
     <Card
       title="Custom Nodes"
       icon="puzzle-piece"
       href="/custom-nodes/overview"
     >
-      Create and publish custom nodes
+      Build your own nodes with a Python backend and a JavaScript interface
     </Card>
     <Card
-      title="Local API"
-      icon="terminal"
-      href="/development/comfyui-server/comms_overview"
+      title="Publish to the Registry"
+      icon="box"
+      href="/registry/overview"
     >
-      Integrate with local ComfyUI server
-    </Card>
-    <Card
-      title="Cloud API"
-      icon="cloud"
-      href="/development/cloud/overview"
-    >
-      Run workflows via ComfyUI Cloud API
-    </Card>
-    <Card
-      title="Cloud API Reference"
-      icon="book"
-      href="/development/cloud/api-reference"
-    >
-      Explore the ComfyUI Cloud API reference
+      Version, publish, and distribute your custom nodes
     </Card>
   </CardGroup>
 </div>


### PR DESCRIPTION
## Problem

A developer who already has a working ComfyUI workflow and wants to automate it cannot find the recommended path.

Measured against `main` at `ffb27fc2`, walking the docs as that persona:

- The homepage "Development & Extension" section had five cards. **None of them named the SDKs or API v2.** It linked "Local API" and "Cloud API", both legacy surfaces.
- The two recommended surfaces were **two clicks away and unnamed**. The two legacy surfaces were **one click away and named**.
- `development/comfyui-server/comms_overview.mdx`, where the homepage sent self-hosted developers, contained **zero** occurrences of "SDK", "API v2", or any `api-development` link. The most natural click for the priority persona was a dead end.
- Developer content sat in **section 4 of 6**, below ten creator-oriented cards.

Underneath that is a vocabulary problem. The docs use "development" for three different jobs: contributing to ComfyUI, building *with* it, and building *inside* it. The homepage card for the Development tab was subtitled "Contribute to ComfyUI development", which describes none of what a developer automating a workflow is trying to do.

There is a good historical reason for this. Before the SDKs existed, "development" in these docs meant custom nodes and nothing else. The SDKs arrived and were appended rather than placed. This PR finishes that move rather than starting a new one.

## Audience and desired behavior

| Audience | Should land on | Was |
|---|---|---|
| Developer with a workflow to automate | Comfy SDKs, in one click, named | 2 clicks, unnamed |
| Self-hosted developer | Told the SDK exists on the page they arrive at | Never told |
| Cloud developer | SDK first, API key on the same path | Legacy Cloud API card |
| Custom node author | A section that says "extending", not "development" | Mixed with API content |
| Existing integration owner | Legacy and lower-level references still reachable | Unchanged, still reachable |

## Changes

**Homepage (`index.mdx`)**
- Add a three-way persona gateway above the fold: Use ComfyUI, Develop against ComfyUI, Build extensions.
- Replace the five-card "Development & Extension" group with two named sections: **Developing with ComfyUI** (Comfy SDKs, Run Workflows, Comfy API v2) and **Extending ComfyUI** (Custom Nodes, Publish to the Registry).
- Drop the "Cloud API Reference" card and collapse the separate "Local API" and "Cloud API" cards into one SDK card.

**Self-hosted entry point (`development/comfyui-server/comms_overview.mdx`)**
- Add a pointer to the SDKs and API v2, mirroring the paragraph `development/cloud/overview.mdx` already gets right.
- Add the two-process explanation: start ComfyUI on `8188`, then the proxy on `8189`, with the end state stated.
- Say when the Server API *is* the right choice, so the page reads as a different job rather than a demotion.

**SDK page (`development/api-development/sdks.mdx`)**
- Add a **Concepts** section defining workflow, node ID, API format, and asset before the code that uses them.
- Kill the magic numbers: state that the `"10"` and `"9"` node IDs are workflow-specific and explain how to find your own by matching on `class_type`.
- Split the self-hosted setup by install method. `python main.py` does not apply to ComfyUI Desktop, which has its own launcher.
- Offer `uvx comfy-api-proxy` alongside `pip install`.

**Cloud getting-started (`get_started/cloud.mdx`)**
- Replace the legacy-first "Cloud API" card in Next steps with "Run workflows from code" (SDK) and "Get an API key". Cloud API is kept, reframed as credits and concurrency.

**Navigation (`docs.json`)**
- Reorder Run Workflows to: APIs Overview, Comfy SDKs, Self-Hosted Server, Comfy Cloud, Workflow Formats, Comfy API v2, SDK design notes, Partner Node API Integration, Comfy CLI.
- Move "Getting an API Key" into the Comfy Cloud group.
- Promote the Comfy API v2 OpenAPI reference to a top-level tab; demote the Cloud API Reference tab to "(Legacy)".
- Nest Package & Publish under Build Custom Nodes, Specifications under the Registry API Overview, and Comfy CLI under Run Workflows. **The Development tab goes from six top-level entries to three.**

**Development landing page (`development/overview.mdx`)**
- Rewritten so the page matches the nav it fronts. Seven peer sections become two, mirroring the two nav groups, plus a short Related pointer. Agent Tools drops from a full section to one line.

## Why this structure

The shape came from three conversations, not from taste.

**Jacob** set the direction: the SDK is for building *against* ComfyUI, not for authoring nodes; Cloud API and Server API are "almost 100% identical" apart from auth, so the docs should present one recommended path and one legacy surface rather than three co-equal APIs; the priority persona already has a workflow and wants to automate it; Agent Tools and MCP serve agents executing workflows, not developers, so they do not belong in the developer path.

**Austin** supplied the history above, and asked for the single SDK card that replaces "Local API" and "Cloud API", so people stop clicking "Local API" and landing on the legacy option. He arrived at that independently of the audit, which found the same dead end by grep. The Extensions restructure and the CLI demotion are also his.

**Simon** reviewed the implementation and corrected four things, two of which reversed calls made here: that an asset is bytes rather than a file, that `python main.py` does not apply to Desktop installs, that Workflow Formats belongs after the runtime choice rather than before it, and that the API key belongs under Comfy Cloud. All four are incorporated.

## Validation

**Routing, measured before and after**

| Destination | Clicks before | Clicks after |
|---|---|---|
| Comfy SDKs | 2, unnamed | **1, named twice** |
| APIs Overview | 2, unnamed | **1, named** |
| Comfy API v2 | 2, unnamed | **1, named** |
| ComfyUI Server API | 1 | 2, via Run Workflows |
| Cloud API | 2 | 2, via Run Workflows |

Developer content moved from section 4 of 6 to section 1 of 8. Nothing became unreachable: `api-development/overview.mdx` still carries cards to Cloud API, ComfyUI Server API, and Partner Node API Integration.

**Content**
- `comms_overview.mdx` went from 0 to 4 mentions of the SDK or API v2.
- All 35 internal links on the rewritten landing page resolve, checked individually against files on disk.
- All five changed pages render with zero unrendered JSX and zero MDX compile errors. The `<Tabs>` and `<CodeGroup>` blocks emit all panels.

**Navigation safety**
- Everything outside `navigation` in `docs.json` is **byte-identical**.
- Get Started, Built-in Nodes, and Support tabs are **untouched**.
- The page-path multiset is unchanged at **4,990**. No page was added, removed, or re-pathed, so no redirects are needed and `redirect-check.yml` is not triggered.
- All four language trees restructured identically. Locale prefixes and translated group labels preserved; **no new nav labels were invented**, which is why this needed no translation cycle.
- Zero `ja/zh/ko` `.mdx` edits. English remains the source of truth.

**OpenAPI tabs** were verified on a full `mint dev` build, not the default preview. Generated v2 pages serve, and generated legacy Cloud pages still serve, so the demotion did not break anything under it.

**Screenshots** (before = production `docs.comfy.org`, after = local preview). Ten before/after pairs captured; being attached to this PR as comments.

| File | Shows |
|---|---|
| `Shot1-Homepage-Top-of-Page.png` | Gateway is now the first thing on the page |
| `Shot2-Homepage-Developer-Section.png` | Five mixed cards become two named sections |
| `Shot3-Development-Sidebar.png` | Six top-level groups become three |
| `Shot4-Run-Workflows-Expanded.png` | Self-Hosted and Workflow Formats move out of positions 8 and 9 |
| `Shot5-Server-Overview.png` | The dead end, before and after |
| `Shot6-SDK-Page-Install-to-Quickstart.png` | Concepts section now sits between Install and Quickstart |
| `Shot7-SDK-Page-Your-Own-ComfyUI.png` | Desktop and manual install split, plus `uvx` |
| `Shot8-Tab-Bar.png` | v2 reference promoted, Cloud API Reference demoted to "(Legacy)" |
| `Shot9-Development-Page-Overview.png` | Landing page: seven sections become two |
| `Shot10-Cloud-Getting-Started-Next-Steps.png` | Legacy-first card becomes SDK plus API key |

## Required before merge

1. **Run `pnpm translate:sync-docs-json`.** The "(Legacy)" tab rename is English only; the zh, ja, and ko tab labels still read the old translated strings. The script needs `TRANSLATE_API_KEY`, which was not available on the machine this was authored on. Hand-writing the three translations would have violated the English-as-source-of-truth rule, so it was deliberately left.
2. **Re-verify the OpenAPI tabs with `pnpm dev:full`.** The default `pnpm dev` runs `--disable-openapi` and cannot render them, so a reviewer checking on the default preview will not see that change at all.

## Known gaps

- **The Development landing page rewrite is the only full-page rewrite here** and the largest single content change. Everything else is additive or a nav permutation. It deserves the closest read, and it is the one change where a reviewer might reasonably prefer a different structure.
- **"AI Agents & MCP" is still homepage section 3**, above "Developing with ComfyUI" at section 5. The gateway at the top mitigates this because a developer no longer scrolls that far, but the section order is unchanged. Left alone because reordering creator-facing sections was out of scope.
- **The SDK Quickstart is still Cloud-first** in its code sample, while the nav now leads self-hosted. Which runtime should come first is a product call about first-run experience, not a docs cleanup, so it is flagged rather than decided.

## Non-goals

- Site-wide navigation migration or top-level tab restructuring beyond the sanctioned v2 promotion and Cloud demotion.
- Rewriting API reference content.
- Removing or deprecating any existing API documentation. Every legacy surface is still reachable.
- Hand-editing any `ja/zh/ko` file.
- Pulling migration guides out of feature docs.

## Follow-ups

- **Add a success check to the SDK Quickstart** before outputs are read. Raised by Simon; left out because it needs the SDK's idiomatic terminal-state API rather than a guess.
- **Document what "custom node" means across local, developer platform, and Cloud.** Cloud has a fixed node set users cannot extend, and nothing says so, so a Cloud user can reasonably expect to deploy a custom node and be wrong. This is a user trap, not a nice-to-have.
- **Two overlapping "Comfy CLI" entry points** exist: `agent-tools/cli` under Get Started and `comfy-cli/*` under Development. Similar scope, no cross-links, no stated difference. Deciding which survives is a content-ownership call.
- **`agent-tools/cli` may be mis-shelved.** Agent Tools serves agents executing workflows; a CLI is a developer tool.
- **Nothing in CI checks that a landing page still matches the nav it fronts.** `development/overview.mdx` drifted for months and was only caught by reading it end to end.
- **Two different things are called "specifications"** in the same nav group: the `registry/specifications` page and the `Specifications` group (`specs/workflow_json`, `specs/nodedef_json`).
- **Korean redirects are missing** for the `development/mcp` to `agent-tools` move. English, Chinese, and Japanese each have three; Korean has none.
- **Pull migration guides out of feature docs.** At least one references a PR merged roughly 18 months ago.
- **Reconcile `NAV_LABEL_PRESERVE` with the committed nav.** `nav-label-translate.mjs` lists "Cloud API Reference" and "Registry API Reference" as labels that should stay English, but the committed locale entries are translated. Pre-existing.
