### PR TITLE
docs: metadata batch 2 from the AEO tracker (30 live-verified weak pages)

### DIFF
--- a/basic-concepts/custom-nodes.mdx
+++ b/basic-concepts/custom-nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Nodes"
-description: "Learn about installing, enabling dependencies, updating, disabling, and uninstalling custom nodes in ComfyUI"
+description: "Custom nodes in ComfyUI: how they differ from Comfy Core nodes, plus installing, updating, enabling dependencies, disabling, and uninstalling them."
 icon: "window-maximize"
 ---
 

--- a/basic-concepts/nodes.mdx
+++ b/basic-concepts/nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nodes"
-description: "Understand the concept of a node in ComfyUI."
+description: "Nodes are ComfyUI's fundamental building blocks: independent Comfy Core or custom modules you connect with links to assemble complex workflows."
 icon: "circle"
 ---
 

--- a/built-in-nodes/CheckpointLoaderSimple.mdx
+++ b/built-in-nodes/CheckpointLoaderSimple.mdx
@@ -1,6 +1,6 @@
 ---
-title: "CheckpointLoaderSimple - ComfyUI Built-in Node Documentation"
-description: "Documentation for CheckpointLoaderSimple node."
+title: "CheckpointLoaderSimple Node"
+description: "CheckpointLoaderSimple loads a diffusion checkpoint and splits it into model, CLIP, and VAE, auto-detecting files in ComfyUI/models/checkpoints."
 sidebarTitle: "CheckpointLoaderSimple"
 icon: "circle"
 mode: wide

--- a/built-in-nodes/MultiGPU_WorkUnits.mdx
+++ b/built-in-nodes/MultiGPU_WorkUnits.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MultiGPU_WorkUnits - ComfyUI Built-in Node Documentation"
-description: "Documentation for MultiGPUWorkUnits node."
+title: "MultiGPU CFG Split Node"
+description: "MultiGPU CFG Split node reference: run diffusion processing across multiple identical GPUs in one system, with speedups up to 1.95x."
 sidebarTitle: "MultiGPU_WorkUnits"
 icon: "circle"
 mode: wide

--- a/built-in-nodes/sampling/ksampler.mdx
+++ b/built-in-nodes/sampling/ksampler.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Ksampler - ComfyUI Built-in Node Documentation"
-description: "The Ksampler node is a commonly used sampling node in ComfyUI."
+title: "KSampler Node"
+description: "KSampler node reference: multi-step denoising of latent images with conditioning, sampler, and scheduler, the core of text-to-image workflows."
 sidebarTitle: "Ksampler"
 icon: "circle"
 ---

--- a/development/comfyui-server/startup-flags.mdx
+++ b/development/comfyui-server/startup-flags.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Startup Flags"
 sidebarTitle: "Startup Flags"
-description: "Complete reference for ComfyUI main.py command-line arguments"
+description: "ComfyUI startup flags reference: every main.py command-line argument from comfy/cli_args.py, plus how to add flags to Windows Portable .bat launchers."
 icon: "terminal"
 ---
 

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Linux — Comfy Desktop"
-description: "Build and run Comfy Desktop from source on Linux"
+title: "Comfy Desktop on Linux"
+description: "Comfy Desktop on Linux: no official installer exists. Clone the repo and run from source instead. Requires Ubuntu 22.04+, x64, and Node.js v22 LTS."
 icon: "linux"
 sidebarTitle: "Linux"
 ---

--- a/installation/desktop/overview.mdx
+++ b/installation/desktop/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Comfy Desktop Overview"
-description: "Learn about Comfy Desktop — a modern desktop app for managing multiple ComfyUI installations"
+description: "Comfy Desktop overview: a desktop app that installs, manages, and launches multiple instances of ComfyUI, the node-based engine for generative AI."
 icon: "desktop"
 sidebarTitle: "Overview"
 ---

--- a/interface/credits.mdx
+++ b/interface/credits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Credits Management"
-description: "In this article, we will introduce ComfyUI's credit management features, including how to obtain, use, and view credits."
+description: "Credits for Partner Nodes in ComfyUI: how to buy credits, track usage history, and monitor your balance from Settings > Credits."
 sidebarTitle: "Credits"
 icon: "coins"
 ---

--- a/interface/nodes-2.mdx
+++ b/interface/nodes-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nodes 2.0"
-description: "Learn about Nodes 2.0, the new Vue-based node rendering system in ComfyUI that enables faster development and richer interactions."
+description: "Nodes 2.0 moves ComfyUI node rendering from LiteGraph Canvas to a Vue-based system for faster iteration: what changed and how to enable it."
 sidebarTitle: "Nodes 2.0"
 icon: "sparkles"
 ---

--- a/interface/overview.mdx
+++ b/interface/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Interface Overview"
-description: "In this article, we will briefly introduce the basic user interface of ComfyUI, familiarizing you with the various parts of the ComfyUI interface."
+title: "Interface Overview"
+description: "ComfyUI interface tour covering the workspace parts used to build, organize, and debug workflows in the visual node editor."
 sidebarTitle: "Interface Overview"
 icon: "window"
 ---

--- a/interface/shortcuts.mdx
+++ b/interface/shortcuts.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Keyboard Shortcuts and Custom Settings"
-description: "Keyboard and mouse shortcuts for ComfyUI and related settings"
+title: "Keyboard and Mouse Shortcuts"
+description: "ComfyUI keyboard and mouse shortcuts: the full default list, plus how to view and customize keybindings in the in-app settings menu."
 sidebarTitle: "Keybinding"
 icon: "keyboard"
 ---

--- a/ja/basic-concepts/custom-nodes.mdx
+++ b/ja/basic-concepts/custom-nodes.mdx
@@ -1,13 +1,13 @@
 ---
 title: "カスタムノード"
-description: "ComfyUI におけるカスタムノードのインストール、依存関係の有効化、更新、無効化、アンインストールについて学びます"
+description: "ComfyUI のカスタムノード：Comfy Core ノードとの違い、およびインストール、更新、依存関係の有効化、無効化、アンインストール方法。"
 icon: "window-maximize"
-translationSourceHash: 20bf73d3
+translationSourceHash: 08b636e4
 translationFrom: basic-concepts/custom-nodes.mdx
 translationBlockHashes:
   "About Custom Nodes": bfe7409e
-  "Custom Node Management": 2097f41b
-  "ComfyUI Manager": b3de97a9
+  "Custom Node Management": af7c2a5c
+  "ComfyUI Manager": 17902775
   "Developing a Custom Node": b4016ecf
 ---
 

--- a/ja/basic-concepts/nodes.mdx
+++ b/ja/basic-concepts/nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ノード"
-description: "ComfyUI におけるノードの概念を理解する。"
+description: "ノードは ComfyUI の基本構成要素です。リンクで接続する独立した Comfy Core またはカスタムモジュールで、複雑なワークフローを組み立てます。"
 icon: "circle"
 translationSourceHash: ee1ca352
 translationFrom: basic-concepts/nodes.mdx

--- a/ja/built-in-nodes/CheckpointLoaderSimple.mdx
+++ b/ja/built-in-nodes/CheckpointLoaderSimple.mdx
@@ -1,6 +1,6 @@
 ---
-title: "CheckpointLoaderSimple - ComfyUI Built-in Node Documentation"
-description: "Documentation for CheckpointLoaderSimple node."
+title: "CheckpointLoaderSimple ノード"
+description: "CheckpointLoaderSimple は拡散モデルのチェックポイントを読み込み、モデル・CLIP・VAE に分割し、ComfyUI/models/checkpoints のファイルを自動検出します。"
 sidebarTitle: "CheckpointLoaderSimple"
 icon: "circle"
 mode: wide

--- a/ja/built-in-nodes/MultiGPU_WorkUnits.mdx
+++ b/ja/built-in-nodes/MultiGPU_WorkUnits.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MultiGPU_WorkUnits - ComfyUI Built-in Node Documentation"
-description: "Documentation for MultiGPUWorkUnits node."
+title: "MultiGPU CFG 分割ノード"
+description: "MultiGPU CFG 分割ノードリファレンス：1 台のシステム内の複数の同一 GPU で拡散処理を実行し、最大 1.95 倍の高速化を実現します。"
 sidebarTitle: "MultiGPU_WorkUnits"
 icon: "circle"
 mode: wide

--- a/ja/built-in-nodes/sampling/ksampler.mdx
+++ b/ja/built-in-nodes/sampling/ksampler.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Ksampler - ComfyUI 組み込みノードのドキュメント"
-description: "Ksampler ノードは、ComfyUI でよく使われるサンプリングノードです。"
+title: "KSampler ノード"
+description: "KSampler ノードリファレンス：conditioning・サンプラー・スケジューラーによる潜像の多段階ノイズ除去で、テキストから画像へのワークフローの核です。"
 sidebarTitle: "Ksampler"
 icon: "circle"
 translationSourceHash: 60a1c6f5

--- a/ja/development/comfyui-server/startup-flags.mdx
+++ b/ja/development/comfyui-server/startup-flags.mdx
@@ -1,7 +1,7 @@
 ---
 title: "起動オプション"
 sidebarTitle: "起動オプション"
-description: "ComfyUI main.py コマンドライン引数の完全リファレンス"
+description: "ComfyUI 起動フラグリファレンス：comfy/cli_args.py のすべての main.py コマンドライン引数と、Windows ポータブル版の .bat ランチャーへのフラグ追加方法。"
 icon: "terminal"
 translationSourceHash: 23664520
 translationFrom: development/comfyui-server/startup-flags.mdx

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Linux: Comfyデスクトップ"
-description: "Linux で Comfy Desktop をソースからビルドして実行する"
+title: "Linux 版 Comfy Desktop"
+description: "Linux 版 Comfy Desktop：公式インストーラーは存在しないため、リポジトリをクローンしてソースから実行します。Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
 translationSourceHash: b42848c3

--- a/ja/installation/desktop/overview.mdx
+++ b/ja/installation/desktop/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Comfy Desktop 概要"
-description: "Comfy Desktop：複数の ComfyUI インストールを管理するモダンなデスクトップアプリについて"
+description: "Comfy Desktop の概要：生成 AI 向けノードベースエンジンである ComfyUI の複数インスタンスをインストール・管理・起動するデスクトップアプリ。"
 icon: "desktop"
 sidebarTitle: "概要"
-translationSourceHash: 4221d408
+translationSourceHash: 7ad9cbf9
 translationFrom: installation/desktop/overview.mdx
 ---
 

--- a/ja/interface/credits.mdx
+++ b/ja/interface/credits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "クレジット管理"
-description: "この記事では、ComfyUI のクレジット管理機能について、クレジットの取得、使用、確認方法などを紹介します。"
+description: "ComfyUI の Partner Nodes 向けクレジット：クレジットの購入方法、利用履歴の確認、設定 > クレジット からの残高監視。"
 sidebarTitle: "クレジット"
 icon: "coins"
 translationSourceHash: 7f939609

--- a/ja/interface/nodes-2.mdx
+++ b/ja/interface/nodes-2.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Nodes 2.0"
-description: "ComfyUI の新しい Vue ベースのノードレンダリングシステムである Nodes 2.0 について学び、より迅速な開発と豊かなインタラクションを実現する方法を理解しましょう。"
+description: "Nodes 2.0 は ComfyUI のノードレンダリングを LiteGraph Canvas から Vue ベースのシステムに移行し、反復を高速化します。変更点と有効化方法。"
 sidebarTitle: "Nodes 2.0"
 icon: "sparkles"
-translationSourceHash: 28539a92
+translationSourceHash: ab32579d
 translationFrom: interface/nodes-2.mdx
 ---
 

--- a/ja/interface/overview.mdx
+++ b/ja/interface/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI インターフェース概要"
-description: "この記事では、ComfyUI の基本的なユーザーインターフェースを簡単に紹介し、ComfyUI インターフェースのさまざまな部分に慣れていただきます。"
+title: "インターフェース概要"
+description: "ComfyUI インターフェースツアー：ビジュアルノードエディターでワークフローを構築・整理・デバッグするためのワークスペース各部の解説。"
 sidebarTitle: "インターフェース概要"
 icon: "window"
 translationSourceHash: a604333b

--- a/ja/interface/shortcuts.mdx
+++ b/ja/interface/shortcuts.mdx
@@ -1,9 +1,9 @@
 ---
-title: "ComfyUI のキーボードショートカットとカスタム設定"
-description: "ComfyUI のキーボードとマウスのショートカットおよび関連設定"
+title: "キーボードとマウスのショートカット"
+description: "ComfyUI のキーボードとマウスのショートカット：デフォルトの全一覧と、アプリ内設定メニューでのキーバインドの表示・カスタマイズ方法。"
 sidebarTitle: "ショートカット"
 icon: "keyboard"
-translationSourceHash: 457d7181
+translationSourceHash: 9f1f3c15
 translationFrom: interface/shortcuts.mdx
 ---
 

--- a/ja/manager/configuration.mdx
+++ b/ja/manager/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: 設定
+title: "ComfyUI-Manager 設定"
 sidebarTitle: 設定
-description: ComfyUI-Manager の設定を構成します
+description: "ComfyUI-Manager 設定リファレンス：config.ini のパスとオプション、セキュリティレベル、V3.38 で導入された保護システムパス。"
 translationSourceHash: 632d3536
 translationFrom: manager/configuration.mdx
 translationBlockHashes:

--- a/ja/manager/troubleshooting.mdx
+++ b/ja/manager/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: トラブルシューティング
+title: "ComfyUI-Manager トラブルシューティング"
 sidebarTitle: トラブルシューティング
-description: 一般的な ComfyUI-Manager の問題を解決します
+description: "ComfyUI-Manager のトラブルシューティング：config.ini のカスタム git 実行ファイルパス、Manager の自己更新失敗、インストールエラーの修正。"
 translationSourceHash: 574d8622
 translationFrom: manager/troubleshooting.mdx
 translationBlockHashes:

--- a/ja/specs/workflow_json.mdx
+++ b/ja/specs/workflow_json.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ワークフロー JSON"
-description: "ComfyUI ワークフローの JSON スキーマ。"
+description: "ComfyUI ワークフローファイル形式（v1.0 および旧 v0.4）の Workflow JSON スキーマ。ノード、リンク、グループ、バージョンフィールドを網羅。"
 translationSourceHash: d25be209
 translationFrom: specs/workflow_json.mdx
 translationBlockHashes:

--- a/ja/troubleshooting/custom-node-issues.mdx
+++ b/ja/troubleshooting/custom-node-issues.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI の問題をトラブルシューティングして解決する方法"
-description: "カスタムノードと拡張機能によって引き起こされる問題をトラブルシューティングし修正します"
+title: "カスタムノードの問題のトラブルシューティング"
+description: "ComfyUI のカスタムノード問題の修正：--disable-all-custom-nodes ですべてのカスタムノードを無効化し、二分探索で問題のノードを特定・修正・削除します。"
 icon: "puzzle-piece"
 sidebarTitle: "カスタムノードの問題"
 translationSourceHash: 09e72de3

--- a/ja/troubleshooting/overview.mdx
+++ b/ja/troubleshooting/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI の問題のトラブルシューティングと解決方法"
-description: "一般的な ComfyUI の問題、解決策、および効果的なバグ報告方法"
+description: "ComfyUI トラブルシューティングガイド：まずカスタムノードを切り分け、一般的なコア問題を修正し、適切な詳細を添えてバグレポートを提出します。"
 icon: "lightbulb"
 sidebarTitle: "概要"
 translationSourceHash: 9e3cacd4

--- a/ja/tutorials/3d/hunyuan3D-2.mdx
+++ b/ja/tutorials/3d/hunyuan3D-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Hunyuan3D-2 例"
-description: "このガイドでは、ComfyUI で Hunyuan3D-2 を使用して 3D アセットを生成する方法を説明します。"
+description: "ComfyUI の Hunyuan3D 2.0：腾讯のオープンソース 2 段階モデルで、テキストまたは画像からテクスチャ付き 3D モデルを生成します。まず形状、次にテクスチャ。"
 sidebarTitle: "Hunyuan3D-2"
 translationSourceHash: 8798b946
 translationFrom: tutorials/3d/hunyuan3D-2.mdx

--- a/ja/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/ja/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ACE-Step ネイティブサンプル"
-description: "本ガイドでは、ComfyUI で ACE-Step モデルを用いてダイナミックな音楽を作成する方法を説明します"
+description: "ComfyUI での ACE-Step 音楽生成：StepFun と ACE Studio の Apache-2.0 オープンソースモデルによるテキストから音楽への生成と音楽編集ワークフロー。"
 sidebarTitle: "ACE-Step 1.0"
 translationSourceHash: b3044926
 translationFrom: tutorials/audio/ace-step/ace-step-v1.mdx

--- a/ja/tutorials/basic/inpaint.mdx
+++ b/ja/tutorials/basic/inpaint.mdx
@@ -1,13 +1,13 @@
 ---
 title: ComfyUI 局部再描画ワークフロー
-description: このガイドでは、ComfyUIにおける局部再描画（インペインティング）ワークフローについて紹介し、実際のインペインティング例を解説するとともに、マスクエディタの使用方法などについても説明します。
+description: "ComfyUI インペイントチュートリアル：画像の一部を編集し、マスクエディターでマスクを描き、ワークフローで VAE Encode (for Inpainting) ノードを接続します。"
 sidebarTitle: "局部再描画"
-translationSourceHash: 8bfe7bac
+translationSourceHash: 08fe752b
 translationFrom: tutorials/basic/inpaint.mdx
 translationBlockHashes:
   "_intro": 5cef9232
   "About Inpainting": 7bf3aef3
-  "ComfyUI Inpainting Workflow Example": 44a609f4
+  "ComfyUI Inpainting Workflow Example": 3a49cdc2
   "VAE Encoder (for Inpainting) Node": 222c8a2c
 ---
 

--- a/ja/tutorials/basic/outpaint.mdx
+++ b/ja/tutorials/basic/outpaint.mdx
@@ -1,13 +1,13 @@
 ---
-title: "ComfyUI 拡張描画（Outpainting）ワークフローの例"
-description: このガイドでは、ComfyUIにおける拡張描画（Outpainting）のワークフローについて紹介し、実際の拡張描画の例を順に説明します
+title: "アウトペインティングワークフロー例"
+description: "ComfyUI のアウトペインティングワークフロー：Pad Image for Outpainting ノードとインペイントモデルの手法で、画像を境界の外に拡張します。"
 sidebarTitle: "拡張描画"
-translationSourceHash: 67107df5
+translationSourceHash: 30f50d19
 translationFrom: tutorials/basic/outpaint.mdx
 translationBlockHashes:
   "_intro": 7cf1c763
   "About Outpainting": decb981d
-  "ComfyUI Outpainting Workflow Example Explanation": e06f66e2
+  "ComfyUI Outpainting Workflow Example Explanation": 52ce114d
 ---
 
 このガイドでは、AI画像生成における拡張描画（Outpainting）の概念と、ComfyUIで拡張描画ワークフローを作成する方法について解説します。以下のような内容をカバーします：

--- a/ja/tutorials/controlnet/controlnet.mdx
+++ b/ja/tutorials/controlnet/controlnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ControlNet ComfyUIチュートリアル | AI画像生成・制御ガイド"
-description: "ControlNetは、エッジ、深度、ポーズなどの条件を使ってComfyUIでのAI画像生成を細かく制御できます。ワークフロー、モデル設定、関連ノードを紹介します。"
+description: "ComfyUI の ControlNet：試行錯誤のプロンプトではなく条件画像で画像生成を制御し、ステップバイステップのワークフロー例も紹介します。"
 sidebarTitle: "ControlNet"
 translationSourceHash: b14c7383
 translationFrom: tutorials/controlnet/controlnet.mdx

--- a/ja/tutorials/controlnet/depth-controlnet.mdx
+++ b/ja/tutorials/controlnet/depth-controlnet.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Depth ControlNet の使用例"
-description: "本ガイドでは、Depth ControlNet の基本概念を紹介し、ComfyUI で対応する画像を生成する方法を解説します"
+title: "Depth ControlNet ワークフロー例"
+description: "ComfyUI の Depth ControlNet ワークフロー：深度マップが距離をどう符号化するか、また画像生成時にシーン構造を制御する方法。"
 sidebarTitle: "Depth ControlNet"
 translationSourceHash: 61508e7c
 translationFrom: tutorials/controlnet/depth-controlnet.mdx

--- a/ja/tutorials/flux/flux-1-controlnet.mdx
+++ b/ja/tutorials/flux/flux-1-controlnet.mdx
@@ -1,14 +1,14 @@
 ---
 title: "ComfyUI Flux.1 ControlNet の使用例"
-description: "本ガイドでは、Flux.1 ControlNet を用いたワークフローの使用例を紹介します。"
+description: "ComfyUI 向け FLUX.1 Canny・Depth ワークフロー例：Black Forest Labs の FLUX.1 Tools で FLUX.1 に ControlNet 風の構造制御を追加します。"
 sidebarTitle: "Flux.1 ControlNet"
-translationSourceHash: f7ccc37b
+translationSourceHash: 4e1904ca
 translationFrom: tutorials/flux/flux-1-controlnet.mdx
 translationBlockHashes:
   "_intro": a69fbfae
   "FLUX.1 ControlNet Model Introduction": c242319b
-  "FLUX.1-Canny-dev Complete Version Workflow": 8e23a9ea
-  "FLUX.1-Depth-dev-lora Workflow": 435b20fc
+  "FLUX.1-Canny-dev Complete Version Workflow": 62888620
+  "FLUX.1-Depth-dev-lora Workflow": 7aa4e7e1
   "Community Versions of Flux Controlnets": 29728dcf
 ---
 

--- a/ja/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/ja/tutorials/flux/flux-1-kontext-dev.mdx
@@ -1,14 +1,14 @@
 ---
 title: "ComfyUI Flux Kontext Dev ネイティブワークフローの例"
-description: "ComfyUI Flux Kontext Dev ネイティブワークフローの例。"
+description: "ComfyUI 向け FLUX.1 Kontext Dev ワークフロー：Black Forest Labs のオープンソース 12B マルチモーダル編集モデルで、テキストと画像入力を用いて画像を編集します。"
 sidebarTitle: "Flux.1 Kontext Dev"
-translationSourceHash: 2342a0b8
+translationSourceHash: 644dbe55
 translationFrom: tutorials/flux/flux-1-kontext-dev.mdx
 translationBlockHashes:
   "_intro": 51c48128
   "About FLUX.1 Kontext Dev": bb2f00f7
   "Model Download": e6b40970
-  "Flux.1 Kontext Dev Workflow": 79058f2d
+  "Flux.1 Kontext Dev Workflow": 5284c9c2
 ---
 
 import PromptTechniques from "/snippets/ja/tutorials/flux/prompt-techniques.mdx";

--- a/ja/tutorials/image/ideogram/ideogram-v4.mdx
+++ b/ja/tutorials/image/ideogram/ideogram-v4.mdx
@@ -1,12 +1,12 @@
 ---
 title: "ComfyUI Ideogram 4.0 オープンソースモデルチュートリアル"
-description: "ComfyUI で Ideogram 4.0 オープンソースモデルを使用する方法"
+description: "ComfyUI の Ideogram 4.0：Ideogram のオープンソース text-to-image モデルをローカルで実行。正確なテキストレンダリングと、JSON または自然言語スタイルのプロンプトに対応。"
 sidebarTitle: "Ideogram 4.0"
-translationSourceHash: e667f2e0
+translationSourceHash: e27917ad
 translationFrom: tutorials/image/ideogram/ideogram-v4.mdx
 translationBlockHashes:
   "_intro": e87a6658
-  "Ideogram 4.0 Text-to-Image Workflow": 847be061
+  "Ideogram 4.0 Text-to-Image Workflow": 29499261
   "Live Conversation with Ideogram & ComfyOrg": 9f3809e0
 ---
 

--- a/ja/tutorials/partner-nodes/luma/luma-image-to-video.mdx
+++ b/ja/tutorials/partner-nodes/luma/luma-image-to-video.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Luma Image to Video パートナーノード ComfyUI 公式サンプル"
-description: "ComfyUI で Luma Image to Video パートナーノードを活用する方法を学びましょう"
+title: "Luma Image to Video Partner ノード"
+description: "Luma Image to Video Partner ノードのワークフロー：ComfyUI で静止画像を動画に変換します。必要なクレジットとノードパラメータを含みます。"
 sidebarTitle: "Luma Image to Video"
-translationSourceHash: d1417e7a
+translationSourceHash: 8c52dad9
 translationFrom: tutorials/partner-nodes/luma/luma-image-to-video.mdx
 ---
 

--- a/ja/tutorials/partner-nodes/overview.mdx
+++ b/ja/tutorials/partner-nodes/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "パートナー ノード"
-description: "本記事では、ComfyUI のパートナー ノードおよび関連情報を紹介します。"
+description: "Partner Nodes は ComfyUI 内の API リクエストを通じて OpenAI、Kling、Luma などのクローズドソースモデルを呼び出します。概要、クレジット、使い方を解説。"
 sidebarTitle: "概要"
 translationSourceHash: 1fa2edb3
 translationFrom: tutorials/partner-nodes/overview.mdx

--- a/ja/tutorials/partner-nodes/pricing.mdx
+++ b/ja/tutorials/partner-nodes/pricing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "料金"
-description: "この記事では、現在のパートナーノードの料金を一覧表示します。"
+title: "Partner Node 価格"
+description: "Anthropic、OpenAI、Kling、Luma など全プロバイダーの Partner Node クレジット価格。モデル、トークン種別、生成種別ごとに分類。"
 sidebarTitle: "料金"
 mode: "wide"
 translationSourceHash: e1f6ba3a

--- a/ja/tutorials/video/wan/wan-ati.mdx
+++ b/ja/tutorials/video/wan/wan-ati.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Wan ATI ComfyUI ネイティブワークフローチュートリアル"
-description: "動画生成における軌道制御の使用方法。"
+title: "Wan ATI ネイティブワークフロー"
+description: "ComfyUI の Wan ATI トラジェクトリ制御：軌跡を描いて生成動画のオブジェクト・領域・カメラモーションを操作します。Wan2.1 ベース。"
 sidebarTitle: "WAN2l1 ATI"
 translationSourceHash: b030360b
 translationFrom: tutorials/video/wan/wan-ati.mdx

--- a/ko/basic-concepts/custom-nodes.mdx
+++ b/ko/basic-concepts/custom-nodes.mdx
@@ -1,13 +1,13 @@
 ---
 title: "커스텀 노드"
-description: "ComfyUI에서 커스텀 노드 설치, 의존성 활성화, 업데이트, 비활성화, 제거에 대해 알아보세요"
+description: "ComfyUI의 커스텀 노드: Comfy Core 노드와의 차이점과 설치, 업데이트, 의존성 활성화, 비활성화, 제거 방법."
 icon: "window-maximize"
-translationSourceHash: 20bf73d3
+translationSourceHash: 08b636e4
 translationFrom: basic-concepts/custom-nodes.mdx
 translationBlockHashes:
   "About Custom Nodes": bfe7409e
-  "Custom Node Management": 2097f41b
-  "ComfyUI Manager": b3de97a9
+  "Custom Node Management": af7c2a5c
+  "ComfyUI Manager": 17902775
   "Developing a Custom Node": b4016ecf
 ---
 ## 커스텀 노드 소개

--- a/ko/basic-concepts/nodes.mdx
+++ b/ko/basic-concepts/nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "노드"
-description: "ComfyUI에서 노드의 개념을 이해하세요."
+description: "노드는 ComfyUI의 기본 구성 요소입니다. 링크로 연결하는 독립적인 Comfy Core 또는 커스텀 모듈로 복잡한 워크플로를 구성합니다."
 icon: "circle"
 translationSourceHash: ee1ca352
 translationFrom: basic-concepts/nodes.mdx

--- a/ko/built-in-nodes/CheckpointLoaderSimple.mdx
+++ b/ko/built-in-nodes/CheckpointLoaderSimple.mdx
@@ -1,6 +1,6 @@
 ---
-title: "CheckpointLoaderSimple - ComfyUI Built-in Node Documentation"
-description: "Documentation for CheckpointLoaderSimple node."
+title: "CheckpointLoaderSimple 노드"
+description: "CheckpointLoaderSimple은 확산 모델 체크포인트를 로드하여 모델, CLIP, VAE로 분리하고 ComfyUI/models/checkpoints의 파일을 자동 감지합니다."
 sidebarTitle: "CheckpointLoaderSimple"
 icon: "circle"
 mode: wide

--- a/ko/built-in-nodes/MultiGPU_WorkUnits.mdx
+++ b/ko/built-in-nodes/MultiGPU_WorkUnits.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MultiGPU_WorkUnits - ComfyUI Built-in Node Documentation"
-description: "Documentation for MultiGPUWorkUnits node."
+title: "MultiGPU CFG 분할 노드"
+description: "MultiGPU CFG 분할 노드 레퍼런스: 한 시스템의 여러 동일 GPU에서 확산 처리를 실행하여 최대 1.95배까지 속도를 높입니다."
 sidebarTitle: "MultiGPU_WorkUnits"
 icon: "circle"
 mode: wide

--- a/ko/built-in-nodes/sampling/ksampler.mdx
+++ b/ko/built-in-nodes/sampling/ksampler.mdx
@@ -1,0 +1,101 @@
+---
+title: "KSampler 노드"
+description: "KSampler 노드 레퍼런스: conditioning, sampler, scheduler를 사용한 잠재 이미지의 다단계 디노이징으로, 텍스트-이미지 워크플로의 핵심입니다."
+sidebarTitle: "Ksampler"
+icon: "circle"
+---
+
+![Ksampler](/images/built-in-nodes/sampling/ksampler.jpg)
+
+
+KSampler 노드는 잠재 이미지(latent image)에 대해 다단계 디노이징 샘플링을 수행합니다. 양성 및 음성 조건(prompt)을 결합하고 지정된 샘플링 알고리즘과 스케줄러를 사용하여 고품질 잠재 이미지를 생성합니다. 텍스트-이미지, 이미지-이미지와 같은 AI 이미지 생성 워크플로에서 일반적으로 사용됩니다.
+
+## 매개변수 설명
+
+### 입력 매개변수
+| 매개변수     | 유형         | 필수 | 기본값 | 설명                                                            |
+| ------------ | ------------ | ---- | ------ | ------------------------------------------------------------ |
+| model        | MODEL        | 예   | 없음   | 디노이징에 사용되는 모델(예: Stable Diffusion 모델)              |
+| seed         | INT          | 예   | 0      | 재현 가능한 결과를 보장하는 난수 시드                             |
+| steps        | INT          | 예   | 20     | 디노이징 단계 수. 단계가 많을수록 세부 묘사가 정교해지지만 생성이 느려집니다 |
+| cfg          | FLOAT        | 예   | 8.0    | Classifier-Free Guidance 스케일. 값이 높을수록 프롬프트에 더 잘 맞지만 너무 높으면 품질에 영향을 줍니다 |
+| sampler_name | 열거형       | 예   | 없음   | 샘플링 알고리즘 이름. 생성 속도, 스타일, 품질에 영향을 줍니다      |
+| scheduler    | 열거형       | 예   | 없음   | 노이즈 제거 과정을 제어하는 스케줄러                              |
+| positive     | CONDITIONING | 예   | 없음   | 이미지에 포함할 내용을 설명하는 양성 조건                          |
+| negative     | CONDITIONING | 예   | 없음   | 이미지에서 제외할 내용을 설명하는 음성 조건                        |
+| latent_image | LATENT       | 예   | 없음   | 디노이징할 잠재 이미지. 일반적으로 노이즈 또는 이전 단계의 출력     |
+| denoise      | FLOAT        | 예   | 1.0    | 디노이징 강도. 1.0은 완전 디노이징, 낮을수록 원본 구조를 유지하며 이미지-이미지에 적합합니다 |
+
+### 출력 매개변수
+| 출력    | 유형   | 설명                                         |
+| ------- | ------ | ------------------------------------------- |
+| samples | LATENT | 디노이징된 잠재 이미지. 최종 이미지로 디코딩할 수 있습니다 |
+
+## 사용 예시
+
+<Card title="Stable diffusion 1.5 텍스트-이미지 워크플로 예시" icon="book" href="/ko/tutorials/basic/text-to-image">
+Stable diffusion 1.5 텍스트-이미지 워크플로 예시
+</Card>
+<Card title="Stable diffusion 1.5 이미지-이미지 워크플로 예시" icon="book" href="/ko/tutorials/basic/image-to-image">
+Stable diffusion 1.5 이미지-이미지 워크플로 예시
+</Card>
+
+## 소스 코드
+
+[2025년 5월 15일 업데이트]
+
+```Python
+
+def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent, denoise=1.0, disable_noise=False, start_step=None, last_step=None, force_full_denoise=False):
+    latent_image = latent["samples"]
+    latent_image = comfy.sample.fix_empty_latent_channels(model, latent_image)
+
+    if disable_noise:
+        noise = torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
+    else:
+        batch_inds = latent["batch_index"] if "batch_index" in latent else None
+        noise = comfy.sample.prepare_noise(latent_image, seed, batch_inds)
+
+    noise_mask = None
+    if "noise_mask" in latent:
+        noise_mask = latent["noise_mask"]
+
+    callback = latent_preview.prepare_callback(model, steps)
+    disable_pbar = not comfy.utils.PROGRESS_BAR_ENABLED
+    samples = comfy.sample.sample(model, noise, steps, cfg, sampler_name, scheduler, positive, negative, latent_image,
+                                  denoise=denoise, disable_noise=disable_noise, start_step=start_step, last_step=last_step,
+                                  force_full_denoise=force_full_denoise, noise_mask=noise_mask, callback=callback, disable_pbar=disable_pbar, seed=seed)
+    out = latent.copy()
+    out["samples"] = samples
+    return (out, )
+
+
+class KSampler:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL", {"tooltip": "The model used for denoising the input latent."}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True, "tooltip": "The random seed used for creating the noise."}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 10000, "tooltip": "The number of steps used in the denoising process."}),
+                "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "step":0.1, "round": 0.01, "tooltip": "The Classifier-Free Guidance scale balances creativity and adherence to the prompt. Higher values result in images more closely matching the prompt however too high values will negatively impact quality."}),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS, {"tooltip": "The algorithm used when sampling, this can affect the quality, speed, and style of the generated output."}),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS, {"tooltip": "The scheduler controls how noise is gradually removed to form the image."}),
+                "positive": ("CONDITIONING", {"tooltip": "The conditioning describing the attributes you want to include in the image."}),
+                "negative": ("CONDITIONING", {"tooltip": "The conditioning describing the attributes you want to exclude from the image."}),
+                "latent_image": ("LATENT", {"tooltip": "The latent image to denoise."}),
+                "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "The amount of denoising applied, lower values will maintain the structure of the initial image allowing for image to image sampling."}),
+            }
+        }
+
+    RETURN_TYPES = ("LATENT",)
+    OUTPUT_TOOLTIPS = ("The denoised latent.",)
+    FUNCTION = "sample"
+
+    CATEGORY = "sampling"
+    DESCRIPTION = "Uses the provided model, positive and negative conditioning to denoise the latent image."
+
+    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise=1.0):
+        return common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise=denoise)
+
+```

--- a/ko/development/comfyui-server/startup-flags.mdx
+++ b/ko/development/comfyui-server/startup-flags.mdx
@@ -1,7 +1,7 @@
 ---
 title: "시작 플래그"
 sidebarTitle: "시작 플래그"
-description: "ComfyUI main.py 명령줄 인수에 대한 완전한 참조"
+description: "ComfyUI 시작 플래그 레퍼런스: comfy/cli_args.py의 모든 main.py 명령줄 인수와 Windows 휴대용 .bat 런처에 플래그를 추가하는 방법."
 icon: "terminal"
 translationSourceHash: 23664520
 translationFrom: development/comfyui-server/startup-flags.mdx

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Linux: Comfy Desktop"
-description: "Linux에서 소스로부터 Comfy Desktop을 빌드하고 실행하기"
+title: "Linux용 Comfy Desktop"
+description: "Linux용 Comfy Desktop: 공식 설치 프로그램이 없으므로 리포지토리를 클론하여 소스에서 실행합니다. Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
 translationSourceHash: b42848c3

--- a/ko/installation/desktop/overview.mdx
+++ b/ko/installation/desktop/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Comfy Desktop 개요"
-description: "Comfy Desktop — 여러 ComfyUI 설치를 관리하는 최신 데스크톱 앱에 대해 알아보세요"
+description: "Comfy Desktop 개요: 생성형 AI를 위한 노드 기반 엔진인 ComfyUI의 여러 인스턴스를 설치, 관리, 실행하는 데스크톱 앱."
 icon: "desktop"
 sidebarTitle: "개요"
-translationSourceHash: 4221d408
+translationSourceHash: 7ad9cbf9
 translationFrom: installation/desktop/overview.mdx
 ---
 

--- a/ko/interface/credits.mdx
+++ b/ko/interface/credits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "크레딧 관리"
-description: "이 기사에서는 ComfyUI의 크레딧 관리 기능, 즉 크레딧을 획득하고 사용하며 조회하는 방법을 소개합니다."
+description: "ComfyUI Partner Nodes용 크레딧: 크레딧 구매 방법, 사용 내역 확인, 설정 > 크레딧에서 잔액 모니터링."
 sidebarTitle: "크레딧"
 icon: "coins"
 translationSourceHash: 7f939609

--- a/ko/interface/nodes-2.mdx
+++ b/ko/interface/nodes-2.mdx
@@ -1,9 +1,9 @@
 ---
 title: "노드 2.0"
-description: "ComfyUI의 새로운 Vue 기반 노드 렌더링 시스템인 노드 2.0에 대해 알아보세요. 이 시스템은 더 빠른 개발과 풍부한 상호작용을 가능하게 합니다."
+description: "Nodes 2.0는 ComfyUI 노드 렌더링을 LiteGraph Canvas에서 Vue 기반 시스템으로 전환하여 반복 작업을 더 빠르게 합니다. 변경 사항과 활성화 방법."
 sidebarTitle: "노드 2.0"
 icon: "sparkles"
-translationSourceHash: 28539a92
+translationSourceHash: ab32579d
 translationFrom: interface/nodes-2.mdx
 ---
 

--- a/ko/interface/overview.mdx
+++ b/ko/interface/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI 인터페이스 개요"
-description: "이 글에서는 ComfyUI의 기본 사용자 인터페이스를 간략히 소개하며, ComfyUI 인터페이스의 다양한 부분에 익숙해지도록 안내합니다."
+title: "인터페이스 개요"
+description: "ComfyUI 인터페이스 둘러보기: 시각적 노드 편집기에서 워크플로를 구축, 구성, 디버깅하는 데 사용되는 작업 공간 부분을 소개합니다."
 sidebarTitle: "인터페이스 개요"
 icon: "window"
 translationSourceHash: a604333b

--- a/ko/interface/shortcuts.mdx
+++ b/ko/interface/shortcuts.mdx
@@ -1,9 +1,9 @@
 ---
-title: "ComfyUI 키보드 단축키 및 맞춤 설정"
-description: "ComfyUI용 키보드 및 마우스 단축키와 관련 설정"
+title: "키보드 및 마우스 단축키"
+description: "ComfyUI 키보드 및 마우스 단축키: 기본 전체 목록과 앱 내 설정 메뉴에서 키 바인딩을 확인하고 사용자 지정하는 방법."
 sidebarTitle: "키 바인딩"
 icon: "keyboard"
-translationSourceHash: 457d7181
+translationSourceHash: 9f1f3c15
 translationFrom: interface/shortcuts.mdx
 ---
 

--- a/ko/manager/configuration.mdx
+++ b/ko/manager/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: 구성
+title: "ComfyUI-Manager 설정"
 sidebarTitle: 설정
-description: "ComfyUI-Manager 설정 구성"
+description: "ComfyUI-Manager 설정 레퍼런스: config.ini 경로 및 옵션, 보안 수준, V3.38에서 도입된 보호 시스템 경로."
 translationSourceHash: 632d3536
 translationFrom: manager/configuration.mdx
 translationBlockHashes:

--- a/ko/manager/troubleshooting.mdx
+++ b/ko/manager/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: 문제 해결
+title: "ComfyUI-Manager 문제 해결"
 sidebarTitle: 문제 해결
-description: "일반적인 ComfyUI-Manager 문제 해결하기"
+description: "ComfyUI-Manager 문제 해결: config.ini의 사용자 지정 git 실행 파일 경로, Manager 자체 업데이트 실패, 설치 오류 수정."
 translationSourceHash: 574d8622
 translationFrom: manager/troubleshooting.mdx
 translationBlockHashes:

--- a/ko/specs/workflow_json.mdx
+++ b/ko/specs/workflow_json.mdx
@@ -1,6 +1,6 @@
 ---
 title: "워크플로 JSON"
-description: "ComfyUI 워크플로를 위한 JSON 스키마."
+description: "ComfyUI 워크플로 파일 형식(v1.0 및 레거시 v0.4)의 Workflow JSON 스키마로, 노드, 링크, 그룹, 버전 필드를 다룹니다."
 translationSourceHash: d25be209
 translationFrom: specs/workflow_json.mdx
 translationBlockHashes:

--- a/ko/troubleshooting/custom-node-issues.mdx
+++ b/ko/troubleshooting/custom-node-issues.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI 문제 해결 및 해결 방법"
-description: "커스텀 노드와 확장 기능으로 인한 문제를 해결하고 고치세요"
+title: "커스텀 노드 문제 해결"
+description: "ComfyUI 커스텀 노드 문제 수정: --disable-all-custom-nodes로 모든 커스텀 노드를 비활성화한 뒤 이분 탐색으로 문제 노드를 격리, 수정, 제거합니다."
 icon: "puzzle-piece"
 sidebarTitle: "커스텀 노드 문제"
 translationSourceHash: 09e72de3

--- a/ko/troubleshooting/overview.mdx
+++ b/ko/troubleshooting/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI 문제 해결 및 해결 방법"
-description: "일반적인 ComfyUI 문제, 해결 방법 및 버그를 효과적으로 보고하는 방법"
+description: "ComfyUI 문제 해결 가이드: 먼저 커스텀 노드를 배제하고, 일반적인 핵심 문제를 수정하며, 올바른 세부 정보와 함께 버그 리포트를 제출합니다."
 icon: "lightbulb"
 sidebarTitle: "개요"
 translationSourceHash: 9e3cacd4

--- a/ko/tutorials/3d/hunyuan3D-2.mdx
+++ b/ko/tutorials/3d/hunyuan3D-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Hunyuan3D-2 예시"
-description: "이 가이드에서는 ComfyUI에서 Hunyuan3D-2를 사용해 3D 자산을 생성하는 방법을 보여드립니다."
+description: "ComfyUI의 Hunyuan3D 2.0: 텐센트의 오픈소스 2단계 모델로 텍스트 또는 이미지에서 텍스처가 있는 3D 모델을 생성합니다. 먼저 지오메트리, 그다음 텍스처."
 sidebarTitle: "Hunyuan3D-2"
 translationSourceHash: 8798b946
 translationFrom: tutorials/3d/hunyuan3D-2.mdx

--- a/ko/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/ko/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ACE-Step 네이티브 예제"
-description: "이 가이드는 ComfyUI에서 ACE-Step 모델을 사용해 다이내믹한 음악을 만드는 데 도움을 줄 것입니다."
+description: "ComfyUI의 ACE-Step 음악 생성: StepFun과 ACE Studio의 Apache-2.0 오픈소스 모델을 사용한 텍스트-음악 및 음악 편집 워크플로."
 sidebarTitle: "ACE-Step 1.0"
 translationSourceHash: b3044926
 translationFrom: tutorials/audio/ace-step/ace-step-v1.mdx

--- a/ko/tutorials/basic/inpaint.mdx
+++ b/ko/tutorials/basic/inpaint.mdx
@@ -1,13 +1,13 @@
 ---
 title: ComfyUI 인페인팅 워크플로우
-description: "이 가이드에서는 ComfyUI의 인페인팅 워크플로우를 소개하고, 인페인팅 예시를 따라가며 마스크 편집기 사용법과 같은 주제를 다룹니다."
+description: "ComfyUI 인페인팅 튜토리얼: 이미지의 일부를 편집하고, 마스크 편집기로 마스크를 그리며, 워크플로에서 VAE Encode(for Inpainting) 노드를 연결합니다."
 sidebarTitle: "인페인트"
-translationSourceHash: 8bfe7bac
+translationSourceHash: 08fe752b
 translationFrom: tutorials/basic/inpaint.mdx
 translationBlockHashes:
   "_intro": 5cef9232
   "About Inpainting": 7bf3aef3
-  "ComfyUI Inpainting Workflow Example": 44a609f4
+  "ComfyUI Inpainting Workflow Example": 3a49cdc2
   "VAE Encoder (for Inpainting) Node": 222c8a2c
 ---
 

--- a/ko/tutorials/basic/outpaint.mdx
+++ b/ko/tutorials/basic/outpaint.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI 아웃페인팅 워크플로우 예시"
-description: "이 가이드에서는 ComfyUI의 아웃페인팅 워크플로우를 소개하고, 아웃페인팅 예시를 통해 안내해 드립니다."
+title: "아웃페인팅 워크플로 예제"
+description: "ComfyUI의 아웃페인팅 워크플로: Pad Image for Outpainting 노드와 인페인팅 모델 기법을 사용하여 이미지를 경계 밖으로 확장합니다."
 sidebarTitle: "아웃페인팅"
 translationSourceHash: 30f50d19
 translationFrom: tutorials/basic/outpaint.mdx

--- a/ko/tutorials/controlnet/controlnet.mdx
+++ b/ko/tutorials/controlnet/controlnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ControlNet 사용 예시"
-description: "이 가이드에서는 ControlNet의 기본 개념을 소개하고 ComfyUI에서 해당 이미지를 생성하는 방법을 보여드립니다."
+description: "ComfyUI의 ControlNet: 시행착오 프롬프트 대신 조건 이미지로 이미지 생성을 제어하며, 단계별 워크플로 예제를 제공합니다."
 sidebarTitle: "ControlNet"
 translationSourceHash: b14c7383
 translationFrom: tutorials/controlnet/controlnet.mdx

--- a/ko/tutorials/controlnet/depth-controlnet.mdx
+++ b/ko/tutorials/controlnet/depth-controlnet.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Depth ControlNet 사용 예시"
-description: "이 가이드에서는 Depth ControlNet의 기본 개념을 소개하고 ComfyUI에서 해당 이미지를 생성하는 방법을 보여드립니다."
+title: "Depth ControlNet 워크플로 예제"
+description: "ComfyUI의 Depth ControlNet 워크플로: 깊이 맵이 거리를 인코딩하는 방식과 이미지 생성 중 장면 구조를 제어하는 데 사용하는 방법."
 sidebarTitle: "Depth ControlNet"
 translationSourceHash: 61508e7c
 translationFrom: tutorials/controlnet/depth-controlnet.mdx

--- a/ko/tutorials/flux/flux-1-controlnet.mdx
+++ b/ko/tutorials/flux/flux-1-controlnet.mdx
@@ -1,13 +1,13 @@
 ---
 title: "ComfyUI Flux.1 ControlNet 예제"
-description: "이 가이드에서는 Flux.1 ControlNet을 사용한 워크플로우 예제를 보여드립니다."
+description: "ComfyUI용 FLUX.1 Canny 및 Depth 워크플로 예제: Black Forest Labs의 FLUX.1 Tools로 FLUX.1에 ControlNet 스타일 구조 제어를 추가합니다."
 sidebarTitle: "Flux.1 ControlNet"
-translationSourceHash: 4c4cc656
+translationSourceHash: 4e1904ca
 translationFrom: tutorials/flux/flux-1-controlnet.mdx
 translationBlockHashes:
   "_intro": a69fbfae
   "FLUX.1 ControlNet Model Introduction": c242319b
-  "FLUX.1-Canny-dev Complete Version Workflow": 8e23a9ea
+  "FLUX.1-Canny-dev Complete Version Workflow": 62888620
   "FLUX.1-Depth-dev-lora Workflow": 7aa4e7e1
   "Community Versions of Flux Controlnets": 29728dcf
 ---

--- a/ko/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/ko/tutorials/flux/flux-1-kontext-dev.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Flux Kontext Dev 네이티브 워크플로우 예시"
-description: "ComfyUI Flux Kontext Dev 네이티브 워크플로우 예시."
+description: "ComfyUI용 FLUX.1 Kontext Dev 워크플로: Black Forest Labs의 오픈소스 12B 멀티모달 편집 모델로 텍스트 및 이미지 입력을 사용해 이미지를 편집합니다."
 sidebarTitle: "Flux.1 Kontext Dev"
 translationSourceHash: 644dbe55
 translationFrom: tutorials/flux/flux-1-kontext-dev.mdx

--- a/ko/tutorials/image/ideogram/ideogram-v4.mdx
+++ b/ko/tutorials/image/ideogram/ideogram-v4.mdx
@@ -1,12 +1,12 @@
 ---
 title: "ComfyUI Ideogram 4.0 오픈소스 모델 튜토리얼"
-description: "ComfyUI에서 Ideogram 4.0 오픈소스 모델을 사용하는 방법 알아보기"
+description: "ComfyUI의 Ideogram 4.0: Ideogram의 오픈소스 텍스트-이미지 모델을 로컬에서 실행하며, 정확한 텍스트 렌더링과 JSON 또는 자연어 스타일 프롬프트를 지원합니다."
 sidebarTitle: "Ideogram 4.0"
-translationSourceHash: e667f2e0
+translationSourceHash: e27917ad
 translationFrom: tutorials/image/ideogram/ideogram-v4.mdx
 translationBlockHashes:
   "_intro": e87a6658
-  "Ideogram 4.0 Text-to-Image Workflow": 847be061
+  "Ideogram 4.0 Text-to-Image Workflow": 29499261
   "Live Conversation with Ideogram & ComfyOrg": 9f3809e0
 ---
 

--- a/ko/tutorials/partner-nodes/luma/luma-image-to-video.mdx
+++ b/ko/tutorials/partner-nodes/luma/luma-image-to-video.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Luma 이미지에서 비디오 파트너 노드 ComfyUI 공식 예제"
-description: "ComfyUI에서 Luma 이미지에서 비디오 파트너 노드를 사용하는 방법을 알아보세요"
+title: "Luma 이미지-비디오 Partner 노드"
+description: "Luma 이미지-비디오 Partner 노드 워크플로: ComfyUI에서 정적 이미지를 비디오로 변환하며, 필요한 크레딧과 노드 매개변수를 포함합니다."
 sidebarTitle: "Luma 이미지에서 비디오"
-translationSourceHash: d1417e7a
+translationSourceHash: 8c52dad9
 translationFrom: tutorials/partner-nodes/luma/luma-image-to-video.mdx
 ---
 

--- a/ko/tutorials/partner-nodes/overview.mdx
+++ b/ko/tutorials/partner-nodes/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "파트너 노드"
-description: "이 기사에서는 ComfyUI의 파트너 노드와 관련 정보를 소개하겠습니다."
+description: "Partner Nodes는 ComfyUI 내부의 API 요청을 통해 OpenAI, Kling, Luma 등 폐쇄형 모델을 호출합니다. 정의, 크레딧, 사용 방법을 다룹니다."
 sidebarTitle: "개요"
 translationSourceHash: 1fa2edb3
 translationFrom: tutorials/partner-nodes/overview.mdx

--- a/ko/tutorials/partner-nodes/pricing.mdx
+++ b/ko/tutorials/partner-nodes/pricing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Pricing"
-description: "이 문서에는 현재 파트너 노드의 가격 정책이 나와 있습니다."
+title: "Partner Node 가격"
+description: "Anthropic, OpenAI, Kling, Luma 등 모든 제공업체의 Partner Node 크레딧 가격을 모델, 토큰 유형, 생성 유형별로 구분합니다."
 sidebarTitle: "가격 정책"
 mode: "wide"
 translationSourceHash: e1f6ba3a

--- a/ko/tutorials/video/wan/wan-ati.mdx
+++ b/ko/tutorials/video/wan/wan-ati.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Wan ATI ComfyUI 네이티브 워크플로우 튜토리얼"
-description: "트래젝터리 제어를 사용한 비디오 생성"
+title: "Wan ATI 네이티브 워크플로"
+description: "ComfyUI의 Wan ATI 궤적 제어: 궤적을 그려 생성된 비디오의 객체, 영역, 카메라 움직임을 제어합니다. Wan2.1 기반."
 sidebarTitle: "WAN2l1 ATI"
 translationSourceHash: b030360b
 translationFrom: tutorials/video/wan/wan-ati.mdx

--- a/manager/configuration.mdx
+++ b/manager/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: Configuration
+title: "ComfyUI-Manager Configuration"
 sidebarTitle: Config
-description: Configure ComfyUI-Manager settings
+description: "ComfyUI-Manager configuration reference: config.ini paths and options, security levels, and the protected system path introduced in V3.38."
 ---
 
 ## Configuration paths

--- a/manager/troubleshooting.mdx
+++ b/manager/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: Troubleshooting
+title: "ComfyUI-Manager Troubleshooting"
 sidebarTitle: Troubleshooting
-description: Resolve common ComfyUI-Manager issues
+description: "ComfyUI-Manager troubleshooting: fixes for custom git executable paths in config.ini, Manager self-update failures, and install errors."
 ---
 
 ## Common issues

--- a/specs/workflow_json.mdx
+++ b/specs/workflow_json.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Workflow JSON"
-description: "JSON schema for a ComfyUI workflow."
+description: "Workflow JSON schema for the ComfyUI workflow file format (v1.0 plus legacy v0.4), covering nodes, links, groups, and version fields."
 ---
 
 The workflow JSON is defined using [JSON Schema](https://json-schema.org/). Changes to this schema will be discussed in the [rfcs repo](https://github.com/comfy-org/rfcs).

--- a/troubleshooting/custom-node-issues.mdx
+++ b/troubleshooting/custom-node-issues.mdx
@@ -1,6 +1,6 @@
 ---
-title: "How to Troubleshoot and Solve ComfyUI Issues"
-description: "Troubleshoot and fix problems caused by custom nodes and extensions"
+title: "Troubleshooting Custom Node Issues"
+description: "Fix ComfyUI custom node issues: disable all custom nodes with --disable-all-custom-nodes, then binary-search to isolate, fix, or remove the broken node."
 icon: "puzzle-piece"
 sidebarTitle: "Custom Node Issues"
 ---

--- a/troubleshooting/overview.mdx
+++ b/troubleshooting/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to Troubleshoot and Solve ComfyUI Issues"
-description: "Common ComfyUI issues, solutions, and how to report bugs effectively"
+description: "ComfyUI troubleshooting guide: rule out custom nodes first, fix common core issues, and file a bug report with the right details."
 icon: "lightbulb"
 sidebarTitle: "Overview"
 ---

--- a/tutorials/3d/hunyuan3D-2.mdx
+++ b/tutorials/3d/hunyuan3D-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Hunyuan3D-2 Examples"
-description: "This guide will demonstrate how to use Hunyuan3D-2 in ComfyUI to generate 3D assets."
+description: "Hunyuan3D 2.0 in ComfyUI: generate textured 3D models from text or images with Tencent's open-source two-stage model, geometry first, then textures."
 sidebarTitle: "Hunyuan3D-2"
 ---
 

--- a/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ACE-Step Native Example"
-description: "This guide will help you create dynamic music using the ACE-Step model in ComfyUI"
+description: "ACE-Step music generation in ComfyUI: text-to-music and music editing workflows with the Apache-2.0 open-source model from StepFun and ACE Studio."
 sidebarTitle: "ACE-Step 1.0"
 ---
 

--- a/tutorials/basic/inpaint.mdx
+++ b/tutorials/basic/inpaint.mdx
@@ -1,6 +1,6 @@
 ---
 title: ComfyUI Inpainting Workflow
-description: This guide will introduce you to the inpainting workflow in ComfyUI, walk you through an inpainting example, and cover topics like using the mask editor
+description: "ComfyUI inpainting tutorial: edit parts of an image, draw masks with the mask editor, and connect the VAE Encode (for Inpainting) node in a workflow."
 sidebarTitle: "Inpaint"
 ---
 

--- a/tutorials/basic/outpaint.mdx
+++ b/tutorials/basic/outpaint.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Outpainting Workflow Example"
-description: This guide will introduce you to the outpainting workflow in ComfyUI and walk you through an outpainting example
+title: "Outpainting Workflow Example"
+description: "Outpainting workflow in ComfyUI: extend an image beyond its borders using the Pad Image for Outpainting node and inpainting-model techniques."
 sidebarTitle: "Outpaint"
 ---
 

--- a/tutorials/controlnet/controlnet.mdx
+++ b/tutorials/controlnet/controlnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ControlNet Usage Example"
-description: "This guide will introduce you to the basic concepts of ControlNet and demonstrate how to generate corresponding images in ComfyUI"
+description: "ControlNet in ComfyUI: control image generation with condition images instead of trial-and-error prompting, plus a step-by-step workflow example."
 sidebarTitle: "ControlNet"
 ---
 

--- a/tutorials/controlnet/depth-controlnet.mdx
+++ b/tutorials/controlnet/depth-controlnet.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Depth ControlNet Usage Example"
-description: "This guide will introduce you to the basic concepts of Depth ControlNet and demonstrate how to generate corresponding images in ComfyUI"
+title: "Depth ControlNet Workflow Example"
+description: "Depth ControlNet workflow in ComfyUI: how depth maps encode distance, and how to use one to control scene structure during image generation."
 sidebarTitle: "Depth ControlNet"
 ---
 

--- a/tutorials/flux/flux-1-controlnet.mdx
+++ b/tutorials/flux/flux-1-controlnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Flux.1 ControlNet Examples"
-description: "This guide will demonstrate workflow examples using Flux.1 ControlNet."
+description: "FLUX.1 Canny and Depth workflow examples for ComfyUI: add ControlNet-style structural control to FLUX.1 with Black Forest Labs' FLUX.1 Tools."
 sidebarTitle: "Flux.1 ControlNet"
 ---
 

--- a/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/tutorials/flux/flux-1-kontext-dev.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Flux Kontext Dev Native Workflow Example"
-description: "ComfyUI Flux Kontext Dev Native Workflow Example."
+description: "FLUX.1 Kontext Dev workflow for ComfyUI: edit images with text and image input using Black Forest Labs' open-source 12B multimodal editing model."
 sidebarTitle: "Flux.1 Kontext Dev"
 ---
 

--- a/tutorials/image/ideogram/ideogram-v4.mdx
+++ b/tutorials/image/ideogram/ideogram-v4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Ideogram 4.0 Open-Source Model Tutorial"
-description: "Learn how to use the Ideogram 4.0 open-source model in ComfyUI"
+description: "Ideogram 4.0 in ComfyUI: run Ideogram's open-source text-to-image model locally, with accurate text rendering and JSON or natural-language style prompts."
 sidebarTitle: "Ideogram 4.0"
 ---
 

--- a/tutorials/partner-nodes/luma/luma-image-to-video.mdx
+++ b/tutorials/partner-nodes/luma/luma-image-to-video.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Luma Image to Video Partner Nodes ComfyUI Official Example"
-description: "Learn how to use the Luma Image to Video Partner node in ComfyUI"
+title: "Luma Image to Video Partner Node"
+description: "Luma Image to Video Partner node workflow: convert a static image into video in ComfyUI, including required credits and node parameters."
 sidebarTitle: "Luma Image to Video"
 ---
 

--- a/tutorials/partner-nodes/overview.mdx
+++ b/tutorials/partner-nodes/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Partner Nodes"
-description: "In this article, we will introduce ComfyUI's Partner Nodes and related information."
+description: "Partner Nodes call closed-source models such as OpenAI, Kling, and Luma through API requests inside ComfyUI: what they are, credits, and how to use them."
 sidebarTitle: "Overview"
 ---
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Pricing"
-description: "This article lists the pricing of the current Partner Nodes."
+title: "Partner Node Pricing"
+description: "Partner Node pricing in credits for every provider, including Anthropic, OpenAI, Kling, and Luma, broken down by model, token type, and generation type."
 sidebarTitle: "Pricing"
 mode: "wide"
 ---

--- a/tutorials/video/wan/wan-ati.mdx
+++ b/tutorials/video/wan/wan-ati.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Wan ATI ComfyUI Native Workflow Tutorial"
-description: "Using trajectory control for video generation."
+title: "Wan ATI Native Workflow"
+description: "Wan ATI trajectory control in ComfyUI: draw trajectories to direct object, region, and camera motion in generated video, built on Wan2.1."
 sidebarTitle: "WAN2l1 ATI"
 ---
 

--- a/zh/basic-concepts/custom-nodes.mdx
+++ b/zh/basic-concepts/custom-nodes.mdx
@@ -1,13 +1,13 @@
 ---
 title: "自定义节点"
-description: "了解 ComfyUI 中自定义节点的安装、依赖启用、更新、禁用、卸载"
+description: "ComfyUI 自定义节点：与 Comfy Core 节点的区别，以及安装、更新、启用依赖、禁用和卸载方法。"
 icon: "window-maximize"
-translationSourceHash: 20bf73d3
+translationSourceHash: 08b636e4
 translationFrom: basic-concepts/custom-nodes.mdx
 translationBlockHashes:
   "About Custom Nodes": bfe7409e
-  "Custom Node Management": 2097f41b
-  "ComfyUI Manager": b3de97a9
+  "Custom Node Management": af7c2a5c
+  "ComfyUI Manager": 17902775
   "Developing a Custom Node": b4016ecf
 ---
 

--- a/zh/basic-concepts/nodes.mdx
+++ b/zh/basic-concepts/nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "节点"
-description: "了解 ComfyUI 中节点的概念。"
+description: "节点是 ComfyUI 的基本构建块：通过连线连接的独立 Comfy Core 或自定义模块，用来组装复杂工作流。"
 icon: "circle"
 translationSourceHash: ee1ca352
 translationFrom: basic-concepts/nodes.mdx

--- a/zh/built-in-nodes/CheckpointLoaderSimple.mdx
+++ b/zh/built-in-nodes/CheckpointLoaderSimple.mdx
@@ -1,6 +1,6 @@
 ---
-title: "CheckpointLoaderSimple - ComfyUI Built-in Node Documentation"
-description: "Documentation for CheckpointLoaderSimple node."
+title: "CheckpointLoaderSimple 节点"
+description: "CheckpointLoaderSimple 加载扩散模型检查点，并拆分为模型、CLIP 和 VAE，自动检测 ComfyUI/models/checkpoints 中的文件。"
 sidebarTitle: "CheckpointLoaderSimple"
 icon: "circle"
 mode: wide

--- a/zh/built-in-nodes/MultiGPU_WorkUnits.mdx
+++ b/zh/built-in-nodes/MultiGPU_WorkUnits.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MultiGPU_WorkUnits - ComfyUI Built-in Node Documentation"
-description: "Documentation for MultiGPUWorkUnits node."
+title: "MultiGPU CFG 拆分节点"
+description: "MultiGPU CFG 拆分节点参考：在一台系统的多块相同 GPU 上运行扩散处理，速度提升最高可达 1.95 倍。"
 sidebarTitle: "MultiGPU_WorkUnits"
 icon: "circle"
 mode: wide

--- a/zh/built-in-nodes/sampling/ksampler.mdx
+++ b/zh/built-in-nodes/sampling/ksampler.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Ksampler - ComfyUI 原生节点文档"
-description: "Ksampler 节点是 ComfyUI 中常用的采样节点。"
+title: "KSampler 节点"
+description: "KSampler 节点参考：对潜空间图像进行多步去噪（带条件、采样器和调度器），是文生图工作流的核心。"
 sidebarTitle: "Ksampler"
 icon: "circle"
 ---

--- a/zh/development/comfyui-server/startup-flags.mdx
+++ b/zh/development/comfyui-server/startup-flags.mdx
@@ -1,7 +1,7 @@
 ---
 title: "启动参数"
 sidebarTitle: "启动参数"
-description: "ComfyUI main.py 命令行启动参数完整参考"
+description: "ComfyUI 启动参数参考：comfy/cli_args.py 中的全部 main.py 命令行参数，以及如何在 Windows 便携版 .bat 启动器中添加参数。"
 icon: "terminal"
 translationSourceHash: 23664520
 translationFrom: development/comfyui-server/startup-flags.mdx

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Linux — Comfy Desktop"
-description: "在 Linux 上从源码构建并运行 Comfy Desktop"
+title: "Linux 上的 Comfy Desktop"
+description: "Linux 上的 Comfy Desktop：没有官方安装程序，需要克隆仓库并从源码运行。要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
 translationSourceHash: b42848c3

--- a/zh/installation/desktop/overview.mdx
+++ b/zh/installation/desktop/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Comfy Desktop 概览"
-description: "了解 Comfy Desktop — 一个现代化的桌面应用，用于管理多个 ComfyUI 安装"
+description: "Comfy Desktop 概览：一个安装、管理和启动多个 ComfyUI 实例的桌面应用，ComfyUI 是生成式 AI 的基于节点的引擎。"
 icon: "desktop"
 sidebarTitle: "概览"
-translationSourceHash: 4221d408
+translationSourceHash: 7ad9cbf9
 translationFrom: installation/desktop/overview.mdx
 ---
 

--- a/zh/interface/credits.mdx
+++ b/zh/interface/credits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "积分管理"
-description: "在本篇中我们将介绍 ComfyUI 的积分管理功能，包括积分的获取、使用和查看。"
+description: "ComfyUI 中 Partner Nodes 的积分：如何购买积分、查看使用历史，以及从 设置 > 积分 中监控余额。"
 sidebarTitle: "积分"
 icon: "coins"
 translationSourceHash: 7f939609

--- a/zh/interface/nodes-2.mdx
+++ b/zh/interface/nodes-2.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Nodes 2.0"
-description: "了解 Nodes 2.0，ComfyUI 中全新的基于 Vue 的节点渲染系统，实现更快的开发速度和更丰富的交互体验。"
+description: "Nodes 2.0 将 ComfyUI 节点渲染从 LiteGraph Canvas 迁移到基于 Vue 的系统以加快迭代：变更内容与启用方法。"
 sidebarTitle: "Nodes 2.0"
 icon: "sparkles"
-translationSourceHash: 28539a92
+translationSourceHash: ab32579d
 translationFrom: interface/nodes-2.mdx
 ---
 

--- a/zh/interface/overview.mdx
+++ b/zh/interface/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI 界面概览"
-description: "在本篇中，我们将简要介绍 ComfyUI 的基础用户界面，带你熟悉了解 ComfyUI 界面的各个部分，"
+title: "界面概览"
+description: "ComfyUI 界面导览：介绍在可视化节点编辑器中构建、组织、调试工作流所用的各个工作区部分。"
 sidebarTitle: "界面概览"
 icon: "window"
 translationSourceHash: a604333b

--- a/zh/interface/shortcuts.mdx
+++ b/zh/interface/shortcuts.mdx
@@ -1,9 +1,9 @@
 ---
-title: "ComfyUI 的快捷键及自定义设置"
-description: "ComfyUI 的键盘和鼠标快捷键及相关设置"
+title: "键盘和鼠标快捷键"
+description: "ComfyUI 键盘和鼠标快捷键：完整的默认列表，以及如何在应用内设置菜单中查看和自定义键位绑定。"
 sidebarTitle: "快捷键"
 icon: "keyboard"
-translationSourceHash: 457d7181
+translationSourceHash: 9f1f3c15
 translationFrom: interface/shortcuts.mdx
 ---
 

--- a/zh/manager/configuration.mdx
+++ b/zh/manager/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: ComfyUI Manager 配置配置
+title: "ComfyUI-Manager 配置"
 sidebarTitle: 配置
-description: 配置 ComfyUI-Manager 设置
+description: "ComfyUI-Manager 配置参考：config.ini 路径与选项、安全级别，以及 V3.38 引入的保护系统路径。"
 translationSourceHash: 632d3536
 translationFrom: manager/configuration.mdx
 translationBlockHashes:

--- a/zh/manager/troubleshooting.mdx
+++ b/zh/manager/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: 故障排除
+title: "ComfyUI-Manager 故障排除"
 sidebarTitle: 故障排除
-description: 解决常见的 ComfyUI-Manager 问题
+description: "ComfyUI-Manager 故障排除：修复 config.ini 中的自定义 git 可执行文件路径、Manager 自更新失败和安装错误。"
 translationSourceHash: 574d8622
 translationFrom: manager/troubleshooting.mdx
 translationBlockHashes:

--- a/zh/specs/workflow_json.mdx
+++ b/zh/specs/workflow_json.mdx
@@ -1,6 +1,6 @@
 ---
 title: "工作流 JSON"
-description: "ComfyUI 工作流的 JSON 模式。"
+description: "ComfyUI 工作流文件格式（v1.0 及旧版 v0.4）的 Workflow JSON schema，涵盖节点、连线、分组和版本字段。"
 translationSourceHash: d25be209
 translationFrom: specs/workflow_json.mdx
 translationBlockHashes:

--- a/zh/troubleshooting/custom-node-issues.mdx
+++ b/zh/troubleshooting/custom-node-issues.mdx
@@ -1,6 +1,6 @@
 ---
-title: "如何解决和排查 ComfyUI 中自定义节点导致的问题"
-description: "故障排除和修复由自定义节点和扩展引起的问题"
+title: "自定义节点问题排查"
+description: "修复 ComfyUI 自定义节点问题：用 --disable-all-custom-nodes 禁用所有自定义节点，然后二分排查以隔离、修复或移除出问题的节点。"
 icon: "puzzle-piece"
 sidebarTitle: "自定义节点问题"
 translationSourceHash: 09e72de3

--- a/zh/troubleshooting/overview.mdx
+++ b/zh/troubleshooting/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "如何排查和解决 ComfyUI 中出现的错误"
-description: "常见 ComfyUI 问题、解决方案和如何有效报告错误"
+description: "ComfyUI 故障排除指南：先排除自定义节点，修复常见核心问题，并提交包含正确细节的错误报告。"
 icon: "lightbulb"
 sidebarTitle: "概述"
 translationSourceHash: 9e3cacd4

--- a/zh/tutorials/3d/hunyuan3D-2.mdx
+++ b/zh/tutorials/3d/hunyuan3D-2.mdx
@@ -1,14 +1,14 @@
 ---
 title: "ComfyUI Hunyuan3D-2 示例"
-description: "本文将使用 Hunyuan3D-2 来完成在 ComfyUI 中 3D 资产生成的工作流示例。"
+description: "ComfyUI 中的 Hunyuan3D 2.0：使用腾讯开源的 Two-Stage 模型从文本或图像生成带纹理的 3D 模型，先生成几何，再生成纹理。"
 sidebarTitle: "Hunyuan3D-2"
-translationSourceHash: cc8f8b48
+translationSourceHash: 8798b946
 translationFrom: tutorials/3d/hunyuan3D-2.mdx
 translationBlockHashes:
   "_intro": 2fbea77b
   "ComfyUI Hunyuan3D-2mv Workflow Example": f73d5f2a
   "Hunyuan3D-2mv-turbo Workflow": b3ac06de
-  "Hunyuan3D-2 Single View Workflow": ac07f7f3
+  "Hunyuan3D-2 Single View Workflow": 46e82b79
   "Community Resources": d12dc58a
   "Hunyuan3D 2.0 Open-Source Model Series": 363ff037
 ---

--- a/zh/tutorials/audio/ace-step/ace-step-v1.mdx
+++ b/zh/tutorials/audio/ace-step/ace-step-v1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ACE-Step 原生示例"
-description: "本文将引导你在 ComfyUI 中使用 ACE-Step 模型来创造灵动音乐"
+description: "ComfyUI 中的 ACE-Step 音乐生成：使用 StepFun 和 ACE Studio 的 Apache-2.0 开源模型进行文生音乐和音乐编辑工作流。"
 sidebarTitle: "ACE-Step 1.0"
 translationSourceHash: b3044926
 translationFrom: tutorials/audio/ace-step/ace-step-v1.mdx

--- a/zh/tutorials/basic/inpaint.mdx
+++ b/zh/tutorials/basic/inpaint.mdx
@@ -1,6 +1,6 @@
 ---
 title: ComfyUI 局部重绘工作流
-description: 本篇指南将带你了解 ComfyUI 中的局部重绘工作流，并带你完成一个局部重绘的示例，以及遮罩编辑器的使用等
+description: "ComfyUI 局部重绘教程：编辑图像的部分区域、用遮罩编辑器绘制蒙版，并在工作流中连接 VAE Encode (for Inpainting) 节点。"
 sidebarTitle: "局部重绘"
 translationSourceHash: 08fe752b
 translationFrom: tutorials/basic/inpaint.mdx

--- a/zh/tutorials/basic/outpaint.mdx
+++ b/zh/tutorials/basic/outpaint.mdx
@@ -1,13 +1,13 @@
 ---
-title: "ComfyUI 扩图（Outpaint）工作流示例"
-description: 本篇指南将带你了解 ComfyUI 中的扩图工作流，带你完成一个扩图的示例
+title: "扩图工作流示例"
+description: "ComfyUI 中的扩图工作流：使用 Pad Image for Outpainting 节点和局部重绘模型技术，将图像扩展到边界之外。"
 sidebarTitle: "扩图"
-translationSourceHash: 67107df5
+translationSourceHash: 30f50d19
 translationFrom: tutorials/basic/outpaint.mdx
 translationBlockHashes:
   "_intro": 7cf1c763
   "About Outpainting": decb981d
-  "ComfyUI Outpainting Workflow Example Explanation": e06f66e2
+  "ComfyUI Outpainting Workflow Example Explanation": 52ce114d
 ---
 
 

--- a/zh/tutorials/controlnet/controlnet.mdx
+++ b/zh/tutorials/controlnet/controlnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI ControlNet 使用示例"
-description: "本篇将引导了解基础的 ControlNet 概念，并在 ComfyUI 中完成对应的图像生成"
+description: "ComfyUI 中的 ControlNet：用条件图像控制图像生成，代替反复试错的提示词，并附带分步工作流示例。"
 sidebarTitle: "ControlNet"
 translationSourceHash: b14c7383
 translationFrom: tutorials/controlnet/controlnet.mdx

--- a/zh/tutorials/controlnet/depth-controlnet.mdx
+++ b/zh/tutorials/controlnet/depth-controlnet.mdx
@@ -1,6 +1,6 @@
 ---
-title: "ComfyUI Depth ControlNet 使用示例"
-description: "本篇将引导了解基础的 Depth ControlNet 概念，并在 ComfyUI 中完成对应的图像生成"
+title: "深度 ControlNet 工作流示例"
+description: "ComfyUI 中的深度 ControlNet 工作流：深度图如何编码距离信息，以及如何用它控制图像生成时的场景结构。"
 sidebarTitle: "Depth ControlNet"
 translationSourceHash: 61508e7c
 translationFrom: tutorials/controlnet/depth-controlnet.mdx

--- a/zh/tutorials/flux/flux-1-controlnet.mdx
+++ b/zh/tutorials/flux/flux-1-controlnet.mdx
@@ -1,13 +1,13 @@
 ---
 title: "ComfyUI Flux.1 ControlNet 示例"
-description: "本文将使用 Flux.1 ControlNet 来完成 ControlNet 的工作流示例。"
+description: "ComfyUI 的 FLUX.1 Canny 和 Depth 工作流示例：使用 Black Forest Labs 的 FLUX.1 Tools 为 FLUX.1 添加 ControlNet 式结构控制。"
 sidebarTitle: "Flux.1 ControlNet"
-translationSourceHash: 4c4cc656
+translationSourceHash: 4e1904ca
 translationFrom: tutorials/flux/flux-1-controlnet.mdx
 translationBlockHashes:
   "_intro": a69fbfae
   "FLUX.1 ControlNet Model Introduction": c242319b
-  "FLUX.1-Canny-dev Complete Version Workflow": 8e23a9ea
+  "FLUX.1-Canny-dev Complete Version Workflow": 62888620
   "FLUX.1-Depth-dev-lora Workflow": 7aa4e7e1
   "Community Versions of Flux Controlnets": 29728dcf
 ---

--- a/zh/tutorials/flux/flux-1-kontext-dev.mdx
+++ b/zh/tutorials/flux/flux-1-kontext-dev.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ComfyUI Flux Kontext Dev 原生工作流示例"
-description: "ComfyUI Flux Kontext Dev 原生工作流示例。"
+description: "ComfyUI 的 FLUX.1 Kontext Dev 工作流：使用 Black Forest Labs 开源 12B 多模态编辑模型，通过文本和图像输入编辑图片。"
 sidebarTitle: "Flux.1 Kontext Dev"
 translationSourceHash: 644dbe55
 translationFrom: tutorials/flux/flux-1-kontext-dev.mdx

--- a/zh/tutorials/image/ideogram/ideogram-v4.mdx
+++ b/zh/tutorials/image/ideogram/ideogram-v4.mdx
@@ -1,12 +1,12 @@
 ---
 title: "ComfyUI Ideogram 4.0 开源模型教程"
-description: "了解如何在 ComfyUI 中使用 Ideogram 4.0 开源模型"
+description: "ComfyUI 中的 Ideogram 4.0：在本地运行 Ideogram 的开源文生图模型，支持准确的文字渲染和 JSON 或自然语言风格提示词。"
 sidebarTitle: "Ideogram 4.0"
-translationSourceHash: e667f2e0
+translationSourceHash: e27917ad
 translationFrom: tutorials/image/ideogram/ideogram-v4.mdx
 translationBlockHashes:
   "_intro": e87a6658
-  "Ideogram 4.0 Text-to-Image Workflow": 847be061
+  "Ideogram 4.0 Text-to-Image Workflow": 29499261
   "Live Conversation with Ideogram & ComfyOrg": 9f3809e0
 ---
 

--- a/zh/tutorials/partner-nodes/luma/luma-image-to-video.mdx
+++ b/zh/tutorials/partner-nodes/luma/luma-image-to-video.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Luma Image to Video Partner Nodes ComfyUI Official Example"
-description: "Learn how to use the Luma Image to Video Partner node in ComfyUI"
+title: "Luma 图生视频 Partner Node"
+description: "Luma 图生视频 Partner Node 工作流：在 ComfyUI 中将静态图像转换为视频，包括所需积分和节点参数。"
 sidebarTitle: "Luma Image to Video"
-translationSourceHash: d1417e7a
+translationSourceHash: 8c52dad9
 translationFrom: tutorials/partner-nodes/luma/luma-image-to-video.mdx
 ---
 

--- a/zh/tutorials/partner-nodes/overview.mdx
+++ b/zh/tutorials/partner-nodes/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Partner Nodes"
-description: "在本篇中我们将介绍 ComfyUI 关于 Partner Nodes 的相关说明。"
+description: "Partner Nodes 通过 ComfyUI 内的 API 请求调用 OpenAI、Kling、Luma 等闭源模型：它们是什么、积分机制以及使用方法。"
 sidebarTitle: "总览"
 translationSourceHash: 1fa2edb3
 translationFrom: tutorials/partner-nodes/overview.mdx

--- a/zh/tutorials/partner-nodes/pricing.mdx
+++ b/zh/tutorials/partner-nodes/pricing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "定价"
-description: "本文列出了当前合作伙伴节点的定价。"
+title: "Partner Node 定价"
+description: "各提供商（包括 Anthropic、OpenAI、Kling 和 Luma）的 Partner Node 积分定价，按模型、令牌类型和生成类型细分。"
 sidebarTitle: "定价"
 mode: "wide"
 translationSourceHash: e1f6ba3a

--- a/zh/tutorials/video/wan/wan-ati.mdx
+++ b/zh/tutorials/video/wan/wan-ati.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Wan ATI ComfyUI 原生工作流教程"
-description: "使用轨迹控制视频生成。"
+title: "Wan ATI 原生工作流"
+description: "ComfyUI 中的 Wan ATI 轨迹控制：绘制轨迹来控制生成视频中的对象、区域和相机运动，基于 Wan2.1 构建。"
 sidebarTitle: "Wan2.1 ATI"
 translationSourceHash: b030360b
 translationFrom: tutorials/video/wan/wan-ati.mdx


### PR DESCRIPTION
## What

Second metadata batch from the "SEO fixes and AEO Opportunities" tracker ([sheet](https://docs.google.com/spreadsheets/d/1wruhHV2csakDZN34mPRaL8hUZy0TLExp/edit) — see the new **Claude Recs 2026-08-25** tab for the full per-URL breakdown), following #1482.

Because metadata passes land here daily, every candidate was **re-verified against production tonight**: of 209 English tracker URLs, 136 already carry solid descriptions (recent passes covered the biggest pages). This PR is only the 30 that are still weak right now — filler openers ("This guide will..."), too-short (34-68 chars), or title echoes — each rewritten from the page's actual content. Combined reach: ~2.1M GSC impressions/30d.

- Frontmatter only: descriptions on all 30; titles only where weak (node-page stubs like "Ksampler", em-dash titles). `sidebarTitle` preserved or added wherever a title changed, so no navigation label moves.
- English only; zh/ja/ko twins follow the translate pipeline.
- No em dashes, no marketing tone, per the repo prose rules.

## Two findings for a separate decision (not in this PR)

1. **41 api-reference pages have no meta description at all** — they're auto-generated from the OpenAPI spec, so the fix belongs in the spec/Mintlify config, not per-page .mdx edits.
2. **The question-headings half of the tracker is essentially unaddressed**: of 72 flagged pages, only 6 have any question-format heading today, including the two biggest (krea-2 at 574k impressions, the docs homepage at 548k). #1482 established the safe pattern ({#custom-id} pins preserve anchors) if we want a batch 3.

cc @comfyui-wiki — draft for your review; happy to split or trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)