### PR TITLE
docs: add v0.33.2–v0.33.4 changelog and publish CMS release notes

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -651,6 +651,90 @@
         "zh"
       ],
       "published_at": "2026-08-14T03:30:21.194Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.33.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:17:59.544Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.33.2",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:05:01.126Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.33.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:18:18.519Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.33.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:05:19.080Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.33.4",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:18:39.655Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.33.4",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-08-25T13:05:37.800Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="August 24, 2026">
+
+**Partner Node Updates**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v): Text, image, and reference-to-video generation with native audio up to 30 seconds
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model): Adds meshy-7 and ultra mode to text, image, and multi-image-to-3D nodes
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance): Upscales and restores video up to 8K with optional frame interpolation
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Removes kling-v2 from Kling Image Generation ahead of September 15 retirement
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Partner Node Updates**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Upscale video 1.5x to 3x with FLUX super-resolution
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Fast prompt-optimization mode for Seedream 5.0 Pro image-to-image
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash added to the Gemini text node
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Renamed Ideogram P-Image to credit Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="August 17, 2026">
+
+**Partner Node Updates**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Adds text-to-speech, speech-to-text, voice selector, and instant voice clone nodes
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Adds 1080p resolution support for Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Adds extend task type for video continuation
+
+</Update>
+
 <Update label="v0.33.1" description="August 13, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="24 de agosto de 2026">
+
+**Actualizaciones de nodos asociados**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v): Generación de texto, imagen y referencia a video con audio nativo de hasta 30 segundos
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model): Añade meshy-7 y modo ultra a los nodos de texto, imagen y multi-imagen a 3D
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance): Aumenta la resolución y restaura video hasta 8K con interpolación de fotogramas opcional
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Elimina kling-v2 de Kling Image Generation antes de su retiro el 15 de septiembre
+
+</Update>
+
+<Update label="v0.33.3" description="20 de agosto de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Amplía videos de 1.5x a 3x con superresolución FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Modo rápido de optimización de prompts para image-to-image con Seedream 5.0 Pro
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash añadido al nodo de texto Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Renombrado Ideogram P-Image para acreditar a Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 de agosto de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Añade nodos de texto a voz, voz a texto, selector de voz y clonación instantánea de voz
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Añade soporte de resolución 1080p para Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Añade el tipo de tarea extend para la continuación de vídeos
+
+</Update>
+
 <Update label="v0.33.1" description="13 de agosto de 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="August 24, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v) : Génération de texte, d'image et de référence vers vidéo avec audio natif jusqu'à 30 secondes
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model) : Ajoute meshy-7 et le mode ultra aux nœuds texte, image et multi-image vers 3D
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance) : Améliore et restaure les vidéos jusqu'en 8K avec interpolation d'images optionnelle
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676) : Supprime kling-v2 de Kling Image Generation avant son retrait le 15 septembre
+
+</Update>
+
+<Update label="v0.33.3" description="20 août 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753) : Agrandissez la vidéo de 1,5x à 3x avec la super-résolution FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750) : Mode rapide d'optimisation de prompt pour l'image-à-image Seedream 5.0 Pro
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688) : Gemini 3.7 Flash ajouté au nœud de texte Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751) : Ideogram P-Image renommé pour créditer Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 août 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612) : Ajoute des nœuds de synthèse vocale, de reconnaissance vocale, de sélection de voix et de clonage instantané de voix
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684) : Ajoute la prise en charge de la résolution 1080p pour Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579) : Ajoute le type de tâche « extend » pour la continuation vidéo
+
+</Update>
+
 <Update label="v0.33.1" description="13 août 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026年8月24日">
+
+**パートナーノードの更新**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v): テキスト、画像、参照から動画の生成に対応し、ネイティブオーディオは最大30秒まで
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model): テキスト、画像、マルチ画像から3Dの各ノードにmeshy-7とultraモードを追加
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance): ビデオを8Kまでアップスケールおよび復元し、オプションのフレーム補間に対応
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9月15日の廃止に先立ち、Kling Image Generationからkling-v2を削除
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**パートナーノードの更新**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUX超解像でビデオを1.5倍から3倍にアップスケール
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Proの画像から画像への高速プロンプト最適化モード
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): GeminiテキストノードにGemini 3.7 Flashが追加
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-ImageをPrunaにクレジットするよう改名
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**パートナーノードの更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): テキスト読み上げ、音声認識、音声セレクター、即時音声クローンノードを追加します
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5 の 1080p 解像度サポートを追加します
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): ビデオ継続用の拡張タスクタイプを追加します
+
+</Update>
+
 <Update label="v0.33.1" description="2026年8月13日">
 
 **新規オープンソースモデルのサポート**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026년 8월 24일">
+
+**파트너 노드 업데이트**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v): 텍스트, 이미지 및 레퍼런스 기반 비디오 생성, 최대 30초의 네이티브 오디오 지원
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model): 텍스트, 이미지 및 다중 이미지 기반 3D 생성 노드에 meshy-7 및 울트라 모드 추가
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance): 선택적 프레임 보간과 함께 최대 8K까지 비디오 업스케일 및 복원
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9월 15일 서비스 종료를 앞두고 Kling Image Generation에서 kling-v2 제거
+
+</Update>
+
+<Update label="v0.33.3" description="2026년 8월 20일">
+
+**파트너 노드 업데이트**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUX 초고해상도로 비디오를 1.5배~3배로 업스케일
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Pro 이미지 기반 이미지 생성용 빠른 프롬프트 최적화 모드
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 텍스트 노드에 Gemini 3.7 Flash 추가
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Pruna의 공로를 인정하도록 Ideogram P-Image 이름 변경
+
+</Update>
+
+<Update label="v0.33.2" description="2026년 8월 17일">
+
+**파트너 노드 업데이트**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): 텍스트 기반 음성 생성, 음성을 텍스트로 변환, 음성 선택기 및 즉시 음성 복제 노드를 추가합니다
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5에 1080p 해상도 지원을 추가합니다
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): 비디오 연속 생성을 위한 확장 작업 유형을 추가합니다
+
+</Update>
+
 <Update label="v0.33.1" description="2026년 8월 13일">
 
 **새로운 오픈소스 모델 지원**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="24 августа 2026 г.">
+
+**Обновления партнёрских узлов**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v): Генерация текста, изображений и видео по референсу со встроенным аудио длительностью до 30 секунд
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model): Добавляет meshy-7 и ультра-режим в узлы генерации 3D из текста, изображений и нескольких изображений
+* [**ByteDance vCube Video Enhance**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance): Увеличивает разрешение и восстанавливает видео до 8K с опциональной интерполяцией кадров
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Удаляет kling-v2 из Kling Image Generation в преддверии прекращения поддержки 15 сентября
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Обновления партнёрских узлов**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Увеличение видео в 1.5–3 раза с помощью сверхразрешения FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Быстрый режим оптимизации промптов для Seedream 5.0 Pro image-to-image
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash добавлен в текстовый узел Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-Image переименован в честь Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 августа 2026 г.">
+
+**Обновления партнёрских узлов**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Добавлены узлы для преобразования текста в речь, речи в текст, выбора голоса и мгновенного клонирования голоса
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Добавлена поддержка разрешения 1080p для Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Добавлен тип задачи extend для продолжения видео
+
+</Update>
+
 <Update label="v0.33.1" description="13 августа 2026">
 
 **Новая поддержка открытых моделей**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026年8月24日">
+
+**合作伙伴节点更新**
+* [**Wan 3.0**](https://cloud.comfy.org/?template=api_wan3_0_i2v)：支持文本、图像和参考生视频生成，原生音频最长30秒
+* [**Meshy-7**](https://cloud.comfy.org/?template=api_meshy7_image_to_model)：为文本、图像和多图像转3D节点添加 meshy-7 和 ultra 模式
+* [**字节跳动 vCube 视频增强**](https://cloud.comfy.org/?template=api_bytedance_vcube_video_enhance)：可将视频放大并修复至最高8K，并支持可选的帧插值
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676)：在9月15日下线之前，从Kling 图像生成中移除kling-v2
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**合作伙伴节点更新**
+* [**Flux 视频放大**](https://github.com/Comfy-Org/ComfyUI/pull/15753)：使用 FLUX 超分辨率将视频放大 1.5 到 3 倍
+* [**字节跳动 Seedream 快速模式**](https://github.com/Comfy-Org/ComfyUI/pull/15750)：面向 Seedream 5.0 Pro 图生图的快速提示词优化模式
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688)：Gemini 3.7 Flash 已添加到 Gemini 文本节点
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751)：重命名 Ideogram P-Image 以标注 Pruna 的贡献
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**合作伙伴节点更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612)：新增文本转语音、语音转文本、语音选择器和实时语音克隆节点
+* [**字节跳动 Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684)：新增对 Seedance 2.5 的 1080p 分辨率支持
+* [**字节跳动 Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579)：新增用于视频延续的扩展任务类型
+
+</Update>
+
 <Update label="v0.33.1" description="2026年8月13日">
 
 **新增开源模型支持**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="August 24, 2026">
+
+**Partner Node Updates**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Text, image, and reference-to-video generation with native audio up to 30 seconds
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Adds meshy-7 and ultra mode to text, image, and multi-image-to-3D nodes
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): Upscales and restores video up to 8K with optional frame interpolation
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Removes kling-v2 from Kling Image Generation ahead of September 15 retirement
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Partner Node Updates**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Upscale video 1.5x to 3x with FLUX super-resolution
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Fast prompt-optimization mode for Seedream 5.0 Pro image-to-image
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash added to the Gemini text node
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Renamed Ideogram P-Image to credit Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="August 17, 2026">
+
+**Partner Node Updates**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Adds text-to-speech, speech-to-text, voice selector, and instant voice clone nodes
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Adds 1080p resolution support for Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Adds extend task type for video continuation
+
+</Update>
+
 <Update label="v0.33.1" description="August 13, 2026">
 
 **New Open-Source Model Support**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="24 de agosto de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Generación de texto, imagen y referencia a video con audio nativo de hasta 30 segundos
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Añade meshy-7 y el modo ultra a los nodos de texto, imagen y multi-imagen a 3D
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): Amplía y restaura video hasta 8K con interpolación de fotogramas opcional
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Elimina kling-v2 de Kling Image Generation antes de su retiro el 15 de septiembre
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Amplía video de 1.5x a 3x con superresolución FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Modo rápido de optimización de prompt para imagen a imagen con Seedream 5.0 Pro
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash añadido al nodo de texto Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-Image renombrado para acreditar a Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 de agosto de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Añade nodos de texto a voz, voz a texto, selector de voz y clonación instantánea de voz
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Añade soporte de resolución 1080p para Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Añade el tipo de tarea *extend* para la continuación de video
+
+</Update>
+
 <Update label="v0.33.1" description="13 de agosto de 2026">
 
 **Nuevo soporte para modelos de código abierto**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="24 août 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Génération de texte, d’image et de vidéo à partir de référence avec audio natif jusqu’à 30 secondes
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Ajoute meshy-7 et le mode ultra aux nœuds de texte, d’image et de multi-image vers 3D
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): Augmente la résolution et restaure la vidéo jusqu’à 8K avec interpolation d’images optionnelle
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Supprime kling-v2 de Kling Image Generation avant le retrait prévu pour le 15 septembre
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753) : Agrandissement vidéo de 1,5x à 3x avec la super-résolution FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750) : Mode rapide d'optimisation de prompt pour l'image-à-image Seedream 5.0 Pro
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688) : Gemini 3.7 Flash ajouté au nœud de texte Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751) : Ideogram P-Image renommé pour créditer Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 août 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612) : Ajoute des nœuds de synthèse vocale, de reconnaissance vocale, de sélection de voix et de clonage instantané de voix
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684) : Ajoute la prise en charge de la résolution 1080p pour Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579) : Ajoute le type de tâche d’extension pour la continuation vidéo
+
+</Update>
+
 <Update label="v0.33.1" description="13 août 2026">
 
 **Nouveau support de modèles open-source**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026年8月24日">
+
+**パートナーノード更新**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): テキスト、画像、参照から動画生成、最大30秒のネイティブオーディオ対応
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): テキスト、画像、複数画像から3Dへのノードにmeshy-7およびウルトラモードを追加
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): ビデオを8Kまでアップスケール・復元、オプションのフレーム補間対応
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9月15日の廃止に先立ち、Kling Image Generationからkling-v2を削除
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**パートナーノードの更新**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUXスーパー解像度でビデオを1.5倍から3倍にアップスケールします
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Proの画像から画像への高速プロンプト最適化モード
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 FlashがGeminiテキストノードに追加されました
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): PrunaにクレジットするようIdeogram P-Imageを改名しました
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**パートナーノードの更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): テキスト読み上げ、音声認識、音声セレクター、および即時音声クローンノードを追加
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5 の 1080p 解像度サポートを追加
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): ビデオ継続用のextendタスクタイプを追加
+
+</Update>
+
 <Update label="v0.33.1" description="2026年8月13日">
 
 **新規オープンソースモデルのサポート**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026년 8월 24일">
+
+**파트너 노드 업데이트**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): 최대 30초의 네이티브 오디오를 지원하는 텍스트, 이미지 및 레퍼런스 기반 비디오 생성
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): 텍스트, 이미지 및 멀티 이미지 기반 3D 생성 노드에 meshy-7과 ultra 모드를 추가합니다
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): 선택적 프레임 보간을 지원하며 최대 8K까지 비디오를 업스케일하고 복원합니다
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9월 15일 서비스 종료에 앞서 Kling Image Generation에서 kling-v2를 제거합니다
+
+</Update>
+
+<Update label="v0.33.3" description="2026년 8월 20일">
+
+**파트너 노드 업데이트**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUX 초고해상도로 비디오를 1.5배에서 3배까지 업스케일
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Pro 이미지 기반 이미지 생성용 빠른 프롬프트 최적화 모드
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 텍스트 노드에 Gemini 3.7 Flash 추가
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-Image를 Pruna로 이름 변경하여 크레딧 표기
+
+</Update>
+
+<Update label="v0.33.2" description="2026년 8월 17일">
+
+**파트너 노드 업데이트**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): 텍스트 기반 음성 생성, 음성 텍스트 변환, 음성 선택기 및 즉시 음성 복제 노드를 추가합니다
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5에 1080p 해상도 지원을 추가합니다
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): 비디오 연속 생성을 위한 extend 작업 유형을 추가합니다
+
+</Update>
+
 <Update label="v0.33.1" description="2026년 8월 13일">
 
 **새로운 오픈소스 모델 지원**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="August 24, 2026">
+
+**Обновления партнёрских узлов**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Генерация текста, изображений и видео по референсу со встроенным аудио до 30 секунд
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Добавляет meshy-7 и режим ultra в узлы для генерации 3D из текста, изображений и нескольких изображений
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): Повышает разрешение и восстанавливает видео до 8K с опциональной интерполяцией кадров
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Удаляет kling-v2 из Kling Image Generation в преддверии прекращения поддержки 15 сентября
+
+</Update>
+
+<Update label="v0.33.3" description="20 августа 2026">
+
+**Обновления партнёрских узлов**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Увеличение масштаба видео в 1,5–3 раза с помощью суперразрешения FLUX
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Быстрый режим оптимизации промптов для Seedream 5.0 Pro image-to-image
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 3.7 Flash добавлен в текстовый узел Gemini
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-Image переименован в честь Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="17 августа 2026">
+
+**Обновления партнёрских узлов**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Добавляет узлы преобразования текста в речь, преобразования речи в текст, выбора голоса и мгновенного клонирования голоса
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Добавляет поддержку разрешения 1080p для Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Добавляет тип задачи extend для продолжения видео
+
+</Update>
+
 <Update label="v0.33.1" description="13 августа 2026">
 
 **Новая поддержка открытых моделей**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,35 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.33.4" description="2026年8月24日">
+
+**合作伙伴节点更新**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): 文本、图像和参考生视频生成，原生音频长达30秒
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): 为文本、图像和多图像转3D节点添加 meshy-7 和 ultra 模式
+* [**字节跳动 vCube 视频增强**](https://github.com/Comfy-Org/ComfyUI/pull/15755): 将视频放大并修复至8K，支持可选的帧插值
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 在9月15日退役之前，从 Kling 图像生成中移除 kling-v2
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**合作伙伴节点更新**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753)：使用FLUX超分辨率将视频放大1.5倍至3倍
+* [**字节跳动 Seedream 快速模式**](https://github.com/Comfy-Org/ComfyUI/pull/15750)：适用于Seedream 5.0 Pro图生图的快速提示词优化模式
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688)：Gemini 3.7 Flash已添加到Gemini文本节点
+* [**Ideogram 与 Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751)：重命名Ideogram P-Image以署名Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**合作伙伴节点更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612)：添加了文本转语音、语音转文本、语音选择器以及实时语音克隆节点
+* [**字节跳动 Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684)：为 Seedance 2.5 添加了 1080p 分辨率支持
+* [**字节跳动 Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579)：为视频延续添加了扩展任务类型
+
+</Update>
+
 <Update label="v0.33.1" description="2026年8月13日">
 
 **新增开源模型支持**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,38 @@ description: "Track ComfyUI's latest features, improvements, and bug fixes. For 
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.33.4" description="August 24, 2026">
+
+**Partner Node Updates**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Added Wan 3.0 text, image, and reference to video with native audio, up to 30 seconds
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Added meshy-7 and ultra mode to Meshy text, image, and multi-image to 3D nodes
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): Upscale and restore video up to 8K, with optional frame interpolation
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): Removed kling-v2 from Kling Image Generation ahead of September 15 retirement
+
+</Update>
+
+<Update label="v0.33.3" description="August 20, 2026">
+
+**Partner Node Updates**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): Upscale video 1.5x to 3x with FLUX super-resolution
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Fast prompt-optimization mode for Seedream 5.0 Pro image-to-image
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Added Gemini 3.7 Flash to the Gemini text node
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Renamed Ideogram P-Image to credit Pruna
+
+</Update>
+
+<Update label="v0.33.2" description="August 17, 2026">
+
+**Partner Node Updates**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): Added text-to-speech, speech-to-text, voice selector, and instant voice clone nodes
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Added 1080p resolution to Seedance 2.5
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): Added extend task type for video continuation
+
+**Frontend Updates**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15526): Bumped comfyui-frontend-package to 1.49.6
+
+</Update>
+
 <Update label="v0.33.1" description="August 13, 2026">
 
 **New Open-Source Model Support**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "変更履歴"
 description: "ComfyUI の最新機能、改善点、およびバグ修正を追跡します。詳細なリリースノートについては、[GitHub リリースページ](https://github.com/Comfy-Org/ComfyUI/releases) をご覧ください。"
 icon: "clock-rotate-left"
-translationSourceHash: 7eb37332
+translationSourceHash: ebc67546
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.4": b312835e
+  "v0.33.3": 6e4e2d15
+  "v0.33.2": 8b09595f
   "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
@@ -117,6 +120,38 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.4" description="2026年8月24日">
+
+**パートナーノードの更新**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): Wan 3.0 テキスト、画像、参照からビデオを追加しました（ネイティブオーディオ対応、最大30秒）
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Meshy テキスト、画像、マルチ画像から3Dノードに、meshy-7とultraモードを追加しました
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): オプションのフレーム補間に対応し、最大8Kまでのビデオをアップスケールおよび復元します
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9月15日の廃止に先立ち、Kling Image Generationからkling-v2を削除しました
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**パートナーノードの更新**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUX 超解像でビデオを1.5倍から3倍にアップスケール
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Pro の画像から画像への高速プロンプト最適化モード
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini テキストノードに Gemini 3.7 Flash を追加
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Ideogram P-Image を Pruna のクレジット表記に名称変更
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**パートナーノードの更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): text-to-speech、speech-to-text、音声セレクター、および即時音声クローンのノードを追加
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5に1080p解像度を追加
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): ビデオ継続用のextendタスクタイプを追加
+
+**フロントエンドの更新**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15526): comfyui-frontend-packageを1.49.6に更新
+
+</Update>
 
 <Update label="v0.33.1" description="2026年8月13日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "변경 로그"
 description: "ComfyUI의 최신 기능, 개선 사항 및 버그 수정을 추적하세요. 자세한 릴리스 노트는 [Github 릴리스](https://github.com/Comfy-Org/ComfyUI/releases) 페이지를 참조하세요."
 icon: "clock-rotate-left"
-translationSourceHash: 7eb37332
+translationSourceHash: ebc67546
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.4": b312835e
+  "v0.33.3": 6e4e2d15
+  "v0.33.2": 8b09595f
   "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
@@ -117,6 +120,38 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.4" description="2026년 8월 24일">
+
+**파트너 노드 업데이트**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): 최대 30초까지 네이티브 오디오를 지원하는 Wan 3.0 텍스트, 이미지, 레퍼런스 기반 비디오 생성 기능을 추가했습니다
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): Meshy 텍스트, 이미지, 다중 이미지 3D 노드에 meshy-7과 울트라 모드를 추가했습니다
+* [**ByteDance vCube Video Enhance**](https://github.com/Comfy-Org/ComfyUI/pull/15755): 최대 8K까지 비디오를 업스케일하고 복원하며, 선택적 프레임 보간을 지원합니다
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 9월 15일 서비스 종료에 앞서 Kling Image Generation에서 kling-v2를 제거했습니다
+
+</Update>
+
+<Update label="v0.33.3" description="2026년 8월 20일">
+
+**파트너 노드 업데이트**
+* [**Flux Video Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753): FLUX 초해상도로 비디오를 1.5배에서 3배까지 업스케일
+* [**ByteDance Seedream Fast Mode**](https://github.com/Comfy-Org/ComfyUI/pull/15750): Seedream 5.0 Pro 이미지 기반 이미지 생성(image-to-image)을 위한 빠른 프롬프트 최적화 모드
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688): Gemini 텍스트 노드에 Gemini 3.7 Flash 추가
+* [**Ideogram & Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751): Pruna를 표기하도록 Ideogram P-Image 이름 변경
+
+</Update>
+
+<Update label="v0.33.2" description="2026년 8월 17일">
+
+**파트너 노드 업데이트**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612): 텍스트 기반 음성 생성, 음성 기반 텍스트 생성, 음성 선택기, 즉시 음성 복제 노드를 추가했습니다.
+* [**ByteDance Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684): Seedance 2.5에 1080p 해상도 지원을 추가했습니다.
+* [**ByteDance Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579): 비디오 연속 생성을 위한 extend 작업 유형을 추가했습니다.
+
+**프론트엔드 업데이트**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15526): comfyui-frontend-package를 1.49.6으로 업그레이드했습니다.
+
+</Update>
 
 <Update label="v0.33.1" description="2026년 8월 13일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,12 @@
 title: "更新日志"
 description: "跟踪 ComfyUI 的最新功能、改进和错误修复。详细的发布说明请查看 [Github releases](https://github.com/Comfy-Org/ComfyUI/releases) 页面。"
 icon: "clock-rotate-left"
-translationSourceHash: 7eb37332
+translationSourceHash: ebc67546
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.33.4": b312835e
+  "v0.33.3": 6e4e2d15
+  "v0.33.2": 8b09595f
   "v0.33.1": 78f53830
   "v0.32.0": d5cacc19
   "v0.31.0": 6f21d8d8
@@ -117,6 +120,38 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.33.4" description="2026年8月24日">
+
+**合作伙伴节点更新**
+* [**Wan 3.0**](https://github.com/Comfy-Org/ComfyUI/pull/15843): 新增 Wan 3.0 文本转视频、图像转视频和参考转视频功能，支持原生音频，最长 30 秒
+* [**Meshy-7**](https://github.com/Comfy-Org/ComfyUI/pull/15807): 为 Meshy 文本、图像和多图像转 3D 节点新增 meshy-7 和 ultra 模式
+* [**字节跳动 vCube 视频增强**](https://github.com/Comfy-Org/ComfyUI/pull/15755): 放大并修复视频，最高支持 8K，可选帧插值
+* [**Kling v2**](https://github.com/Comfy-Org/ComfyUI/pull/15676): 在 9 月 15 日停用之前，已从 Kling 图像生成中移除 kling-v2
+
+</Update>
+
+<Update label="v0.33.3" description="2026年8月20日">
+
+**合作伙伴节点更新**
+* [**Flux 视频 Upscale**](https://github.com/Comfy-Org/ComfyUI/pull/15753)：使用 FLUX 超分辨率将视频放大 1.5 倍至 3 倍
+* [**字节跳动 Seedream 快速模式**](https://github.com/Comfy-Org/ComfyUI/pull/15750)：适用于 Seedream 5.0 Pro 图生图的快速提示词优化模式
+* [**Gemini 3.7 Flash**](https://github.com/Comfy-Org/ComfyUI/pull/15688)：在 Gemini 文本节点中新增了 Gemini 3.7 Flash
+* [**Ideogram 与 Pruna P-Image**](https://github.com/Comfy-Org/ComfyUI/pull/15751)：重命名 Ideogram P-Image 以向 Pruna 致谢
+
+</Update>
+
+<Update label="v0.33.2" description="2026年8月17日">
+
+**合作伙伴节点更新**
+* [**Fish Audio**](https://github.com/Comfy-Org/ComfyUI/pull/15612)：新增文本转语音、语音转文本、音色选择器和实时语音克隆节点
+* [**字节跳动 Seedance 2.5 1080p**](https://github.com/Comfy-Org/ComfyUI/pull/15684)：为 Seedance 2.5 新增 1080p 分辨率
+* [**字节跳动 Seedance 2.5 Extend**](https://github.com/Comfy-Org/ComfyUI/pull/15579)：新增 extend 任务类型，用于视频续写
+
+**前端更新**
+* [**Frontend**](https://github.com/Comfy-Org/ComfyUI/pull/15526)：将 comfyui-frontend-package 升级至 1.49.6
+
+</Update>
 
 <Update label="v0.33.1" description="2026年8月13日">
 


### PR DESCRIPTION
## Summary
- Add ComfyUI changelog for patch tags v0.33.2, v0.33.3, and v0.33.4 (Fish Audio, Flux Video Upscale, Wan 3.0, Meshy-7, vCube, and related partner updates).
- Translate docs changelog to zh/ja/ko and CMS popup copy to en/zh/ja/ko/fr/ru/es.
- Publish ComfyUI and Cloud Strapi release notes; refresh `published-versions.json`.

## Test plan
- [x] CMS drafts synced and published for comfyui + cloud (v0.33.2–v0.33.4, 7 locales)
- [ ] Confirm docs changelog renders v0.33.4 at the top of `/changelog`
- [ ] Confirm in-app popup shows Wan 3.0 / Meshy-7 / vCube; Cloud links open the template URLs