### PR TITLE
Reorganize Registry API Reference into sidebar navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2903,7 +2903,14 @@
                   "registry/standards",
                   "registry/cicd",
                   "registry/specifications",
-                  "registry/api-reference/overview"
+                  "registry/api-reference/overview",
+                  {
+                    "group": "Registry API Reference",
+                    "openapi": {
+                      "source": "https://api.comfy.org/openapi",
+                      "directory": "registry/api-reference"
+                    }
+                  }
                 ]
               }
             ]
@@ -2964,10 +2971,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud API Reference",
@@ -5868,7 +5871,14 @@
                   "zh/registry/standards",
                   "zh/registry/cicd",
                   "zh/registry/specifications",
-                  "zh/registry/api-reference/overview"
+                  "zh/registry/api-reference/overview",
+                  {
+                    "group": "Registry API 参考",
+                    "openapi": {
+                      "source": "https://api.comfy.org/openapi",
+                      "directory": "zh/registry/api-reference"
+                    }
+                  }
                 ]
               }
             ]
@@ -5929,10 +5939,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry API Reference",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud API 参考文档",
@@ -8833,7 +8839,14 @@
                   "ja/registry/standards",
                   "ja/registry/cicd",
                   "ja/registry/specifications",
-                  "ja/registry/api-reference/overview"
+                  "ja/registry/api-reference/overview",
+                  {
+                    "group": "Registry APIリファレンス",
+                    "openapi": {
+                      "source": "https://api.comfy.org/openapi",
+                      "directory": "ja/registry/api-reference"
+                    }
+                  }
                 ]
               }
             ]
@@ -8894,10 +8907,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry APIリファレンス",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud APIリファレンス",
@@ -11776,7 +11785,14 @@
                   "ko/registry/standards",
                   "ko/registry/cicd",
                   "ko/registry/specifications",
-                  "ko/registry/api-reference/overview"
+                  "ko/registry/api-reference/overview",
+                  {
+                    "group": "Registry API 참조",
+                    "openapi": {
+                      "source": "https://api.comfy.org/openapi",
+                      "directory": "ko/registry/api-reference"
+                    }
+                  }
                 ]
               }
             ]
@@ -11837,10 +11853,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Registry API 참조",
-            "openapi": "https://api.comfy.org/openapi"
           },
           {
             "tab": "Cloud API 참조",


### PR DESCRIPTION
## Summary
Restructured the Registry API Reference documentation to be integrated into the sidebar navigation as a grouped section rather than as a separate top-level tab. This change applies consistently across all language variants (English, Chinese, Japanese, and Korean).

## Key Changes
- Moved Registry API Reference from a top-level tab to a nested group within the Registry section of the sidebar navigation
- Updated the OpenAPI configuration to use the new structured format with `source` and `directory` properties
- Applied changes across all four language variants:
  - English: "Registry API Reference"
  - Chinese: "Registry API 参考"
  - Japanese: "Registry APIリファレンス"
  - Korean: "Registry API 참조"
- Removed the old tab-based Registry API Reference entries that used the simple `openapi` URL format

## Implementation Details
- The Registry API Reference now appears as a collapsible group within the Registry sidebar section, alongside other registry documentation pages
- Each language variant maintains its localized group label while pointing to the same OpenAPI source
- The OpenAPI specification is now organized into language-specific directories (e.g., `registry/api-reference`, `zh/registry/api-reference`, etc.)
- This improves information architecture by keeping related Registry documentation together in the navigation

https://claude.ai/code/session_01FvrmVqEa4jQFqtyUiun6LX