### PR TITLE
Add proposed Serverless Build and Deploy guide

### DIFF
--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -29,15 +29,14 @@ Serverless API gives a ComfyUI workflow a managed URL and on-demand GPU capacity
 
 Use these commands when the local install and API-format workflow are ready:
 
-Use the compute output to choose a valid region and GPU. Replace `<region>` and `l4` if needed; `deploy up` records the deployment ID for the final command.
+Use the compute output to choose a valid region and GPU. Replace `<region>` and `l4` if needed; copy the deployment ID that `deploy up` prints into the final command.
 
 ```bash
 comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
 
 comfy build push --release --target linux/nvidia
 comfy deploy refs compute # get available regions and GPU classes
-comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
-comfy deploy ls --workspace --status ready # get the deployment ID for the run command
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch # prints the deployment ID
 comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
 ```
 
@@ -65,10 +64,10 @@ comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --out
     ```bash
     comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
     ```
-    `deploy up` prints the new deployment ID. If you need to retrieve it later, list ready deployments:
+    `deploy up` prints the new deployment ID. If you need to retrieve it later, list this Build's ready deployments:
 
     ```bash
-    comfy deploy ls --workspace --status ready
+    comfy deploy ls --status ready
     ```
 
     Use the returned `dep_...` value with `--deployment`.
@@ -181,7 +180,7 @@ comfy deploy run \
   --output-dir ./results
 ```
 
-The endpoint can also be called from the [Comfy SDKs](/development/api-development/sdks) by setting `COMFY_BASE_URL` to the deployment URL.
+The endpoint can also be called from the [Comfy SDKs](/development/api-development/sdks) by setting `COMFY_BASE_URL` to the deployment URL. The SDK request still needs an API key: see [Choosing a base URL](/development/api-development/sdks#choosing-a-base-url).
 
 ## Operate a deployment
 

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -139,10 +139,16 @@ Region capacity changes, so do not copy a static list into a script. Query the p
 comfy deploy refs compute
 ```
 
-Use `--region <region>` to filter the results. Copy a returned `region` and `gpu` pair into `comfy deploy up`:
+Use `--region <region>` to filter the results:
 
 ```bash
 comfy deploy refs compute --region <region>
+```
+
+Copy a returned `region` and `gpu` pair into `comfy deploy up`:
+
+```bash
+comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
 ```
 
 The catalog is the source of truth for which GPU classes are available in each region at deployment time.

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -71,9 +71,9 @@ comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --out
   </Step>
   <Step title="Run the workflow">
     ```bash
-    comfy deploy run \\
-      --workflow workflow_api.json \\
-      --deployment <deployment-id> \\
+    comfy deploy run \
+      --workflow workflow_api.json \
+      --deployment <deployment-id> \
       --output-dir ./results
     ```
     The CLI submits the API-format workflow and downloads its outputs into `./results`.

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -1,0 +1,211 @@
+---
+title: "Serverless API"
+description: "Build a versioned ComfyUI environment, deploy it as a managed endpoint, and run workflows through the API."
+icon: "cloud-arrow-up"
+---
+
+Serverless API gives a ComfyUI workflow a managed URL and on-demand GPU capacity. The new Build and Deploy CLI keeps the build definition in your project, creates releases from that definition, and deploys a release when it is ready to serve traffic.
+
+<CardGroup cols={2}>
+  <Card title="1. Build" icon="box">
+    Create a local build specification from your ComfyUI install.
+  </Card>
+  <Card title="2. Release" icon="tag">
+    Cut an immutable Linux/NVIDIA release from the Build.
+  </Card>
+  <Card title="3. Deploy" icon="cloud-arrow-up">
+    Give the release a URL and managed GPU capacity.
+  </Card>
+  <Card title="4. Run" icon="code">
+    Submit an API-format workflow to the active deployment.
+  </Card>
+</CardGroup>
+
+## Quick start
+
+Use these commands when the local install and API-format workflow are ready:
+
+Use the compute output to choose a valid region and GPU. Replace `<region>` and `l4` if needed; `deploy up` records the deployment ID for the final command.
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+
+comfy build push --release --target linux/nvidia
+comfy deploy refs compute # get available regions and GPU classes
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
+comfy deploy ls --workspace --status ready # get the deployment ID for the run command
+comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
+```
+
+<Steps>
+  <Step title="Initialize">
+    ```bash
+    comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+    ```
+  </Step>
+  <Step title="Create a release">
+    ```bash
+    comfy build push --release --target linux/nvidia
+    ```
+    This syncs the Build and creates a release for the target.
+  </Step>
+  <Step title="Start a deployment">
+    If you do not already know where the selected GPU is available, check first:
+
+    ```bash
+    comfy deploy refs compute --region <region>
+    ```
+
+    Then create or reconcile the deployment:
+
+    ```bash
+    comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
+    ```
+    `deploy up` prints the new deployment ID. If you need to retrieve it later, list ready deployments:
+
+    ```bash
+    comfy deploy ls --workspace --status ready
+    ```
+
+    Use the returned `dep_...` value with `--deployment`.
+  </Step>
+  <Step title="Run the workflow">
+    ```bash
+    comfy deploy run \\
+      --workflow workflow_api.json \\
+      --deployment <deployment-id> \\
+      --output-dir ./results
+    ```
+    The CLI submits the API-format workflow and downloads its outputs into `./results`.
+  </Step>
+</Steps>
+
+## The build file
+
+`comfy-build.yaml` is the local source of truth for a Build. It stores the build definition and the last known remote state, so the CLI can choose the right Build automatically and warn before local changes overwrite a newer remote definition.
+
+Keep this file with the project. It describes the Build; it does not contain the model bytes themselves.
+
+## 1. Initialize a Build
+
+Start from a local ComfyUI install. This scans the models and custom nodes, then writes `comfy-build.yaml`.
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+```
+
+Before pushing, check how the local spec compares with the install and the remote Build:
+
+```bash
+comfy build status
+```
+
+## 2. Update and release
+
+After changing the local ComfyUI install, refresh the local build definition:
+
+```bash
+comfy build update --yes
+```
+
+For the quick path, push the definition and release it for a target in one command:
+
+```bash
+comfy build push --release --target linux/nvidia
+```
+
+When you need to create another release from an existing Build, inspect the supported targets and cut one explicitly:
+
+```bash
+comfy build refs build-targets
+comfy build release create --target linux/nvidia --watch
+```
+
+Follow one release's build log with:
+
+```bash
+comfy build release logs rel_123456 --target linux/nvidia --follow
+```
+
+## Regions and GPU availability
+
+Region capacity changes, so do not copy a static list into a script. Query the platform catalog when you choose a deployment target:
+
+```bash
+comfy deploy refs compute
+```
+
+Use `--region <region>` to filter the results. Copy a returned `region` and `gpu` pair into `comfy deploy up`:
+
+```bash
+comfy deploy refs compute --region <region>
+```
+
+The catalog is the source of truth for which GPU classes are available in each region at deployment time.
+
+## 3. Deploy a release
+
+Discover the available compute in a region, then create or reconcile a deployment for the selected release:
+
+```bash
+comfy deploy refs compute --region US-MO-2
+
+comfy deploy up \
+  --gpu l4 \
+  --region US-MO-2 \
+  --min 1 \
+  --max 4 \
+  --watch
+```
+
+`--min` and `--max` set the worker bounds. Use `comfy deploy status --watch` to follow deployment health, release freshness, and serving activity.
+
+## 4. Run a workflow
+
+Submit an [API-format workflow](/development/api-development/workflow-api-format) to a ready deployment:
+
+```bash
+comfy deploy run \
+  --workflow workflow_api.json \
+  --deployment dep_123456 \
+  --output-dir ./results
+```
+
+The endpoint can also be called from the [Comfy SDKs](/development/api-development/sdks) by setting `COMFY_BASE_URL` to the deployment URL.
+
+## Operate a deployment
+
+```bash
+# Change the worker bounds
+comfy deploy scale --deployment dep_123456 --min 2 --max 5
+
+# Pause or resume while retaining the deployment record
+comfy deploy stop --deployment dep_123456
+comfy deploy start --deployment dep_123456
+```
+
+## Inspect and clean up
+
+```bash
+# Build state
+comfy build ls
+comfy build show --id bld_123456
+comfy build release ls
+comfy build release show rel_123456
+
+# Deployment state
+comfy deploy ls --workspace --status ready
+comfy deploy logs --deployment dep_123456
+comfy deploy events --deployment dep_123456
+```
+
+<Warning>
+  Deleting a deployment and deleting a Build are separate irreversible operations. Confirm the target before using `comfy deploy delete --yes` or `comfy build delete --id bld_123456 --yes`.
+</Warning>
+
+## Next steps
+
+- [Comfy SDKs](/development/api-development/sdks)
+- [Comfy API v2 Overview](/api-reference/v2/overview)
+- [Workflow API Format](/development/api-development/workflow-api-format)
+- [Comfy CLI Reference](/comfy-cli/reference)

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -4,6 +4,10 @@ description: "Build a versioned ComfyUI environment, deploy it as a managed endp
 icon: "cloud-arrow-up"
 ---
 
+<Warning>
+  Serverless API is in beta. Sign up for access at [platform.comfy.org](https://platform.comfy.org).
+</Warning>
+
 Serverless API gives a ComfyUI workflow a managed URL and on-demand GPU capacity. The new Build and Deploy CLI keeps the build definition in your project, creates releases from that definition, and deploys a release when it is ready to serve traffic.
 
 <CardGroup cols={2}>

--- a/docs.json
+++ b/docs.json
@@ -2791,6 +2791,7 @@
                 "group": "Run Workflows",
                 "pages": [
                   "development/api-development/sdks",
+                  "development/serverless/overview",
                   "development/api-development/getting-an-api-key",
                   "development/api-development/overview",
                   "api-reference/v2/overview",
@@ -5756,6 +5757,7 @@
                 "group": "运行工作流",
                 "pages": [
                   "zh/development/api-development/sdks",
+                  "zh/development/serverless/overview",
                   "zh/development/api-development/getting-an-api-key",
                   "zh/development/api-development/overview",
                   "zh/api-reference/v2/overview",
@@ -8721,6 +8723,7 @@
                 "group": "ワークフローの実行",
                 "pages": [
                   "ja/development/api-development/sdks",
+                  "ja/development/serverless/overview",
                   "ja/development/api-development/getting-an-api-key",
                   "ja/development/api-development/overview",
                   "ja/api-reference/v2/overview",
@@ -11664,6 +11667,7 @@
                 "group": "워크플로 실행",
                 "pages": [
                   "ko/development/api-development/sdks",
+                  "ko/development/serverless/overview",
                   "ko/development/api-development/getting-an-api-key",
                   "ko/development/api-development/overview",
                   "ko/api-reference/v2/overview",

--- a/ja/development/serverless/overview.mdx
+++ b/ja/development/serverless/overview.mdx
@@ -2,17 +2,17 @@
 title: "Serverless API"
 description: "バージョン管理された ComfyUI 環境を構築し、マネージドエンドポイントとしてデプロイして、API 経由でワークフローを実行します。"
 icon: "cloud-arrow-up"
-translationSourceHash: ea88ed22
+translationSourceHash: 011b0f78
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
-  "Quick start": 58b5516a
+  "Quick start": 60f7fe62
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
   "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
-  "4. Run a workflow": 657360f1
+  "4. Run a workflow": 30eca3a8
   "Operate a deployment": de5e72b5
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
@@ -43,15 +43,14 @@ Serverless API は、ComfyUI ワークフローにマネージド URL とオン�
 
 ローカルインストールと API 形式のワークフローが準備できたら、次のコマンドを使用します。
 
-compute の出力を使って、有効なリージョンと GPU を選択してください。必要に応じて `<region>` と `l4` を置き換えます。`deploy up` は最後のコマンドで使うデプロイメント ID を記録します。
+compute の出力を使って、有効なリージョンと GPU を選択してください。必要に応じて `<region>` と `l4` を置き換えます。`deploy up` が表示するデプロイメント ID を最後のコマンドにコピーしてください。
 
 ```bash
 comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
 
 comfy build push --release --target linux/nvidia
 comfy deploy refs compute # 利用可能なリージョンと GPU クラスを取得
-comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
-comfy deploy ls --workspace --status ready # run コマンドに使うデプロイメント ID を取得
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch # デプロイメント ID を表示
 comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
 ```
 
@@ -79,10 +78,10 @@ comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --out
     ```bash
     comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
     ```
-    `deploy up` は新しいデプロイメント ID を表示します。後から取得する必要がある場合は、準備完了状態のデプロイメントを一覧表示します。
+    `deploy up` は新しいデプロイメント ID を表示します。後から取得する必要がある場合は、この Build の準備完了状態のデプロイメントを一覧表示します。
 
     ```bash
-    comfy deploy ls --workspace --status ready
+    comfy deploy ls --status ready
     ```
 
     返された `dep_...` の値を `--deployment` に指定してください。
@@ -195,7 +194,7 @@ comfy deploy run \
   --output-dir ./results
 ```
 
-`COMFY_BASE_URL` をデプロイメント URL に設定すれば、[Comfy SDK](/ja/development/api-development/sdks) からもこのエンドポイントを呼び出せます。
+`COMFY_BASE_URL` をデプロイメント URL に設定すれば、[Comfy SDK](/ja/development/api-development/sdks) からもこのエンドポイントを呼び出せます。SDK リクエストには API キーが必要です。[ベース URL の選択](/ja/development/api-development/sdks#ベースurlの選択)を参照してください。
 
 ## デプロイメントの運用
 

--- a/ja/development/serverless/overview.mdx
+++ b/ja/development/serverless/overview.mdx
@@ -2,10 +2,10 @@
 title: "Serverless API"
 description: "バージョン管理された ComfyUI 環境を構築し、マネージドエンドポイントとしてデプロイして、API 経由でワークフローを実行します。"
 icon: "cloud-arrow-up"
-translationSourceHash: 4de71d49
+translationSourceHash: df47d684
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
-  "_intro": 1c2dc7b4
+  "_intro": 61dfd25a
   "Quick start": 58b5516a
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
@@ -17,6 +17,10 @@ translationBlockHashes:
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
 ---
+
+<Warning>
+  Serverless API はベータ版です。[platform.comfy.org](https://platform.comfy.org) からサインアップしてアクセスをリクエストしてください。
+</Warning>
 
 Serverless API は、ComfyUI ワークフローにマネージド URL とオンデマンドの GPU キャパシティを提供します。新しい Build and Deploy CLI は、ビルド定義をプロジェクト内に保持し、その定義からリリースを作成し、トラフィックを受け付ける準備ができたらリリースをデプロイします。
 

--- a/ja/development/serverless/overview.mdx
+++ b/ja/development/serverless/overview.mdx
@@ -1,0 +1,225 @@
+---
+title: "Serverless API"
+description: "バージョン管理された ComfyUI 環境を構築し、マネージドエンドポイントとしてデプロイして、API 経由でワークフローを実行します。"
+icon: "cloud-arrow-up"
+translationSourceHash: 4de71d49
+translationFrom: development/serverless/overview.mdx
+translationBlockHashes:
+  "_intro": 1c2dc7b4
+  "Quick start": 58b5516a
+  "The build file": fc8f3702
+  "1. Initialize a Build": 3e2f5628
+  "2. Update and release": 79f5a9a4
+  "Regions and GPU availability": 48c33bf3
+  "3. Deploy a release": 2052f8d5
+  "4. Run a workflow": 657360f1
+  "Operate a deployment": de5e72b5
+  "Inspect and clean up": 0033fd9b
+  "Next steps": 8765dc11
+---
+
+Serverless API は、ComfyUI ワークフローにマネージド URL とオンデマンドの GPU キャパシティを提供します。新しい Build and Deploy CLI は、ビルド定義をプロジェクト内に保持し、その定義からリリースを作成し、トラフィックを受け付ける準備ができたらリリースをデプロイします。
+
+<CardGroup cols={2}>
+  <Card title="1. ビルド（Build）" icon="box">
+    ローカルの ComfyUI インストールからビルド仕様を作成します。
+  </Card>
+  <Card title="2. リリース（Release）" icon="tag">
+    Build からイミュータブルな Linux/NVIDIA リリースを切り出します。
+  </Card>
+  <Card title="3. デプロイ（Deploy）" icon="cloud-arrow-up">
+    リリースに URL とマネージド GPU キャパシティを割り当てます。
+  </Card>
+  <Card title="4. 実行（Run）" icon="code">
+    アクティブなデプロイメントに API 形式のワークフローを送信します。
+  </Card>
+</CardGroup>
+
+## クイックスタート
+
+ローカルインストールと API 形式のワークフローが準備できたら、次のコマンドを使用します。
+
+compute の出力を使って、有効なリージョンと GPU を選択してください。必要に応じて `<region>` と `l4` を置き換えます。`deploy up` は最後のコマンドで使うデプロイメント ID を記録します。
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+
+comfy build push --release --target linux/nvidia
+comfy deploy refs compute # 利用可能なリージョンと GPU クラスを取得
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
+comfy deploy ls --workspace --status ready # run コマンドに使うデプロイメント ID を取得
+comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
+```
+
+<Steps>
+  <Step title="初期化">
+    ```bash
+    comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+    ```
+  </Step>
+  <Step title="リリースを作成">
+    ```bash
+    comfy build push --release --target linux/nvidia
+    ```
+    このコマンドは Build を同期し、指定したターゲット向けのリリースを作成します。
+  </Step>
+  <Step title="デプロイメントを開始">
+    選択した GPU がどこで利用可能か分からない場合は、まず確認します。
+
+    ```bash
+    comfy deploy refs compute --region <region>
+    ```
+
+    次に、デプロイメントを作成または調整（reconcile）します。
+
+    ```bash
+    comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
+    ```
+    `deploy up` は新しいデプロイメント ID を表示します。後から取得する必要がある場合は、準備完了状態のデプロイメントを一覧表示します。
+
+    ```bash
+    comfy deploy ls --workspace --status ready
+    ```
+
+    返された `dep_...` の値を `--deployment` に指定してください。
+  </Step>
+  <Step title="ワークフローを実行">
+    ```bash
+    comfy deploy run \
+      --workflow workflow_api.json \
+      --deployment <deployment-id> \
+      --output-dir ./results
+    ```
+    CLI は API 形式のワークフローを送信し、その出力を `./results` にダウンロードします。
+  </Step>
+</Steps>
+
+## ビルドファイル
+
+`comfy-build.yaml` は Build のローカルにおける信頼できる情報源（source of truth）です。ビルド定義と最後に確認したリモートの状態を保存しているため、CLI は適切な Build を自動的に選択し、ローカルの変更がより新しいリモート定義を上書きしそうな場合に警告できます。
+
+このファイルはプロジェクトと一緒に管理してください。Build を記述するものであり、モデルのデータ自体は含みません。
+
+## 1. Build を初期化する
+
+ローカルの ComfyUI インストールから始めます。このコマンドはモデルとカスタムノードをスキャンし、`comfy-build.yaml` を書き出します。
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+```
+
+プッシュする前に、ローカル仕様がインストールおよびリモートの Build とどう異なるかを確認します。
+
+```bash
+comfy build status
+```
+
+## 2. 更新とリリース
+
+ローカルの ComfyUI インストールを変更した後、ローカルのビルド定義を更新します。
+
+```bash
+comfy build update --yes
+```
+
+最短の手順として、1 つのコマンドで定義をプッシュし、ターゲット向けにリリースできます。
+
+```bash
+comfy build push --release --target linux/nvidia
+```
+
+既存の Build から別のリリースを作成する必要がある場合は、サポートされているターゲットを確認し、明示的にリリースを切り出します。
+
+```bash
+comfy build refs build-targets
+comfy build release create --target linux/nvidia --watch
+```
+
+特定のリリースのビルドログを追跡するには次を使います。
+
+```bash
+comfy build release logs rel_123456 --target linux/nvidia --follow
+```
+
+## リージョンと GPU の可用性
+
+リージョンのキャパシティは変動するため、静的なリストをスクリプトにコピーしないでください。デプロイ先を選ぶ際は、プラットフォームカタログを照会します。
+
+```bash
+comfy deploy refs compute
+```
+
+結果を絞り込むには `--region <region>` を使います。返された `region` と `gpu` のペアを `comfy deploy up` にコピーしてください。
+
+```bash
+comfy deploy refs compute --region <region>
+```
+
+デプロイ時に各リージョンでどの GPU クラスが利用可能かについては、このカタログが信頼できる情報源です。
+
+## 3. リリースをデプロイする
+
+リージョンで利用可能なコンピュートを確認し、選択したリリース向けのデプロイメントを作成または調整します。
+
+```bash
+comfy deploy refs compute --region US-MO-2
+
+comfy deploy up \
+  --gpu l4 \
+  --region US-MO-2 \
+  --min 1 \
+  --max 4 \
+  --watch
+```
+
+`--min` と `--max` はワーカー数の上下限を設定します。デプロイメントの健全性、リリースの新しさ、サービングの状況を追跡するには `comfy deploy status --watch` を使います。
+
+## 4. ワークフローを実行する
+
+準備完了状態のデプロイメントに [API 形式のワークフロー](/ja/development/api-development/workflow-api-format)を送信します。
+
+```bash
+comfy deploy run \
+  --workflow workflow_api.json \
+  --deployment dep_123456 \
+  --output-dir ./results
+```
+
+`COMFY_BASE_URL` をデプロイメント URL に設定すれば、[Comfy SDK](/ja/development/api-development/sdks) からもこのエンドポイントを呼び出せます。
+
+## デプロイメントの運用
+
+```bash
+# ワーカー数の上下限を変更
+comfy deploy scale --deployment dep_123456 --min 2 --max 5
+
+# デプロイメントのレコードを保持したまま一時停止・再開
+comfy deploy stop --deployment dep_123456
+comfy deploy start --deployment dep_123456
+```
+
+## 確認とクリーンアップ
+
+```bash
+# Build の状態
+comfy build ls
+comfy build show --id bld_123456
+comfy build release ls
+comfy build release show rel_123456
+
+# デプロイメントの状態
+comfy deploy ls --workspace --status ready
+comfy deploy logs --deployment dep_123456
+comfy deploy events --deployment dep_123456
+```
+
+<Warning>
+  デプロイメントの削除と Build の削除は、それぞれ独立した取り消し不可能な操作です。`comfy deploy delete --yes` や `comfy build delete --id bld_123456 --yes` を実行する前に、対象を確認してください。
+</Warning>
+
+## 次のステップ
+
+- [Comfy SDK](/ja/development/api-development/sdks)
+- [Comfy API v2 概要](/ja/api-reference/v2/overview)
+- [ワークフロー API 形式](/ja/development/api-development/workflow-api-format)
+- [Comfy CLI リファレンス](/ja/comfy-cli/reference)

--- a/ja/development/serverless/overview.mdx
+++ b/ja/development/serverless/overview.mdx
@@ -2,7 +2,7 @@
 title: "Serverless API"
 description: "バージョン管理された ComfyUI 環境を構築し、マネージドエンドポイントとしてデプロイして、API 経由でワークフローを実行します。"
 icon: "cloud-arrow-up"
-translationSourceHash: df47d684
+translationSourceHash: ea88ed22
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
@@ -10,7 +10,7 @@ translationBlockHashes:
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
-  "Regions and GPU availability": 48c33bf3
+  "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
   "4. Run a workflow": 657360f1
   "Operate a deployment": de5e72b5
@@ -153,10 +153,16 @@ comfy build release logs rel_123456 --target linux/nvidia --follow
 comfy deploy refs compute
 ```
 
-結果を絞り込むには `--region <region>` を使います。返された `region` と `gpu` のペアを `comfy deploy up` にコピーしてください。
+結果を絞り込むには `--region <region>` を使います。
 
 ```bash
 comfy deploy refs compute --region <region>
+```
+
+返された `region` と `gpu` のペアを `comfy deploy up` にコピーしてください。
+
+```bash
+comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
 ```
 
 デプロイ時に各リージョンでどの GPU クラスが利用可能かについては、このカタログが信頼できる情報源です。

--- a/ko/development/serverless/overview.mdx
+++ b/ko/development/serverless/overview.mdx
@@ -2,17 +2,17 @@
 title: "Serverless API"
 description: "버전 관리되는 ComfyUI 환경을 빌드하고, 관리형 엔드포인트로 배포한 뒤 API를 통해 워크플로를 실행합니다."
 icon: "cloud-arrow-up"
-translationSourceHash: ea88ed22
+translationSourceHash: 011b0f78
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
-  "Quick start": 58b5516a
+  "Quick start": 60f7fe62
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
   "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
-  "4. Run a workflow": 657360f1
+  "4. Run a workflow": 30eca3a8
   "Operate a deployment": de5e72b5
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
@@ -43,15 +43,14 @@ Serverless API는 ComfyUI 워크플로에 관리형 URL과 온디맨드 GPU 용�
 
 로컬 설치와 API 형식 워크플로가 준비되면 다음 명령을 사용하세요.
 
-compute 출력 결과를 참고해 유효한 리전과 GPU를 선택하세요. 필요하면 `<region>`과 `l4`를 바꿉니다. `deploy up`은 마지막 명령에서 사용할 배포 ID를 기록합니다.
+compute 출력 결과를 참고해 유효한 리전과 GPU를 선택하세요. 필요하면 `<region>`과 `l4`를 바꿉니다. `deploy up`이 출력하는 배포 ID를 마지막 명령에 복사하세요.
 
 ```bash
 comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
 
 comfy build push --release --target linux/nvidia
 comfy deploy refs compute # 사용 가능한 리전과 GPU 클래스 확인
-comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
-comfy deploy ls --workspace --status ready # run 명령에 사용할 배포 ID 확인
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch # 배포 ID 출력
 comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
 ```
 
@@ -79,10 +78,10 @@ comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --out
     ```bash
     comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
     ```
-    `deploy up`은 새 배포 ID를 출력합니다. 나중에 다시 확인해야 한다면 준비 상태의 배포를 나열하세요.
+    `deploy up`은 새 배포 ID를 출력합니다. 나중에 다시 확인해야 한다면 현재 Build의 준비 상태 배포를 나열하세요.
 
     ```bash
-    comfy deploy ls --workspace --status ready
+    comfy deploy ls --status ready
     ```
 
     반환된 `dep_...` 값을 `--deployment`에 사용합니다.
@@ -195,7 +194,7 @@ comfy deploy run \
   --output-dir ./results
 ```
 
-`COMFY_BASE_URL`을 배포 URL로 설정하면 [Comfy SDK](/ko/development/api-development/sdks)에서도 이 엔드포인트를 호출할 수 있습니다.
+`COMFY_BASE_URL`을 배포 URL로 설정하면 [Comfy SDK](/ko/development/api-development/sdks)에서도 이 엔드포인트를 호출할 수 있습니다. SDK 요청에는 여전히 API 키가 필요합니다. [기본 URL 선택](/ko/development/api-development/sdks#기본-url-선택)을 참조하세요.
 
 ## 배포 운영
 

--- a/ko/development/serverless/overview.mdx
+++ b/ko/development/serverless/overview.mdx
@@ -2,7 +2,7 @@
 title: "Serverless API"
 description: "버전 관리되는 ComfyUI 환경을 빌드하고, 관리형 엔드포인트로 배포한 뒤 API를 통해 워크플로를 실행합니다."
 icon: "cloud-arrow-up"
-translationSourceHash: df47d684
+translationSourceHash: ea88ed22
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
@@ -10,7 +10,7 @@ translationBlockHashes:
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
-  "Regions and GPU availability": 48c33bf3
+  "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
   "4. Run a workflow": 657360f1
   "Operate a deployment": de5e72b5
@@ -153,10 +153,16 @@ comfy build release logs rel_123456 --target linux/nvidia --follow
 comfy deploy refs compute
 ```
 
-결과를 필터링하려면 `--region <region>`을 사용하세요. 반환된 `region`과 `gpu` 쌍을 `comfy deploy up`에 복사합니다.
+결과를 필터링하려면 `--region <region>`을 사용하세요.
 
 ```bash
 comfy deploy refs compute --region <region>
+```
+
+반환된 `region`과 `gpu` 쌍을 `comfy deploy up`에 복사합니다.
+
+```bash
+comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
 ```
 
 배포 시점에 각 리전에서 사용할 수 있는 GPU 클래스는 이 카탈로그가 원본 정보입니다.

--- a/ko/development/serverless/overview.mdx
+++ b/ko/development/serverless/overview.mdx
@@ -1,0 +1,225 @@
+---
+title: "Serverless API"
+description: "버전 관리되는 ComfyUI 환경을 빌드하고, 관리형 엔드포인트로 배포한 뒤 API를 통해 워크플로를 실행합니다."
+icon: "cloud-arrow-up"
+translationSourceHash: 4de71d49
+translationFrom: development/serverless/overview.mdx
+translationBlockHashes:
+  "_intro": 1c2dc7b4
+  "Quick start": 58b5516a
+  "The build file": fc8f3702
+  "1. Initialize a Build": 3e2f5628
+  "2. Update and release": 79f5a9a4
+  "Regions and GPU availability": 48c33bf3
+  "3. Deploy a release": 2052f8d5
+  "4. Run a workflow": 657360f1
+  "Operate a deployment": de5e72b5
+  "Inspect and clean up": 0033fd9b
+  "Next steps": 8765dc11
+---
+
+Serverless API는 ComfyUI 워크플로에 관리형 URL과 온디맨드 GPU 용량을 제공합니다. 새로운 Build and Deploy CLI는 빌드 정의를 프로젝트 안에 보관하고, 그 정의로부터 릴리스를 생성하며, 트래픽을 처리할 준비가 되면 릴리스를 배포합니다.
+
+<CardGroup cols={2}>
+  <Card title="1. 빌드(Build)" icon="box">
+    로컬 ComfyUI 설치로부터 빌드 사양을 생성합니다.
+  </Card>
+  <Card title="2. 릴리스(Release)" icon="tag">
+    Build에서 변경 불가능한 Linux/NVIDIA 릴리스를 만듭니다.
+  </Card>
+  <Card title="3. 배포(Deploy)" icon="cloud-arrow-up">
+    릴리스에 URL과 관리형 GPU 용량을 부여합니다.
+  </Card>
+  <Card title="4. 실행(Run)" icon="code">
+    활성 배포에 API 형식 워크플로를 제출합니다.
+  </Card>
+</CardGroup>
+
+## 빠른 시작
+
+로컬 설치와 API 형식 워크플로가 준비되면 다음 명령을 사용하세요.
+
+compute 출력 결과를 참고해 유효한 리전과 GPU를 선택하세요. 필요하면 `<region>`과 `l4`를 바꿉니다. `deploy up`은 마지막 명령에서 사용할 배포 ID를 기록합니다.
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+
+comfy build push --release --target linux/nvidia
+comfy deploy refs compute # 사용 가능한 리전과 GPU 클래스 확인
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
+comfy deploy ls --workspace --status ready # run 명령에 사용할 배포 ID 확인
+comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
+```
+
+<Steps>
+  <Step title="초기화">
+    ```bash
+    comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+    ```
+  </Step>
+  <Step title="릴리스 생성">
+    ```bash
+    comfy build push --release --target linux/nvidia
+    ```
+    이 명령은 Build를 동기화하고 지정한 타깃에 대한 릴리스를 생성합니다.
+  </Step>
+  <Step title="배포 시작">
+    선택한 GPU를 어디에서 사용할 수 있는지 모른다면 먼저 확인하세요.
+
+    ```bash
+    comfy deploy refs compute --region <region>
+    ```
+
+    그런 다음 배포를 생성하거나 조정(reconcile)합니다.
+
+    ```bash
+    comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
+    ```
+    `deploy up`은 새 배포 ID를 출력합니다. 나중에 다시 확인해야 한다면 준비 상태의 배포를 나열하세요.
+
+    ```bash
+    comfy deploy ls --workspace --status ready
+    ```
+
+    반환된 `dep_...` 값을 `--deployment`에 사용합니다.
+  </Step>
+  <Step title="워크플로 실행">
+    ```bash
+    comfy deploy run \
+      --workflow workflow_api.json \
+      --deployment <deployment-id> \
+      --output-dir ./results
+    ```
+    CLI가 API 형식 워크플로를 제출하고 그 출력을 `./results`에 다운로드합니다.
+  </Step>
+</Steps>
+
+## 빌드 파일
+
+`comfy-build.yaml`은 Build의 로컬 원본 정보(source of truth)입니다. 빌드 정의와 마지막으로 확인한 원격 상태를 저장하므로, CLI가 올바른 Build를 자동으로 선택하고 로컬 변경이 더 최신의 원격 정의를 덮어쓰기 전에 경고할 수 있습니다.
+
+이 파일은 프로젝트와 함께 보관하세요. Build를 설명하는 파일일 뿐, 모델 데이터 자체는 포함하지 않습니다.
+
+## 1. Build 초기화
+
+로컬 ComfyUI 설치에서 시작합니다. 이 명령은 모델과 커스텀 노드를 스캔한 뒤 `comfy-build.yaml`을 작성합니다.
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+```
+
+푸시하기 전에 로컬 사양이 설치본 및 원격 Build와 어떻게 다른지 확인하세요.
+
+```bash
+comfy build status
+```
+
+## 2. 업데이트와 릴리스
+
+로컬 ComfyUI 설치를 변경한 후 로컬 빌드 정의를 새로 고칩니다.
+
+```bash
+comfy build update --yes
+```
+
+빠른 방법으로, 한 번의 명령으로 정의를 푸시하고 타깃에 대해 릴리스할 수 있습니다.
+
+```bash
+comfy build push --release --target linux/nvidia
+```
+
+기존 Build에서 또 다른 릴리스를 만들어야 한다면, 지원되는 타깃을 확인한 뒤 명시적으로 릴리스를 생성하세요.
+
+```bash
+comfy build refs build-targets
+comfy build release create --target linux/nvidia --watch
+```
+
+특정 릴리스의 빌드 로그를 따라가려면 다음을 사용합니다.
+
+```bash
+comfy build release logs rel_123456 --target linux/nvidia --follow
+```
+
+## 리전과 GPU 가용성
+
+리전 용량은 변하므로 스크립트에 정적 목록을 복사하지 마세요. 배포 대상을 선택할 때는 플랫폼 카탈로그를 조회하세요.
+
+```bash
+comfy deploy refs compute
+```
+
+결과를 필터링하려면 `--region <region>`을 사용하세요. 반환된 `region`과 `gpu` 쌍을 `comfy deploy up`에 복사합니다.
+
+```bash
+comfy deploy refs compute --region <region>
+```
+
+배포 시점에 각 리전에서 사용할 수 있는 GPU 클래스는 이 카탈로그가 원본 정보입니다.
+
+## 3. 릴리스 배포
+
+리전에서 사용 가능한 컴퓨트를 확인한 뒤, 선택한 릴리스에 대한 배포를 생성하거나 조정합니다.
+
+```bash
+comfy deploy refs compute --region US-MO-2
+
+comfy deploy up \
+  --gpu l4 \
+  --region US-MO-2 \
+  --min 1 \
+  --max 4 \
+  --watch
+```
+
+`--min`과 `--max`는 워커 수의 상한과 하한을 설정합니다. 배포 상태, 릴리스 최신 여부, 서빙 활동을 추적하려면 `comfy deploy status --watch`를 사용하세요.
+
+## 4. 워크플로 실행
+
+준비된 배포에 [API 형식 워크플로](/ko/development/api-development/workflow-api-format)를 제출합니다.
+
+```bash
+comfy deploy run \
+  --workflow workflow_api.json \
+  --deployment dep_123456 \
+  --output-dir ./results
+```
+
+`COMFY_BASE_URL`을 배포 URL로 설정하면 [Comfy SDK](/ko/development/api-development/sdks)에서도 이 엔드포인트를 호출할 수 있습니다.
+
+## 배포 운영
+
+```bash
+# 워커 수의 상한과 하한 변경
+comfy deploy scale --deployment dep_123456 --min 2 --max 5
+
+# 배포 레코드를 유지한 채 일시 중지 또는 재개
+comfy deploy stop --deployment dep_123456
+comfy deploy start --deployment dep_123456
+```
+
+## 확인 및 정리
+
+```bash
+# Build 상태
+comfy build ls
+comfy build show --id bld_123456
+comfy build release ls
+comfy build release show rel_123456
+
+# 배포 상태
+comfy deploy ls --workspace --status ready
+comfy deploy logs --deployment dep_123456
+comfy deploy events --deployment dep_123456
+```
+
+<Warning>
+  배포 삭제와 Build 삭제는 서로 별개인 되돌릴 수 없는 작업입니다. `comfy deploy delete --yes`나 `comfy build delete --id bld_123456 --yes`를 사용하기 전에 대상을 확인하세요.
+</Warning>
+
+## 다음 단계
+
+- [Comfy SDK](/ko/development/api-development/sdks)
+- [Comfy API v2 개요](/ko/api-reference/v2/overview)
+- [워크플로 API 형식](/ko/development/api-development/workflow-api-format)
+- [Comfy CLI 참조](/ko/comfy-cli/reference)

--- a/ko/development/serverless/overview.mdx
+++ b/ko/development/serverless/overview.mdx
@@ -2,10 +2,10 @@
 title: "Serverless API"
 description: "버전 관리되는 ComfyUI 환경을 빌드하고, 관리형 엔드포인트로 배포한 뒤 API를 통해 워크플로를 실행합니다."
 icon: "cloud-arrow-up"
-translationSourceHash: 4de71d49
+translationSourceHash: df47d684
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
-  "_intro": 1c2dc7b4
+  "_intro": 61dfd25a
   "Quick start": 58b5516a
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
@@ -17,6 +17,10 @@ translationBlockHashes:
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
 ---
+
+<Warning>
+  Serverless API는 현재 베타 버전입니다. [platform.comfy.org](https://platform.comfy.org)에서 가입하여 액세스를 신청하세요.
+</Warning>
 
 Serverless API는 ComfyUI 워크플로에 관리형 URL과 온디맨드 GPU 용량을 제공합니다. 새로운 Build and Deploy CLI는 빌드 정의를 프로젝트 안에 보관하고, 그 정의로부터 릴리스를 생성하며, 트래픽을 처리할 준비가 되면 릴리스를 배포합니다.
 

--- a/zh/development/serverless/overview.mdx
+++ b/zh/development/serverless/overview.mdx
@@ -2,7 +2,7 @@
 title: "Serverless API"
 description: "构建版本化的 ComfyUI 环境，将其部署为托管端点，并通过 API 运行工作流。"
 icon: "cloud-arrow-up"
-translationSourceHash: df47d684
+translationSourceHash: ea88ed22
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
@@ -10,7 +10,7 @@ translationBlockHashes:
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
-  "Regions and GPU availability": 48c33bf3
+  "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
   "4. Run a workflow": 657360f1
   "Operate a deployment": de5e72b5
@@ -153,10 +153,16 @@ comfy build release logs rel_123456 --target linux/nvidia --follow
 comfy deploy refs compute
 ```
 
-使用 `--region <region>` 过滤结果。将返回的 `region` 和 `gpu` 组合复制到 `comfy deploy up` 中：
+使用 `--region <region>` 过滤结果：
 
 ```bash
 comfy deploy refs compute --region <region>
+```
+
+将返回的 `region` 和 `gpu` 组合复制到 `comfy deploy up` 中：
+
+```bash
+comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
 ```
 
 在部署时，该目录是各区域可用 GPU 类型的事实来源。

--- a/zh/development/serverless/overview.mdx
+++ b/zh/development/serverless/overview.mdx
@@ -2,17 +2,17 @@
 title: "Serverless API"
 description: "构建版本化的 ComfyUI 环境，将其部署为托管端点，并通过 API 运行工作流。"
 icon: "cloud-arrow-up"
-translationSourceHash: ea88ed22
+translationSourceHash: 011b0f78
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
   "_intro": 61dfd25a
-  "Quick start": 58b5516a
+  "Quick start": 60f7fe62
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
   "2. Update and release": 79f5a9a4
   "Regions and GPU availability": 3cf9a951
   "3. Deploy a release": 2052f8d5
-  "4. Run a workflow": 657360f1
+  "4. Run a workflow": 30eca3a8
   "Operate a deployment": de5e72b5
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
@@ -43,15 +43,14 @@ Serverless API 为 ComfyUI 工作流提供托管 URL 和按需 GPU 算力。新�
 
 当本地安装和 API 格式的工作流准备就绪后，使用以下命令：
 
-利用 compute 命令的输出选择有效的区域和 GPU。按需替换 `<region>` 和 `l4`；`deploy up` 会记录部署 ID，供最后一条命令使用。
+利用 compute 命令的输出选择有效的区域和 GPU。按需替换 `<region>` 和 `l4`；将 `deploy up` 打印的部署 ID 复制到最后一条命令中。
 
 ```bash
 comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
 
 comfy build push --release --target linux/nvidia
 comfy deploy refs compute # 获取可用区域和 GPU 类型
-comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
-comfy deploy ls --workspace --status ready # 获取 run 命令所需的部署 ID
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch # 打印部署 ID
 comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
 ```
 
@@ -79,10 +78,10 @@ comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --out
     ```bash
     comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
     ```
-    `deploy up` 会打印新的部署 ID。如需稍后再获取，可列出处于就绪状态的部署：
+    `deploy up` 会打印新的部署 ID。如需稍后再获取，可列出当前 Build 处于就绪状态的部署：
 
     ```bash
-    comfy deploy ls --workspace --status ready
+    comfy deploy ls --status ready
     ```
 
     将返回的 `dep_...` 值用于 `--deployment` 参数。
@@ -195,7 +194,7 @@ comfy deploy run \
   --output-dir ./results
 ```
 
-也可以通过 [Comfy SDK](/zh/development/api-development/sdks) 调用该端点，只需将 `COMFY_BASE_URL` 设置为部署 URL。
+也可以通过 [Comfy SDK](/zh/development/api-development/sdks) 调用该端点，只需将 `COMFY_BASE_URL` 设置为部署 URL。SDK 请求仍需要 API 密钥：参见[选择基础 URL](/zh/development/api-development/sdks#选择基础-url)。
 
 ## 运维部署
 

--- a/zh/development/serverless/overview.mdx
+++ b/zh/development/serverless/overview.mdx
@@ -1,0 +1,225 @@
+---
+title: "Serverless API"
+description: "构建版本化的 ComfyUI 环境，将其部署为托管端点，并通过 API 运行工作流。"
+icon: "cloud-arrow-up"
+translationSourceHash: 4de71d49
+translationFrom: development/serverless/overview.mdx
+translationBlockHashes:
+  "_intro": 1c2dc7b4
+  "Quick start": 58b5516a
+  "The build file": fc8f3702
+  "1. Initialize a Build": 3e2f5628
+  "2. Update and release": 79f5a9a4
+  "Regions and GPU availability": 48c33bf3
+  "3. Deploy a release": 2052f8d5
+  "4. Run a workflow": 657360f1
+  "Operate a deployment": de5e72b5
+  "Inspect and clean up": 0033fd9b
+  "Next steps": 8765dc11
+---
+
+Serverless API 为 ComfyUI 工作流提供托管 URL 和按需 GPU 算力。新的 Build and Deploy CLI 将构建定义保存在你的项目中，基于该定义创建发布版本（release），并在准备好对外提供服务时部署某个发布版本。
+
+<CardGroup cols={2}>
+  <Card title="1. 构建（Build）" icon="box">
+    从你的本地 ComfyUI 安装创建构建规格文件。
+  </Card>
+  <Card title="2. 发布（Release）" icon="tag">
+    从 Build 切出一个不可变的 Linux/NVIDIA 发布版本。
+  </Card>
+  <Card title="3. 部署（Deploy）" icon="cloud-arrow-up">
+    为发布版本分配 URL 和托管 GPU 算力。
+  </Card>
+  <Card title="4. 运行（Run）" icon="code">
+    向处于活动状态的部署提交 API 格式的工作流。
+  </Card>
+</CardGroup>
+
+## 快速开始
+
+当本地安装和 API 格式的工作流准备就绪后，使用以下命令：
+
+利用 compute 命令的输出选择有效的区域和 GPU。按需替换 `<region>` 和 `l4`；`deploy up` 会记录部署 ID，供最后一条命令使用。
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+
+comfy build push --release --target linux/nvidia
+comfy deploy refs compute # 获取可用区域和 GPU 类型
+comfy deploy up --gpu l4 --region <region> --min 1 --max 4 --watch
+comfy deploy ls --workspace --status ready # 获取 run 命令所需的部署 ID
+comfy deploy run --workflow workflow_api.json --deployment <deployment-id> --output-dir ./results
+```
+
+<Steps>
+  <Step title="初始化">
+    ```bash
+    comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+    ```
+  </Step>
+  <Step title="创建发布版本">
+    ```bash
+    comfy build push --release --target linux/nvidia
+    ```
+    该命令会同步 Build 并为指定目标创建一个发布版本。
+  </Step>
+  <Step title="启动部署">
+    如果你还不确定所选 GPU 在哪些区域可用，请先查询：
+
+    ```bash
+    comfy deploy refs compute --region <region>
+    ```
+
+    然后创建或调整（reconcile）部署：
+
+    ```bash
+    comfy deploy up --gpu <gpu> --region <region> --min 1 --max 4 --watch
+    ```
+    `deploy up` 会打印新的部署 ID。如需稍后再获取，可列出处于就绪状态的部署：
+
+    ```bash
+    comfy deploy ls --workspace --status ready
+    ```
+
+    将返回的 `dep_...` 值用于 `--deployment` 参数。
+  </Step>
+  <Step title="运行工作流">
+    ```bash
+    comfy deploy run \
+      --workflow workflow_api.json \
+      --deployment <deployment-id> \
+      --output-dir ./results
+    ```
+    CLI 会提交 API 格式的工作流，并将其输出下载到 `./results`。
+  </Step>
+</Steps>
+
+## 构建文件
+
+`comfy-build.yaml` 是 Build 的本地事实来源（source of truth）。它保存构建定义和最近一次已知的远程状态，因此 CLI 可以自动选择正确的 Build，并在本地更改可能覆盖较新的远程定义时发出警告。
+
+请将此文件与项目放在一起。它只描述 Build，本身不包含模型文件的内容。
+
+## 1. 初始化 Build
+
+从本地 ComfyUI 安装开始。该命令会扫描模型和自定义节点，然后写入 `comfy-build.yaml`。
+
+```bash
+comfy build init --name "my-comfy-build" --models-dir ./models --custom-nodes-dir ./custom_nodes
+```
+
+在推送之前，检查本地规格与本地安装及远程 Build 的差异：
+
+```bash
+comfy build status
+```
+
+## 2. 更新与发布
+
+修改本地 ComfyUI 安装后，刷新本地构建定义：
+
+```bash
+comfy build update --yes
+```
+
+若想走快捷路径，可用一条命令推送定义并为目标发布：
+
+```bash
+comfy build push --release --target linux/nvidia
+```
+
+当需要从现有 Build 创建另一个发布版本时，先查看支持的构建目标，再显式切出发布版本：
+
+```bash
+comfy build refs build-targets
+comfy build release create --target linux/nvidia --watch
+```
+
+跟踪某个发布版本的构建日志：
+
+```bash
+comfy build release logs rel_123456 --target linux/nvidia --follow
+```
+
+## 区域与 GPU 可用性
+
+区域容量会变化，因此不要在脚本中硬编码静态列表。选择部署目标时，请查询平台目录：
+
+```bash
+comfy deploy refs compute
+```
+
+使用 `--region <region>` 过滤结果。将返回的 `region` 和 `gpu` 组合复制到 `comfy deploy up` 中：
+
+```bash
+comfy deploy refs compute --region <region>
+```
+
+在部署时，该目录是各区域可用 GPU 类型的事实来源。
+
+## 3. 部署发布版本
+
+先查询区域内可用的算力，然后为所选发布版本创建或调整部署：
+
+```bash
+comfy deploy refs compute --region US-MO-2
+
+comfy deploy up \
+  --gpu l4 \
+  --region US-MO-2 \
+  --min 1 \
+  --max 4 \
+  --watch
+```
+
+`--min` 和 `--max` 设置工作节点（worker）数量的上下限。使用 `comfy deploy status --watch` 跟踪部署健康状况、发布版本新旧程度以及服务活动。
+
+## 4. 运行工作流
+
+向就绪的部署提交 [API 格式的工作流](/zh/development/api-development/workflow-api-format)：
+
+```bash
+comfy deploy run \
+  --workflow workflow_api.json \
+  --deployment dep_123456 \
+  --output-dir ./results
+```
+
+也可以通过 [Comfy SDK](/zh/development/api-development/sdks) 调用该端点，只需将 `COMFY_BASE_URL` 设置为部署 URL。
+
+## 运维部署
+
+```bash
+# 修改工作节点数量上下限
+comfy deploy scale --deployment dep_123456 --min 2 --max 5
+
+# 暂停或恢复，同时保留部署记录
+comfy deploy stop --deployment dep_123456
+comfy deploy start --deployment dep_123456
+```
+
+## 查看与清理
+
+```bash
+# Build 状态
+comfy build ls
+comfy build show --id bld_123456
+comfy build release ls
+comfy build release show rel_123456
+
+# 部署状态
+comfy deploy ls --workspace --status ready
+comfy deploy logs --deployment dep_123456
+comfy deploy events --deployment dep_123456
+```
+
+<Warning>
+  删除部署与删除 Build 是两个相互独立且不可逆的操作。在使用 `comfy deploy delete --yes` 或 `comfy build delete --id bld_123456 --yes` 之前，请确认操作对象。
+</Warning>
+
+## 后续步骤
+
+- [Comfy SDK](/zh/development/api-development/sdks)
+- [Comfy API v2 概述](/zh/api-reference/v2/overview)
+- [工作流 API 格式](/zh/development/api-development/workflow-api-format)
+- [Comfy CLI 参考](/zh/comfy-cli/reference)

--- a/zh/development/serverless/overview.mdx
+++ b/zh/development/serverless/overview.mdx
@@ -2,10 +2,10 @@
 title: "Serverless API"
 description: "构建版本化的 ComfyUI 环境，将其部署为托管端点，并通过 API 运行工作流。"
 icon: "cloud-arrow-up"
-translationSourceHash: 4de71d49
+translationSourceHash: df47d684
 translationFrom: development/serverless/overview.mdx
 translationBlockHashes:
-  "_intro": 1c2dc7b4
+  "_intro": 61dfd25a
   "Quick start": 58b5516a
   "The build file": fc8f3702
   "1. Initialize a Build": 3e2f5628
@@ -17,6 +17,10 @@ translationBlockHashes:
   "Inspect and clean up": 0033fd9b
   "Next steps": 8765dc11
 ---
+
+<Warning>
+  Serverless API 目前处于测试版（beta）阶段。请前往 [platform.comfy.org](https://platform.comfy.org) 注册以获取访问权限。
+</Warning>
 
 Serverless API 为 ComfyUI 工作流提供托管 URL 和按需 GPU 算力。新的 Build and Deploy CLI 将构建定义保存在你的项目中，基于该定义创建发布版本（release），并在准备好对外提供服务时部署某个发布版本。
 


### PR DESCRIPTION
## Summary

Adds an English-only guide for the proposed Serverless Build and Deploy CLI.

The guide covers:

- `comfy-build.yaml` as the local Build state
- Build initialization and synchronization
- Release creation and logs
- Region/GPU discovery
- Deployment creation and status
- Running workflows
- Scaling, stopping, starting, inspection, and cleanup

## Dependency

This is a follow-up to [Comfy-Org/docs#1481](https://github.com/Comfy-Org/docs/pull/1481).

PR #1481 must merge first because it adds the `API Development` / `Develop with Comfy` navigation where this guide will be placed. This PR intentionally contains only the guide page and no navigation changes.

## Verification

- `git diff --check` passes.
- The guide was rendered successfully in the local preview before creating this PR.
