### PR TITLE
docs: sharpen search metadata on the highest-traffic installation and basics pages

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Changelog"
-description: "Track ComfyUI's latest features, improvements, and bug fixes. For detailed release notes, see the [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) page."
+description: "ComfyUI changelog: the latest features, improvements, and bug fixes in each release, updated as new versions ship."
 icon: "clock-rotate-left"
 ---
 

--- a/installation/comfyui_portable_windows.mdx
+++ b/installation/comfyui_portable_windows.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI(portable) Windows — Local Self-Hosted"
-description: "This tutorial will guide you on how to download and start using ComfyUI Portable and run the corresponding programs"
+title: "ComfyUI Portable for Windows"
+description: "Download and run ComfyUI Portable on Windows: a standalone package with embedded Python and CUDA builds for Nvidia GPUs. Extract it and start creating."
 icon: "box"
 sidebarTitle: "Portable (Local)"
 ---

--- a/installation/desktop/macos.mdx
+++ b/installation/desktop/macos.mdx
@@ -1,6 +1,6 @@
 ---
-title: "macOS — Comfy Desktop"
-description: "Install and uninstall Comfy Desktop on macOS"
+title: "Comfy Desktop for macOS"
+description: "Install Comfy Desktop on macOS: system requirements, setup steps, updates, and a clean uninstall for running ComfyUI locally on Apple silicon Macs."
 icon: "apple"
 sidebarTitle: "macOS"
 ---

--- a/installation/desktop/windows.mdx
+++ b/installation/desktop/windows.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Windows — Comfy Desktop"
-description: "Install and uninstall Comfy Desktop on Windows"
+title: "Comfy Desktop for Windows"
+description: "Install Comfy Desktop on Windows: system requirements, setup steps, updates, and a clean uninstall for running ComfyUI locally on Windows 10 and later."
 icon: "windows"
 sidebarTitle: "Windows"
 ---

--- a/installation/install_custom_node.mdx
+++ b/installation/install_custom_node.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Install Custom Nodes in ComfyUI"
-description: "This guide will show you different methods to install custom nodes in ComfyUI"
+description: "Install custom nodes in ComfyUI with ComfyUI Manager, git clone, or a ZIP download, and install their Python dependencies safely."
 sidebarTitle: "Custom nodes"
 icon: "puzzle-piece"
 ---

--- a/installation/manual_install.mdx
+++ b/installation/manual_install.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Manual Installation — Local Self-Hosted"
-description: "This section will guide you through the manual installation process on Windows, MacOS and Linux"
+title: "Install ComfyUI Manually (Windows, macOS, Linux)"
+description: "Install ComfyUI manually on Windows, macOS, or Linux: create a virtual environment, clone the repository, install GPU dependencies, and start the app."
 icon: "wrench"
 sidebarTitle: "Manual (Local)"
 ---

--- a/installation/update_comfyui.mdx
+++ b/installation/update_comfyui.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Update ComfyUI"
-description: "This section provides a comprehensive guide to updating ComfyUI"
+description: "Update ComfyUI on any install type: Portable update scripts, Desktop updates, and git pull for manual installs, plus fixes for common update issues."
 icon: "circle-up"
 sidebarTitle: "Update ComfyUI"
 ---

--- a/manager/install.mdx
+++ b/manager/install.mdx
@@ -1,7 +1,7 @@
 ---
 title: ComfyUI-Manager Installation
 sidebarTitle: Install
-description: How to install ComfyUI-Manager for different setups
+description: Install ComfyUI-Manager on Desktop, Portable, or manual ComfyUI setups to search, install, and update custom nodes from inside the app.
 ---
 
 ## Desktop users

--- a/tutorials/basic/image-to-image.mdx
+++ b/tutorials/basic/image-to-image.mdx
@@ -1,10 +1,10 @@
 ---
 title: "ComfyUI Image to Image Workflow"
 sidebarTitle: "Image to Image"
-description: "This guide will help you understand and complete an image to image workflow"
+description: "Build an image-to-image workflow in ComfyUI: load a reference image and generate new versions in a different style, from line art, or restored."
 ---
 
-## What is Image to Image
+## What is image-to-image in ComfyUI? {#what-is-image-to-image}
 
 Image to Image is a workflow in ComfyUI that allows users to input an image and generate a new image based on it.
 

--- a/tutorials/basic/lora.mdx
+++ b/tutorials/basic/lora.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ComfyUI LoRA Example"
 sidebarTitle: "LoRA"
-description: "This guide will help you understand and use a single LoRA model"
+description: "Use LoRA models in ComfyUI: install a LoRA, load it with the Load LoRA node, and run a workflow that applies its style on top of a checkpoint."
 ---
 
 **LoRA (Low-Rank Adaptation)** is an efficient technique for fine-tuning large generative models like Stable Diffusion.

--- a/tutorials/basic/text-to-image.mdx
+++ b/tutorials/basic/text-to-image.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Text to Image Workflow"
-description: "This guide will help you understand the concept of text-to-image in AI art generation and complete a text-to-image workflow in ComfyUI"
+description: "Build a text-to-image workflow in ComfyUI: load the default workflow, install an SD1.5 checkpoint, write prompts, and learn what each node does."
 sidebarTitle: "Text to Image"
 ---
 
@@ -14,7 +14,7 @@ In this document, we will:
 
 We'll start by running a text-to-image workflow, followed by explanations of related concepts. Please choose the relevant sections based on your needs.
 
-## About Text to Image
+## What is text-to-image in ComfyUI? {#about-text-to-image}
 
 **Text to Image** is a fundamental process in AI art generation that creates images from text descriptions, with **diffusion models** at its core.
 
@@ -119,7 +119,7 @@ Negative prompts:
 blurry, low detail, cartoonish, unrealistic anatomy, out of focus, cluttered, flat lighting
 ```
 
-## Text to Image Working Principles
+## How does text-to-image work? {#text-to-image-working-principles}
 
 The entire text-to-image process can be understood as a **reverse diffusion process**. The [v1-5-pruned-emaonly-fp16.safetensors](https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/blob/main/v1-5-pruned-emaonly-fp16.safetensors) we downloaded is a pre-trained model that can **generate target images from pure Gaussian noise**. We only need to input our prompts, and it can generate target images through denoising random noise.
 

--- a/tutorials/basic/upscale.mdx
+++ b/tutorials/basic/upscale.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Image Upscale Workflow"
-description: "This guide explains the concept of image upscaling in AI drawing and demonstrates how to implement an image upscaling workflow in ComfyUI"
+description: "Upscale images in ComfyUI: load an upscale model, build the workflow, and chain it after text-to-image for higher resolution outputs."
 sidebarTitle: "Upscale"
 ---
 

--- a/tutorials/video/wan/wan-video.mdx
+++ b/tutorials/video/wan/wan-video.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Wan2.1 Video Examples"
-description: "This guide demonstrates how to generate videos with first and last frames using Wan2.1 Video in ComfyUI"
+description: "Run Wan2.1 video workflows in ComfyUI: text-to-video with the 1.3B model and image-to-video with the 14B model, including model installation."
 sidebarTitle: "Wan2.1"
 ---
 

--- a/tutorials/video/wan/wan2_2.mdx
+++ b/tutorials/video/wan/wan2_2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wan2.2 Video Generation ComfyUI Official Native Workflow Example"
-description: "Official usage guide for Alibaba Cloud Tongyi Wanxiang 2.2 video generation model in ComfyUI"
+description: "Run Wan2.2 video workflows in ComfyUI: the 5B hybrid TI2V model plus 14B text-to-video, image-to-video, and first-last-frame examples, with downloads."
 sidebarTitle: Wan2.2
 ---
 


### PR DESCRIPTION
## Why these 14 pages

Ranked by real search potential from PostHog (docs.comfy.org, last 30 days: 1.89M pageviews, 128.6k entry sessions), cross-checked against a Screaming Frog + GSC audit. Two findings drove the list:

1. **Installation pages are the AI-assistant front door.** ChatGPT alone sent 35.5k docs sessions (94% of all LLM referrals). `installation/desktop/windows` now gets more entries from ChatGPT than from Google (3,920 vs 3,068) and sends 8,190 outbound clicks to comfy.org, the strongest docs-to-product path. `comfyui_portable_windows` is the most LLM-referred page overall (4,290) with ~694k GSC impressions. Most of these pages had filler ("This tutorial will guide you on how to...") or too-short descriptions ("Install and uninstall Comfy Desktop on Windows").
2. **The basics tutorials are quietly compounding** (+16-18% organic in 14 days: text-to-image, image-to-image, upscale) and still carry "This guide will help you..." descriptions.

| Page | Organic entries/30d | LLM entries/30d | Change |
|---|---|---|---|
| installation/comfyui_portable_windows | 18,734 | 4,290 | description + title em dash |
| manager/install | 10,310 | 259 | description |
| tutorials/video/wan/wan2_2 | 6,737 | 2,415 | description |
| tutorials/basic/image-to-image | 4,802 | 385 | description + question H2 |
| installation/desktop/windows | 3,068 | 3,920 | description + title em dash |
| installation/manual_install | 3,790 | 147 | description + title em dash |
| installation/desktop/macos | 3,700 | 901 | description + title em dash |
| tutorials/basic/upscale | 2,847 | 187 | description |
| tutorials/basic/lora | 2,985 | 150 | description |
| installation/update_comfyui | 2,772 | 64 | description |
| tutorials/basic/text-to-image | 2,340 | 264 | description + question H2s |
| tutorials/video/wan/wan-video | 1,503 | 1,128 | description (was inaccurate: said first/last-frame, page is T2V+I2V) |
| installation/install_custom_node | — | — | description |
| changelog | — | — | description (had a markdown link embedded in the meta) |

## What changed

- **Frontmatter descriptions only** on most pages: front-loaded keyword, under 155 chars, accurate to page content, no em dashes.
- **Four titles** lose their em dashes per the repo prose rules ("Windows — Comfy Desktop" → "Comfy Desktop for Windows", etc.). `sidebarTitle` is untouched everywhere, so navigation labels don't change.
- **Three H2s** on the two basics tutorials become question format for AI answer extraction, each with a `{#custom-id}` pinning the pre-rename slug, so no existing anchor link (internal or external) breaks. `check-anchors.py --only-changed` passes.
- English only; zh/ja/ko twins pick the changes up through the normal `pnpm translate` pipeline (translationSourceHash will flag them stale).

Deliberately skipped: `get_started/first_generation` (rewritten in #1471 on 08-23) and pages whose descriptions are already strong (krea-2, flux-2-klein, flux-1-text-to-image, basic-concepts/models). No overlap with open PRs #1473/#1475 (body-content changes; this PR is frontmatter + three headings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)