### PR TITLE
docs: A/B test nav CTA copy (Comfy Cloud vs Try Cloud for free)

### DIFF
--- a/nav-cta-ab-test.js
+++ b/nav-cta-ab-test.js
@@ -10,11 +10,24 @@
 //   - "control" -> keep "Comfy Cloud" (the docs.json default)
 //   - unset     -> "Comfy Cloud" (control)
 //
+// Flag plumbing: docs.comfy.org's PostHog runs through Mintlify's proxy
+// (api_host = https://ph.mintlify.com) and docs has never evaluated a
+// feature flag, so the proxy's flags endpoint is unverified. If the proxy
+// does not forward flag evaluations, getFeatureFlag() returns undefined and
+// the experiment would silently record 100% control. To remove that failure
+// mode, this hook creates its own posthog-js instance
+// (window.posthog.docsCta, via the named-instance init) pointed directly at
+// PostHog's ingestion host, with autocapture/pageviews disabled so nothing
+// is double-counted, and its distinct_id synced to the main instance so
+// exposure and click events attach to the same person as the pageviews and
+// docs.navitem.cta_click events. It only falls back to Mintlify's proxied
+// instance if the dedicated one cannot be created.
+//
 // The href is intentionally unchanged in both variants. Clicks to
 // comfy.org/cloud already convert well (27% of clickers sign up); the test
 // isolates the copy, not the destination.
 //
-// Exposure: calling posthog.getFeatureFlag() automatically captures the
+// Exposure: calling getFeatureFlag() automatically captures the
 // $feature_flag_called event (deduplicated per session), carrying the flag
 // key and the assigned response. Clicks are captured explicitly as
 // "docs_nav_cta_clicked" with the assigned variant so the test can be
@@ -24,6 +37,11 @@
   "use strict";
 
   var FLAG_KEY = "docs-cta-copy";
+  // Direct PostHog ingestion host, bypassing Mintlify's ph.mintlify.com proxy.
+  var INGESTION_HOST = "https://us.i.posthog.com";
+  var INSTANCE_NAME = "docsCta";
+  // Public client key, same value as docs.json -> integrations.posthog.apiKey.
+  var FALLBACK_TOKEN = "phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO";
   var CTA_HREF = "https://comfy.org/cloud?utm_source=docs";
   var VARIANTS = {
     control: { label: "Comfy Cloud" },
@@ -32,9 +50,40 @@
   // Labels we are allowed to swap, so re-renders and flag flips stay idempotent.
   var KNOWN_LABELS = ["Comfy Cloud", "Try Cloud for free"];
   var assignedVariant = "control";
+  var flagMachineReady = false;
+  var safetyTimer = null;
+
+  function mainPh() {
+    return window.posthog || null;
+  }
+
+  function dedicatedPh() {
+    var m = mainPh();
+    return m && m[INSTANCE_NAME] ? m[INSTANCE_NAME] : null;
+  }
+
+  // The instance used to evaluate flags and capture events.
+  function activePh() {
+    return dedicatedPh() || mainPh();
+  }
 
   function variantLabel(variant) {
     return (VARIANTS[variant] || VARIANTS.control).label;
+  }
+
+  // Keep the dedicated instance's distinct_id in sync with the main
+  // (Mintlify) instance so exposure and click events land on the same person
+  // as the pageviews and docs.navitem.cta_click events. No-op once synced.
+  function ensureIdentity(ph) {
+    if (!ph || !ph.identify || !ph.get_distinct_id) return;
+    try {
+      var main = mainPh();
+      var mainId = main && main.get_distinct_id ? main.get_distinct_id() : "";
+      var ownId = ph.get_distinct_id() || "";
+      if (mainId && ownId !== mainId) ph.identify(mainId);
+    } catch (e) {
+      // Identity sync is best-effort; the experiment still records.
+    }
   }
 
   // Swap the label on every CTA link (desktop button, mobile nav link, and
@@ -58,15 +107,16 @@
 
   function applyVariant() {
     var variant = "control";
+    var ph = activePh();
     try {
-      if (window.posthog) {
-        var raw = window.posthog.getFeatureFlag(FLAG_KEY);
+      if (ph && ph.getFeatureFlag) {
+        var raw = ph.getFeatureFlag(FLAG_KEY);
         if (raw === "control" || raw === "test") {
           variant = raw;
         }
       }
     } catch (e) {
-      // PostHog not ready or flag lookup failed: keep the control copy.
+      // Flag lookup failed: keep the control copy.
     }
     assignedVariant = variant;
     applyLabel(variantLabel(variant));
@@ -89,12 +139,70 @@
     observer.observe(document.body, { childList: true, subtree: true });
   }
 
-  function init() {
-    if (window.posthog && window.posthog.onFeatureFlags) {
-      window.posthog.onFeatureFlags(function () {
-        applyVariant();
-        watchNav();
-      });
+  // Called whenever a flag-capable instance becomes available. Idempotent;
+  // re-applies the variant each time so a late-arriving instance corrects an
+  // early control fallback.
+  function onFlagMachineReady(ph) {
+    if (safetyTimer) {
+      clearTimeout(safetyTimer);
+      safetyTimer = null;
+    }
+    ensureIdentity(ph);
+    applyVariant();
+    if (!flagMachineReady) {
+      flagMachineReady = true;
+      watchNav();
+    }
+  }
+
+  // Create the dedicated posthog-js instance pointed at the direct ingestion
+  // host. Returns true when it was created; its loaded callback then drives
+  // onFlagMachineReady.
+  function initDedicated() {
+    var m = mainPh();
+    if (!m || !m.init || dedicatedPh()) return false;
+    try {
+      var token = (m.config && m.config.token) || FALLBACK_TOKEN;
+      m.init(
+        token,
+        {
+          api_host: INGESTION_HOST,
+          autocapture: false,
+          capture_pageview: false,
+          capture_pageleave: false,
+          disable_session_recording: true,
+          disable_surveys: true,
+          loaded: function (ph) {
+            ensureIdentity(ph);
+            onFlagMachineReady(ph);
+          }
+        },
+        INSTANCE_NAME
+      );
+      return !!m[INSTANCE_NAME];
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function start() {
+    var m = mainPh();
+    if (m && m.config) {
+      // Main instance is already initialized.
+      if (!initDedicated()) {
+        // Fallback: evaluate flags through the main (Mintlify) instance.
+        if (m.onFeatureFlags) {
+          m.onFeatureFlags(function () {
+            onFlagMachineReady(m);
+          });
+        } else {
+          onFlagMachineReady(m);
+        }
+      }
+      // Safety net: never hang on a stub that does not load.
+      safetyTimer = setTimeout(function () {
+        onFlagMachineReady(m);
+      }, 6000);
       return;
     }
     // PostHog loads async via the docs platform integration. Poll briefly so
@@ -102,16 +210,12 @@
     var tries = 0;
     var timer = setInterval(function () {
       tries += 1;
-      if (window.posthog && window.posthog.onFeatureFlags) {
+      if (mainPh() && mainPh().config) {
         clearInterval(timer);
-        window.posthog.onFeatureFlags(function () {
-          applyVariant();
-          watchNav();
-        });
+        start();
       } else if (tries >= 100) {
         clearInterval(timer);
-        applyVariant();
-        watchNav();
+        onFlagMachineReady(null);
       }
     }, 100);
   }
@@ -120,13 +224,15 @@
   document.addEventListener(
     "click",
     function (event) {
-      if (!window.posthog) return;
+      var ph = activePh();
+      if (!ph || !ph.capture) return;
       var target =
         event.target instanceof Element
           ? event.target.closest('a[href="' + CTA_HREF + '"]')
           : null;
       if (!target) return;
-      window.posthog.capture("docs_nav_cta_clicked", {
+      ensureIdentity(ph);
+      ph.capture("docs_nav_cta_clicked", {
         variant: assignedVariant,
         label: variantLabel(assignedVariant),
         href: target.href
@@ -136,8 +242,8 @@
   );
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
+    document.addEventListener("DOMContentLoaded", start);
   } else {
-    init();
+    start();
   }
 })();

--- a/nav-cta-ab-test.js
+++ b/nav-cta-ab-test.js
@@ -1,0 +1,143 @@
+// PostHog A/B test for the docs navbar CTA copy.
+//
+// The navbar CTA ("Comfy Cloud" -> https://comfy.org/cloud?utm_source=docs)
+// is rendered by the docs platform from docs.json, so variant assignment
+// happens here in a small JS hook that reads the PostHog flag. Mintlify
+// inlines every root-level .js file on all pages, so this runs site-wide.
+//
+// Flag: docs_nav_cta_copy_v1 (string flag)
+//   - "try_cloud_free" -> label becomes "Try Cloud Free" (homepage-style copy)
+//   - "control"        -> keep "Comfy Cloud" (the docs.json default)
+//   - unset/undefined  -> "Comfy Cloud" (control)
+//
+// The href is intentionally unchanged in both variants. Clicks to
+// comfy.org/cloud already convert well (27% of clickers sign up); the test
+// isolates the copy, not the destination.
+//
+// Exposure: calling posthog.getFeatureFlag() automatically captures the
+// $feature_flag_called event (deduplicated per session), carrying the flag
+// key and the assigned response. Clicks are captured explicitly as
+// "docs_nav_cta_clicked" with the assigned variant so the test can be
+// analyzed against docs-attributed signups in PostHog.
+
+(function () {
+  "use strict";
+
+  var FLAG_KEY = "docs_nav_cta_copy_v1";
+  var CTA_HREF = "https://comfy.org/cloud?utm_source=docs";
+  var VARIANTS = {
+    control: { label: "Comfy Cloud" },
+    try_cloud_free: { label: "Try Cloud Free" }
+  };
+  // Labels we are allowed to swap, so re-renders and flag flips stay idempotent.
+  var KNOWN_LABELS = ["Comfy Cloud", "Try Cloud Free"];
+  var assignedVariant = "control";
+
+  function variantLabel(variant) {
+    return (VARIANTS[variant] || VARIANTS.control).label;
+  }
+
+  // Swap the label on every CTA link (desktop button, mobile nav link, and
+  // any future duplicate). Returns true when at least one label was updated.
+  function applyLabel(label) {
+    var links = document.querySelectorAll('a[href="' + CTA_HREF + '"]');
+    var changed = false;
+    for (var i = 0; i < links.length; i++) {
+      var spans = links[i].querySelectorAll("span");
+      for (var j = 0; j < spans.length; j++) {
+        var text = (spans[j].textContent || "").trim();
+        if (KNOWN_LABELS.indexOf(text) !== -1) {
+          spans[j].textContent = label;
+          changed = true;
+          break;
+        }
+      }
+    }
+    return changed;
+  }
+
+  function applyVariant() {
+    var variant = "control";
+    try {
+      if (window.posthog) {
+        var raw = window.posthog.getFeatureFlag(FLAG_KEY);
+        if (raw === "control" || raw === "try_cloud_free") {
+          variant = raw;
+        }
+      }
+    } catch (e) {
+      // PostHog not ready or flag lookup failed: keep the control copy.
+    }
+    assignedVariant = variant;
+    applyLabel(variantLabel(variant));
+  }
+
+  // The navbar can re-render on navigation (Mintlify is a Next.js SPA).
+  // Re-apply the variant whenever the CTA link appears or changes, debounced.
+  var observer = null;
+  var scheduled = false;
+  function watchNav() {
+    if (observer || typeof MutationObserver === "undefined") return;
+    observer = new MutationObserver(function () {
+      if (scheduled) return;
+      scheduled = true;
+      setTimeout(function () {
+        scheduled = false;
+        applyVariant();
+      }, 200);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function init() {
+    if (window.posthog && window.posthog.onFeatureFlags) {
+      window.posthog.onFeatureFlags(function () {
+        applyVariant();
+        watchNav();
+      });
+      return;
+    }
+    // PostHog loads async via the docs platform integration. Poll briefly so
+    // the hook still runs if it arrives late, then fall back to control.
+    var tries = 0;
+    var timer = setInterval(function () {
+      tries += 1;
+      if (window.posthog && window.posthog.onFeatureFlags) {
+        clearInterval(timer);
+        window.posthog.onFeatureFlags(function () {
+          applyVariant();
+          watchNav();
+        });
+      } else if (tries >= 100) {
+        clearInterval(timer);
+        applyVariant();
+        watchNav();
+      }
+    }, 100);
+  }
+
+  // Record CTA clicks with the assigned variant for funnel analysis.
+  document.addEventListener(
+    "click",
+    function (event) {
+      if (!window.posthog) return;
+      var target =
+        event.target instanceof Element
+          ? event.target.closest('a[href="' + CTA_HREF + '"]')
+          : null;
+      if (!target) return;
+      window.posthog.capture("docs_nav_cta_clicked", {
+        variant: assignedVariant,
+        label: variantLabel(assignedVariant),
+        href: target.href
+      });
+    },
+    true
+  );
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/nav-cta-ab-test.js
+++ b/nav-cta-ab-test.js
@@ -1,89 +1,60 @@
 // PostHog A/B test for the docs navbar CTA copy.
 //
-// The navbar CTA ("Comfy Cloud" -> https://comfy.org/cloud?utm_source=docs)
-// is rendered by the docs platform from docs.json, so variant assignment
-// happens here in a small JS hook that reads the PostHog flag. Mintlify
-// inlines every root-level .js file on all pages, so this runs site-wide.
+// Self-contained variant assignment (no PostHog feature flag): each visitor
+// is randomly assigned control ("Comfy Cloud") or test ("Try Cloud for free")
+// with a 50/50 split. The assignment is kept stable per browser via
+// localStorage, so the label does not flip between page loads, and every CTA
+// click is captured as a PostHog event for per-variant analysis.
 //
-// Flag: docs-cta-copy (string flag, experiment #448700 "Docs CTA copy")
-//   - "test"    -> label becomes "Try Cloud for free" (homepage-style copy)
-//   - "control" -> keep "Comfy Cloud" (the docs.json default)
-//   - unset     -> "Comfy Cloud" (control)
+// Analysis events:
+//   - docs_nav_cta_exposure  {variant, label}  captured once per page load
+//   - docs_nav_cta_clicked   {variant, label, href}
 //
-// Flag plumbing: docs.comfy.org's PostHog runs through Mintlify's proxy
-// (api_host = https://ph.mintlify.com) and docs has never evaluated a
-// feature flag, so the proxy's flags endpoint is unverified. If the proxy
-// does not forward flag evaluations, getFeatureFlag() returns undefined and
-// the experiment would silently record 100% control. To remove that failure
-// mode, this hook creates its own posthog-js instance
-// (window.posthog.docsCta, via the named-instance init) pointed directly at
-// PostHog's ingestion host, with autocapture/pageviews disabled so nothing
-// is double-counted, and its distinct_id synced to the main instance so
-// exposure and click events attach to the same person as the pageviews and
-// docs.navitem.cta_click events. It only falls back to Mintlify's proxied
-// instance if the dedicated one cannot be created.
-//
-// The href is intentionally unchanged in both variants. Clicks to
+// The href is intentionally identical in both variants. Clicks to
 // comfy.org/cloud already convert well (27% of clickers sign up); the test
 // isolates the copy, not the destination.
 //
-// Exposure: calling getFeatureFlag() automatically captures the
-// $feature_flag_called event (deduplicated per session), carrying the flag
-// key and the assigned response. Clicks are captured explicitly as
-// "docs_nav_cta_clicked" with the assigned variant so the test can be
-// analyzed against docs-attributed signups in PostHog.
+// This deliberately does NOT use a PostHog feature flag / experiment.
+// docs.comfy.org evaluates flags through Mintlify's proxy (an unverified
+// path), and the test is small and self-contained. Trade-off: no PostHog
+// experiment readout (significance testing, guardrails) or dashboard kill
+// switch; analysis is manual, filtering the events above by variant. See the
+// #website-and-docs Slack thread for the discussion.
 
 (function () {
   "use strict";
 
-  var FLAG_KEY = "docs-cta-copy";
-  // Direct PostHog ingestion host, bypassing Mintlify's ph.mintlify.com proxy.
-  var INGESTION_HOST = "https://us.i.posthog.com";
-  var INSTANCE_NAME = "docsCta";
-  // Public client key, same value as docs.json -> integrations.posthog.apiKey.
-  var FALLBACK_TOKEN = "phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO";
+  var STORAGE_KEY = "docs_nav_cta_variant";
   var CTA_HREF = "https://comfy.org/cloud?utm_source=docs";
   var VARIANTS = {
     control: { label: "Comfy Cloud" },
     test: { label: "Try Cloud for free" }
   };
-  // Labels we are allowed to swap, so re-renders and flag flips stay idempotent.
+  // Labels we are allowed to swap, so re-renders and storage flips stay idempotent.
   var KNOWN_LABELS = ["Comfy Cloud", "Try Cloud for free"];
   var assignedVariant = "control";
-  var flagMachineReady = false;
-  var safetyTimer = null;
-
-  function mainPh() {
-    return window.posthog || null;
-  }
-
-  function dedicatedPh() {
-    var m = mainPh();
-    return m && m[INSTANCE_NAME] ? m[INSTANCE_NAME] : null;
-  }
-
-  // The instance used to evaluate flags and capture events.
-  function activePh() {
-    return dedicatedPh() || mainPh();
-  }
 
   function variantLabel(variant) {
     return (VARIANTS[variant] || VARIANTS.control).label;
   }
 
-  // Keep the dedicated instance's distinct_id in sync with the main
-  // (Mintlify) instance so exposure and click events land on the same person
-  // as the pageviews and docs.navitem.cta_click events. No-op once synced.
-  function ensureIdentity(ph) {
-    if (!ph || !ph.identify || !ph.get_distinct_id) return;
+  // Assign the variant once per browser (sticky), falling back to a fresh
+  // random draw when storage is unavailable.
+  function assignVariant() {
+    var stored = null;
     try {
-      var main = mainPh();
-      var mainId = main && main.get_distinct_id ? main.get_distinct_id() : "";
-      var ownId = ph.get_distinct_id() || "";
-      if (mainId && ownId !== mainId) ph.identify(mainId);
+      stored = window.localStorage.getItem(STORAGE_KEY);
     } catch (e) {
-      // Identity sync is best-effort; the experiment still records.
+      // Storage blocked (private mode): fall through to a random draw.
     }
+    if (stored === "control" || stored === "test") return stored;
+    var variant = Math.random() > 0.5 ? "test" : "control";
+    try {
+      window.localStorage.setItem(STORAGE_KEY, variant);
+    } catch (e) {
+      // Best-effort; the draw still applies for this page load.
+    }
+    return variant;
   }
 
   // Swap the label on every CTA link (desktop button, mobile nav link, and
@@ -106,20 +77,8 @@
   }
 
   function applyVariant() {
-    var variant = "control";
-    var ph = activePh();
-    try {
-      if (ph && ph.getFeatureFlag) {
-        var raw = ph.getFeatureFlag(FLAG_KEY);
-        if (raw === "control" || raw === "test") {
-          variant = raw;
-        }
-      }
-    } catch (e) {
-      // Flag lookup failed: keep the control copy.
-    }
-    assignedVariant = variant;
-    applyLabel(variantLabel(variant));
+    assignedVariant = assignVariant();
+    applyLabel(variantLabel(assignedVariant));
   }
 
   // The navbar can re-render on navigation (Mintlify is a Next.js SPA).
@@ -139,83 +98,28 @@
     observer.observe(document.body, { childList: true, subtree: true });
   }
 
-  // Called whenever a flag-capable instance becomes available. Idempotent;
-  // re-applies the variant each time so a late-arriving instance corrects an
-  // early control fallback.
-  function onFlagMachineReady(ph) {
-    if (safetyTimer) {
-      clearTimeout(safetyTimer);
-      safetyTimer = null;
-    }
-    ensureIdentity(ph);
+  // PostHog loads async via the docs platform integration; capture the
+  // exposure once it is available (poll briefly, then give up silently).
+  function captureExposure() {
+    var ph = window.posthog;
+    if (!ph || !ph.capture) return;
+    ph.capture("docs_nav_cta_exposure", {
+      variant: assignedVariant,
+      label: variantLabel(assignedVariant)
+    });
+  }
+
+  function init() {
     applyVariant();
-    if (!flagMachineReady) {
-      flagMachineReady = true;
-      watchNav();
-    }
-  }
-
-  // Create the dedicated posthog-js instance pointed at the direct ingestion
-  // host. Returns true when it was created; its loaded callback then drives
-  // onFlagMachineReady.
-  function initDedicated() {
-    var m = mainPh();
-    if (!m || !m.init || dedicatedPh()) return false;
-    try {
-      var token = (m.config && m.config.token) || FALLBACK_TOKEN;
-      m.init(
-        token,
-        {
-          api_host: INGESTION_HOST,
-          autocapture: false,
-          capture_pageview: false,
-          capture_pageleave: false,
-          disable_session_recording: true,
-          disable_surveys: true,
-          loaded: function (ph) {
-            ensureIdentity(ph);
-            onFlagMachineReady(ph);
-          }
-        },
-        INSTANCE_NAME
-      );
-      return !!m[INSTANCE_NAME];
-    } catch (e) {
-      return false;
-    }
-  }
-
-  function start() {
-    var m = mainPh();
-    if (m && m.config) {
-      // Main instance is already initialized.
-      if (!initDedicated()) {
-        // Fallback: evaluate flags through the main (Mintlify) instance.
-        if (m.onFeatureFlags) {
-          m.onFeatureFlags(function () {
-            onFlagMachineReady(m);
-          });
-        } else {
-          onFlagMachineReady(m);
-        }
-      }
-      // Safety net: never hang on a stub that does not load.
-      safetyTimer = setTimeout(function () {
-        onFlagMachineReady(m);
-      }, 6000);
-      return;
-    }
-    // PostHog loads async via the docs platform integration. Poll briefly so
-    // the hook still runs if it arrives late, then fall back to control.
+    watchNav();
     var tries = 0;
     var timer = setInterval(function () {
       tries += 1;
-      if (mainPh() && mainPh().config) {
+      if (window.posthog && window.posthog.capture) {
         clearInterval(timer);
-        start();
+        captureExposure();
       } else if (tries >= 100) {
         clearInterval(timer);
-        onFlagMachineReady(null);
       }
     }, 100);
   }
@@ -224,14 +128,13 @@
   document.addEventListener(
     "click",
     function (event) {
-      var ph = activePh();
+      var ph = window.posthog;
       if (!ph || !ph.capture) return;
       var target =
         event.target instanceof Element
           ? event.target.closest('a[href="' + CTA_HREF + '"]')
           : null;
       if (!target) return;
-      ensureIdentity(ph);
       ph.capture("docs_nav_cta_clicked", {
         variant: assignedVariant,
         label: variantLabel(assignedVariant),
@@ -242,8 +145,8 @@
   );
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", start);
+    document.addEventListener("DOMContentLoaded", init);
   } else {
-    start();
+    init();
   }
 })();

--- a/nav-cta-ab-test.js
+++ b/nav-cta-ab-test.js
@@ -5,10 +5,10 @@
 // happens here in a small JS hook that reads the PostHog flag. Mintlify
 // inlines every root-level .js file on all pages, so this runs site-wide.
 //
-// Flag: docs_nav_cta_copy_v1 (string flag)
-//   - "try_cloud_free" -> label becomes "Try Cloud Free" (homepage-style copy)
-//   - "control"        -> keep "Comfy Cloud" (the docs.json default)
-//   - unset/undefined  -> "Comfy Cloud" (control)
+// Flag: docs-cta-copy (string flag, experiment #448700 "Docs CTA copy")
+//   - "test"    -> label becomes "Try Cloud for free" (homepage-style copy)
+//   - "control" -> keep "Comfy Cloud" (the docs.json default)
+//   - unset     -> "Comfy Cloud" (control)
 //
 // The href is intentionally unchanged in both variants. Clicks to
 // comfy.org/cloud already convert well (27% of clickers sign up); the test
@@ -23,14 +23,14 @@
 (function () {
   "use strict";
 
-  var FLAG_KEY = "docs_nav_cta_copy_v1";
+  var FLAG_KEY = "docs-cta-copy";
   var CTA_HREF = "https://comfy.org/cloud?utm_source=docs";
   var VARIANTS = {
     control: { label: "Comfy Cloud" },
-    try_cloud_free: { label: "Try Cloud Free" }
+    test: { label: "Try Cloud for free" }
   };
   // Labels we are allowed to swap, so re-renders and flag flips stay idempotent.
-  var KNOWN_LABELS = ["Comfy Cloud", "Try Cloud Free"];
+  var KNOWN_LABELS = ["Comfy Cloud", "Try Cloud for free"];
   var assignedVariant = "control";
 
   function variantLabel(variant) {
@@ -61,7 +61,7 @@
     try {
       if (window.posthog) {
         var raw = window.posthog.getFeatureFlag(FLAG_KEY);
-        if (raw === "control" || raw === "try_cloud_free") {
+        if (raw === "control" || raw === "test") {
           variant = raw;
         }
       }


### PR DESCRIPTION
## What & why

Requested in #website-and-docs ([thread](https://comfy-organization.slack.com/archives/C09NWURUPMF/p1787697225053759)): test whether homepage-style copy on the docs navbar CTA drives more clicks and signups.

PostHog data from the thread: the docs CTA ("Comfy Cloud" → comfy.org/cloud?utm_source=docs) gets ~1.2% click rate (7,637 clicks from 6,294 people against 540k unique visitors, 30d), but 27% of clickers create an account. The funnel suggests people aren't clicking because the CTA doesn't read as an offer, not because the destination fails.

## What changed

`nav-cta-ab-test.js` (repo root; Mintlify inlines every root-level .js file on all pages, same mechanism as `syft.js`):

**Self-contained variant assignment** (no PostHog feature flag), per the thread discussion with Christian (inline `Math.random()` option) and given that docs' PostHog runs through Mintlify's proxy with an unverified flag-evaluation path:

- Each visitor is randomly assigned `control` ("Comfy Cloud") or `test` ("Try Cloud for free"), 50/50.
- The assignment is **sticky per browser via localStorage**, so the label does not flip between page loads (the naive inline version would re-randomize on every page).
- Events for analysis:
  - `docs_nav_cta_exposure` `{variant, label}` — once per page load
  - `docs_nav_cta_clicked` `{variant, label, href}` — on every CTA click (captures the actually-assigned variant)
- The href is identical in both variants to isolate the copy variable.
- A MutationObserver re-applies the label when the SPA re-renders the navbar; storage-blocked browsers fall back to a per-load random draw.

## Trade-off (deliberate)

This does NOT use the PostHog experiment (#448700, flag `docs-cta-copy`, left in draft and unused): no experiment dashboard readout (significance testing, guardrails), no dashboard kill switch, and signup attribution is manual (join `docs_nav_cta_*` events to `$signup` by person). Analysis is done by filtering the two events above by variant. This keeps the hook ~100 lines, removes the flag-launch step and the proxy dependency, and the test is live immediately after deploy.

## How to launch

Merge this PR → Mintlify deploys → the test is live. No PostHog dashboard step needed.

## Verification

Tested in a real browser against the live rendered nav DOM (desktop `#topbar-cta-button` link + mobile nav link), with a mocked PostHog and controlled `Math.random()`:

- `test` arm swaps both labels to "Try Cloud for free"; `control` arm keeps "Comfy Cloud".
- Sticky: reload with a different random draw keeps the stored variant.
- `docs_nav_cta_exposure` fires with the assigned variant; `docs_nav_cta_clicked` carries `{variant, label, href}`.
- Labels re-apply to late-rendered links (SPA navigation).
