### PR TITLE
Reorganize API documentation structure and clarify v1/v2 distinction

### DIFF
--- a/api-reference/v2/overview.mdx
+++ b/api-reference/v2/overview.mdx
@@ -18,7 +18,7 @@ The same API is served by three surfaces, so one integration can move between th
 
 **Comfy Cloud.** The managed, multi-tenant service at `https://cloud.comfy.org`. Create an [API key](/development/api-development/getting-an-api-key) and you can submit any workflow. Cloud-specific features such as credits, model browsing, and queue management live on the [v1 Cloud API](/development/cloud/overview), not on v2.
 
-**Serverless API (Developer Platform).** A workflow you deploy through the [Developer Platform](https://platform.comfy.org) gets its own dedicated endpoint at `https://{deployment}.run.comfy.app`, serving the same v2 API with the same API key. A serverless deployment runs one pinned workflow, so it scales independently and `GET /workflow` returns the executed graph.
+**Serverless API (Developer Platform).** A workflow you deploy through the [Developer Platform](https://platform.comfy.org) gets its own dedicated endpoint at `https://{deployment}.run.comfy.app`, serving the same v2 API with the same API key. A serverless deployment runs one pinned workflow, so it scales independently and `GET /workflow` returns the executed graph. See the [Serverless API guide](/development/serverless/overview) for building and deploying.
 
 **Open-source ComfyUI, via the proxy.** During the beta, a self-hosted ComfyUI speaks v2 through [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy), a small open-source service that runs alongside it:
 

--- a/api-reference/v2/overview.mdx
+++ b/api-reference/v2/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Comfy API v2 Overview"
+sidebarTitle: "Overview"
 description: "Reference for the official Comfy API v2: run ComfyUI workflows from external applications by uploading inputs, submitting jobs, and polling for results."
 ---
 
@@ -9,7 +10,24 @@ description: "Reference for the official Comfy API v2: run ComfyUI workflows fro
 
 The official, versioned HTTP API for running ComfyUI workflows from external applications: upload inputs, submit a workflow, observe execution, retrieve results.
 
-Most people should start with the [Comfy SDKs](/development/api-development/sdks), which wrap this API in Python and TypeScript. Call these endpoints directly if you are working in another language.
+Most people should start with the [Comfy SDKs](/development/api-development/sdks), which wrap this API in Python and TypeScript. Call these endpoints directly if you are working in another language. The full endpoint documentation is in the API Reference pages of this section, generated from the OpenAPI specification.
+
+## Where v2 Runs
+
+The same API is served by three surfaces, so one integration can move between them by changing the base URL.
+
+**Comfy Cloud.** The managed, multi-tenant service at `https://cloud.comfy.org`. Create an [API key](/development/api-development/getting-an-api-key) and you can submit any workflow. Cloud-specific features such as credits, model browsing, and queue management live on the [v1 Cloud API](/development/cloud/overview), not on v2.
+
+**Serverless API (Developer Platform).** A workflow you deploy through the [Developer Platform](https://platform.comfy.org) gets its own dedicated endpoint at `https://{deployment}.run.comfy.app`, serving the same v2 API with the same API key. A serverless deployment runs one pinned workflow, so it scales independently and `GET /workflow` returns the executed graph.
+
+**Open-source ComfyUI, via the proxy.** During the beta, a self-hosted ComfyUI speaks v2 through [comfy-api-proxy](https://github.com/Comfy-Org/comfy-api-proxy), a small open-source service that runs alongside it:
+
+```bash
+pip install comfy-api-proxy
+comfy-api-proxy
+```
+
+By default it proxies the ComfyUI on `127.0.0.1:8188` and serves the v2 API on `127.0.0.1:8189`, binding to loopback only. Authentication is off by default, with an optional static bearer token. The proxy is a stopgap: once v2 stabilizes it moves into ComfyUI core and the proxy is no longer needed. See [Your own ComfyUI](/development/api-development/sdks#your-own-comfyui) in the SDK guide for configuration details.
 
 ## Design Principles
 

--- a/development/api-development/overview.mdx
+++ b/development/api-development/overview.mdx
@@ -10,7 +10,7 @@ ComfyUI offers several API options depending on where you want to run your workf
 
 ## Start Here
 
-For a new integration, use the **Comfy SDKs** and the Comfy API v2 they call. v2 is a new, versioned HTTP interface. It coexists with the existing Cloud API and ComfyUI Server API. See the [Comfy API v2 Overview](/api-reference/v2/overview). The same code runs against Comfy Cloud, a serverless deployment, and your own machine.
+For a new integration, use the **Comfy SDKs** and the Comfy API v2 they call. v2 is a new, versioned HTTP interface. It coexists with the existing v1 Cloud API and ComfyUI Server API. See the [Comfy API v2 Overview](/api-reference/v2/overview). The same code runs against Comfy Cloud, a serverless deployment, and your own machine.
 
 <Card title="Comfy SDKs" icon="code" href="/development/api-development/sdks">
   Official Python and TypeScript SDKs for running workflows from your own application. Currently in beta.
@@ -22,7 +22,7 @@ The other APIs below are still fully supported, and they cover surface the SDKs 
 
 ## Which API Should I Use?
 
-| | Comfy API v2 + SDKs | Cloud API | ComfyUI Server API |
+| | Comfy API v2 + SDKs | v1 Cloud API | ComfyUI Server API |
 |---|---|---|---|
 | **Where it runs** | Comfy Cloud, a serverless deployment, or your own machine via a local proxy | Comfy Cloud (managed GPUs) | Your own machine |
 | **Compatibility** | Versioned, additive changes only within v2 | Experimental, may change without notice | No guarantee across releases |
@@ -45,8 +45,8 @@ All of them use the same workflow format ([API format](/development/api-developm
   <Card title="Comfy SDKs" icon="code" href="/development/api-development/sdks">
     Run workflows from Python or TypeScript, against Cloud or your own machine.
   </Card>
-  <Card title="Cloud API" icon="cloud" href="/development/cloud/overview">
-    Run workflows on Comfy's managed infrastructure. No GPU setup required.
+  <Card title="v1 Cloud API" icon="cloud" href="/development/cloud/overview">
+    The full Comfy Cloud surface: queue, models, and account endpoints.
   </Card>
   <Card title="ComfyUI Server API" icon="server" href="/development/comfyui-server/comms_overview">
     Run ComfyUI as a server on your own machine and call it via API.

--- a/development/api-development/overview.mdx
+++ b/development/api-development/overview.mdx
@@ -16,7 +16,7 @@ For a new integration, use the **Comfy SDKs** and the Comfy API v2 they call. v2
   Official Python and TypeScript SDKs for running workflows from your own application. Currently in beta.
 </Card>
 
-The other APIs below are still fully supported, and they cover surface the SDKs do not reach yet. Nothing here is deprecated.
+The older APIs below still work, and they cover surface the SDKs do not reach yet. The v1 Cloud API is deprecated: use it only for existing integrations or for Cloud capabilities that v2 does not expose yet.
 
 ---
 
@@ -25,7 +25,7 @@ The other APIs below are still fully supported, and they cover surface the SDKs 
 | | Comfy API v2 + SDKs | v1 Cloud API | ComfyUI Server API |
 |---|---|---|---|
 | **Where it runs** | Comfy Cloud, a serverless deployment, or your own machine via a local proxy | Comfy Cloud (managed GPUs) | Your own machine |
-| **Compatibility** | Versioned, additive changes only within v2 | Experimental, may change without notice | No guarantee across releases |
+| **Compatibility** | Versioned, additive changes only within v2 | Deprecated, may change without notice | No guarantee across releases |
 | **GPU management** | Depends on which surface you point it at | Handled for you | You manage your own hardware |
 | **Models** | Depends on which surface you point it at | Pre-installed and managed by Comfy | You download and manage locally |
 | **Authentication** | `Authorization: Bearer` on Cloud. Self-hosted: none by default, optional static bearer token | `X-API-Key` header (Comfy Cloud account) | None (local) or API key for Partner Nodes |
@@ -33,7 +33,7 @@ The other APIs below are still fully supported, and they cover surface the SDKs 
 | **Official clients** | Python and TypeScript SDKs | None, call over HTTP | None, call over HTTP |
 | **Protocol** | REST + SSE | REST + WebSocket | REST + WebSocket |
 | **Scope** | Run a workflow and get results | Full Cloud surface, including models and account | Full local surface, including queue and node info |
-| **Best for** | New integrations that should keep working | Cloud features the SDKs do not cover yet | Full control, custom hardware & models |
+| **Best for** | New integrations that should keep working | Existing integrations and Cloud features v2 does not cover yet | Full control, custom hardware & models |
 
 All of them use the same workflow format ([API format](/development/api-development/workflow-api-format)), so you can develop and test workflows locally and move them to the cloud without changes.
 

--- a/development/cloud/api-reference.mdx
+++ b/development/cloud/api-reference.mdx
@@ -9,7 +9,7 @@ import WebSocketProgress from '/snippets/cloud/websocket-progress.mdx'
 import DownloadOutputs from '/snippets/cloud/download-outputs.mdx'
 
 <Warning>
-  **Experimental API:** This API is experimental and subject to change. Endpoints, request/response formats, and behavior may be modified without notice. Some endpoints are maintained for compatibility with local ComfyUI but may have different semantics (e.g., ignored fields).
+  **Deprecated:** The v1 Cloud API is deprecated in favor of [Comfy API v2](/api-reference/v2/overview). Endpoints, request/response formats, and behavior may be modified without notice. Some endpoints are maintained for compatibility with local ComfyUI but may have different semantics (e.g., ignored fields).
 </Warning>
 
 This page provides complete examples for common Comfy Cloud API operations.

--- a/development/cloud/api-reference.mdx
+++ b/development/cloud/api-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cloud API Reference"
+sidebarTitle: "Code Examples"
 description: "Complete API reference with code examples for Comfy Cloud"
 icon: "book-open"
 ---

--- a/development/cloud/openapi.mdx
+++ b/development/cloud/openapi.mdx
@@ -6,7 +6,7 @@ openapi: "/openapi-cloud.yaml"
 ---
 
 <Warning>
-  **Experimental API:** This API is experimental and subject to change. Endpoints, request/response formats, and behavior may be modified without notice.
+  **Deprecated:** The v1 Cloud API is deprecated in favor of [Comfy API v2](/api-reference/v2/overview). Endpoints, request/response formats, and behavior may be modified without notice.
 </Warning>
 
 # Comfy Cloud API Specification

--- a/development/cloud/overview.mdx
+++ b/development/cloud/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Cloud API Overview"
+title: "v1 Cloud API Overview"
+sidebarTitle: "Overview"
 description: "Programmatic access to Comfy Cloud for running workflows, managing files, and monitoring execution"
 ---
 
@@ -7,11 +8,13 @@ description: "Programmatic access to Comfy Cloud for running workflows, managing
   **Experimental API:** This API is experimental and subject to change. Endpoints, request/response formats, and behavior may be modified without notice.
 </Warning>
 
-# Comfy Cloud API
+# v1 Cloud API
 
-The Comfy Cloud API provides programmatic access to run workflows on Comfy Cloud infrastructure. The API is compatible with local ComfyUI's API, making it easy to migrate existing integrations.
+The v1 Cloud API provides programmatic access to Comfy Cloud, Comfy's managed service for running workflows on cloud infrastructure. The API is compatible with local ComfyUI's API, making it easy to migrate existing integrations.
 
-If you are working in Python or TypeScript, use the [Comfy SDKs](/development/api-development/sdks). They wrap this API and are the shortest path to running a workflow. This page covers what is specific to Comfy Cloud: your API key, credits, and concurrency limits. Everything else is in the [Cloud API Reference](/development/cloud/api-reference).
+Comfy Cloud is a stateful application. Your account carries state that persists across jobs: credits and subscription tier, uploaded assets and generated outputs, the job queue, and the set of installed models and nodes. The v1 API is the surface for that whole application, so it contains functionality not supported in the portable [Comfy API v2](/api-reference/v2/overview), such as queue management, model browsing, node definitions, and account endpoints. Use v2 (or the SDKs that wrap it) to submit workflows and retrieve results in a way that also works against serverless deployments and self-hosted ComfyUI. Use v1 for the Cloud-specific capabilities around it.
+
+If you are working in Python or TypeScript, use the [Comfy SDKs](/development/api-development/sdks). They wrap the v2 API and are the shortest path to running a workflow. This page covers what is specific to Comfy Cloud: your API key, credits, and concurrency limits. Everything else is in the [Cloud API Reference](/development/cloud/api-reference).
 
 <Note>
   **Subscription required:** API access is available on the **Standard**, **Creator** and **Pro** tiers. The Free tier does not include API access. See [pricing plans](https://www.comfy.org/cloud/pricing?utm_source=docs&utm_campaign=cloud-api) for details.

--- a/development/cloud/overview.mdx
+++ b/development/cloud/overview.mdx
@@ -5,7 +5,7 @@ description: "Programmatic access to Comfy Cloud for running workflows, managing
 ---
 
 <Warning>
-  **Experimental API:** This API is experimental and subject to change. Endpoints, request/response formats, and behavior may be modified without notice.
+  **Deprecated:** The v1 Cloud API is deprecated in favor of [Comfy API v2](/api-reference/v2/overview). It remains available for existing integrations and for Cloud capabilities v2 does not expose yet, but endpoints and behavior may change without notice.
 </Warning>
 
 # v1 Cloud API

--- a/development/cloud/overview.mdx
+++ b/development/cloud/overview.mdx
@@ -10,7 +10,7 @@ description: "Programmatic access to Comfy Cloud for running workflows, managing
 
 # v1 Cloud API
 
-The v1 Cloud API provides programmatic access to Comfy Cloud, Comfy's managed service for running workflows on cloud infrastructure. The API is compatible with local ComfyUI's API, making it easy to migrate existing integrations.
+The v1 Cloud API provides programmatic access to Comfy Cloud, Comfy's managed service for running workflows on cloud infrastructure.
 
 Comfy Cloud is a stateful application. Your account carries state that persists across jobs: credits and subscription tier, uploaded assets and generated outputs, the job queue, and the set of installed models and nodes. The v1 API is the surface for that whole application, so it contains functionality not supported in the portable [Comfy API v2](/api-reference/v2/overview), such as queue management, model browsing, node definitions, and account endpoints. Use v2 (or the SDKs that wrap it) to submit workflows and retrieve results in a way that also works against serverless deployments and self-hosted ComfyUI. Use v1 for the Cloud-specific capabilities around it.
 

--- a/development/comfy-api/overview.mdx
+++ b/development/comfy-api/overview.mdx
@@ -10,8 +10,8 @@ The public API for running ComfyUI headlessly has evolved over time. For new int
   <Card title="Comfy API v2" icon="cloud" href="/api-reference/v2/overview">
     The versioned HTTP API for running workflows from any language, on any surface. Start here.
   </Card>
-  <Card title="v1 Cloud API" icon="clock-rotate-left" href="/development/cloud/overview">
-    Deprecated. The older Comfy Cloud API, still available for existing integrations.
+  <Card title="v1 Cloud API (deprecated)" icon="clock-rotate-left" href="/development/cloud/overview">
+    The older Comfy Cloud API, still available for existing integrations.
   </Card>
 </CardGroup>
 

--- a/development/comfy-api/overview.mdx
+++ b/development/comfy-api/overview.mdx
@@ -1,0 +1,18 @@
+---
+title: "Comfy API"
+sidebarTitle: "Overview"
+description: "The public API for running ComfyUI workflows headlessly"
+---
+
+The public API for running ComfyUI headlessly has evolved over time. For new integrations, use [Comfy API v2](/api-reference/v2/overview). It is supported on open-source ComfyUI, Comfy Cloud, and the new [Serverless API](/development/serverless/overview). Older versions include the [v1 Cloud API](/development/cloud/overview), which is deprecated.
+
+<CardGroup cols={2}>
+  <Card title="Comfy API v2" icon="cloud" href="/api-reference/v2/overview">
+    The versioned HTTP API for running workflows from any language, on any surface. Start here.
+  </Card>
+  <Card title="v1 Cloud API" icon="clock-rotate-left" href="/development/cloud/overview">
+    Deprecated. The older Comfy Cloud API, still available for existing integrations.
+  </Card>
+</CardGroup>
+
+See also: [Serverless API](/development/serverless/overview) · [Comfy SDKs](/development/api-development/sdks) · [Getting an API Key](/development/api-development/getting-an-api-key)

--- a/development/overview.mdx
+++ b/development/overview.mdx
@@ -25,15 +25,15 @@ Run ComfyUI in your own environment and expose it as an API endpoint. Learn abou
 
 See also: [API Examples](/development/comfyui-server/api-examples) · [Partner Node API Integration](/development/comfyui-server/api-key-integration)
 
-## Cloud API
+## Comfy API
 
-Run workflows programmatically on Comfy Cloud without managing your own hardware. Use the REST API, browse the OpenAPI spec, and integrate Partner Nodes via API Key.
+Two API surfaces, one job: run workflows and get results back. [Comfy API v2](/api-reference/v2/overview) is the versioned interface that works against Comfy Cloud, serverless deployments, and open-source ComfyUI via a local proxy. The [v1 Cloud API](/development/cloud/overview) is the full surface of Comfy Cloud as a stateful application, covering queue management, models, and account endpoints that v2 does not.
 
-<Card title="Cloud API Overview" icon="cloud" href="/development/cloud/overview">
-  Learn how to authenticate, submit jobs, check status, and download results from Comfy Cloud.
+<Card title="Comfy API v2 Overview" icon="cloud" href="/api-reference/v2/overview">
+  The versioned HTTP API for running workflows from any language, on any surface.
 </Card>
 
-See also: [API Reference](/development/cloud/api-reference) · [OpenAPI Specification](/development/cloud/openapi) · [Getting an API Key](/development/api-development/getting-an-api-key) · [APIs Overview](/development/api-development/overview)
+See also: [v1 Cloud API Overview](/development/cloud/overview) · [Cloud API Reference](/development/cloud/api-reference) · [OpenAPI Specification](/development/cloud/openapi) · [Getting an API Key](/development/api-development/getting-an-api-key) · [APIs Overview](/development/api-development/overview)
 
 ## Agent Tools / MCP
 

--- a/development/overview.mdx
+++ b/development/overview.mdx
@@ -27,13 +27,13 @@ See also: [API Examples](/development/comfyui-server/api-examples) · [Partner N
 
 ## Comfy API
 
-Two API surfaces, one job: run workflows and get results back. [Comfy API v2](/api-reference/v2/overview) is the versioned interface that works against Comfy Cloud, serverless deployments, and open-source ComfyUI via a local proxy. The [v1 Cloud API](/development/cloud/overview) is the full surface of Comfy Cloud as a stateful application, covering queue management, models, and account endpoints that v2 does not.
+The public API for running ComfyUI headlessly has evolved over time. For new integrations, use [Comfy API v2](/api-reference/v2/overview). It is supported on open-source ComfyUI, Comfy Cloud, and the new [Serverless API](/development/serverless/overview). Older versions include the [v1 Cloud API](/development/cloud/overview), which is deprecated.
 
 <Card title="Comfy API v2 Overview" icon="cloud" href="/api-reference/v2/overview">
   The versioned HTTP API for running workflows from any language, on any surface.
 </Card>
 
-See also: [v1 Cloud API Overview](/development/cloud/overview) · [Cloud API Reference](/development/cloud/api-reference) · [OpenAPI Specification](/development/cloud/openapi) · [Getting an API Key](/development/api-development/getting-an-api-key) · [APIs Overview](/development/api-development/overview)
+See also: [Serverless API](/development/serverless/overview) · [v1 Cloud API Overview](/development/cloud/overview) · [Getting an API Key](/development/api-development/getting-an-api-key) · [APIs Overview](/development/api-development/overview)
 
 ## Agent Tools / MCP
 

--- a/docs.json
+++ b/docs.json
@@ -2789,7 +2789,7 @@
                     ]
                   },
                   {
-                    "group": "v1 Cloud API",
+                    "group": "v1 Cloud API (deprecated)",
                     "pages": [
                       "development/cloud/overview",
                       "development/cloud/api-reference",

--- a/docs.json
+++ b/docs.json
@@ -2784,6 +2784,7 @@
                         "group": "v2",
                         "pages": [
                           "api-reference/v2/overview",
+                          "development/api-development/sdks-design",
                           {
                             "group": "API Reference",
                             "openapi": {
@@ -2810,7 +2811,6 @@
                       }
                     ]
                   },
-                  "development/api-development/sdks-design",
                   "development/api-development/workflow-api-format",
                   "development/api-development/workflow-metadata"
                 ]

--- a/docs.json
+++ b/docs.json
@@ -2767,22 +2767,32 @@
                 "group": "Develop with Comfy",
                 "pages": [
                   "development/overview",
+                  "development/api-development/overview",
+                  "development/api-development/getting-an-api-key"
+                ]
+              },
+              {
+                "group": "Comfy API",
+                "pages": [
                   {
-                    "group": "Comfy Cloud",
+                    "group": "v2",
+                    "pages": [
+                      "api-reference/v2/overview",
+                      {
+                        "group": "API Reference",
+                        "openapi": {
+                          "source": "openapi-v2.yaml",
+                          "directory": "api-reference/v2"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "group": "v1 Cloud API",
                     "pages": [
                       "development/cloud/overview",
                       "development/cloud/api-reference",
                       "development/cloud/openapi"
-                    ]
-                  },
-                  {
-                    "group": "Self-Hosted Server",
-                    "pages": [
-                      "development/comfyui-server/comms_overview",
-                      "development/comfyui-server/api-examples",
-                      "development/comfyui-server/comms_routes",
-                      "development/comfyui-server/comms_messages",
-                      "development/comfyui-server/startup-flags"
                     ]
                   }
                 ]
@@ -2792,19 +2802,19 @@
                 "pages": [
                   "development/api-development/sdks",
                   "development/serverless/overview",
-                  "development/api-development/getting-an-api-key",
-                  "development/api-development/overview",
-                  "api-reference/v2/overview",
-                  {
-                    "group": "Comfy API v2 Reference",
-                    "openapi": {
-                      "source": "openapi-v2.yaml",
-                      "directory": "api-reference/v2"
-                    }
-                  },
                   "development/api-development/sdks-design",
                   "development/api-development/workflow-api-format",
-                  "development/api-development/workflow-metadata",
+                  "development/api-development/workflow-metadata"
+                ]
+              },
+              {
+                "group": "Self-Hosted Server",
+                "pages": [
+                  "development/comfyui-server/comms_overview",
+                  "development/comfyui-server/api-examples",
+                  "development/comfyui-server/comms_routes",
+                  "development/comfyui-server/comms_messages",
+                  "development/comfyui-server/startup-flags",
                   "development/comfyui-server/api-key-integration"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -2774,6 +2774,7 @@
               {
                 "group": "Comfy API",
                 "pages": [
+                  "development/comfy-api/overview",
                   {
                     "group": "v2",
                     "pages": [
@@ -2792,7 +2793,14 @@
                     "pages": [
                       "development/cloud/overview",
                       "development/cloud/api-reference",
-                      "development/cloud/openapi"
+                      "development/cloud/openapi",
+                      {
+                        "group": "Cloud API Reference",
+                        "openapi": {
+                          "source": "openapi-cloud.yaml",
+                          "directory": "api-reference/cloud"
+                        }
+                      }
                     ]
                   }
                 ]
@@ -2982,13 +2990,6 @@
                 ]
               }
             ]
-          },
-          {
-            "tab": "Cloud API Reference",
-            "openapi": {
-              "source": "openapi-cloud.yaml",
-              "directory": "api-reference/cloud"
-            }
           }
         ]
       },

--- a/docs.json
+++ b/docs.json
@@ -2772,44 +2772,44 @@
                 ]
               },
               {
-                "group": "Comfy API",
-                "pages": [
-                  "development/comfy-api/overview",
-                  {
-                    "group": "v2",
-                    "pages": [
-                      "api-reference/v2/overview",
-                      {
-                        "group": "API Reference",
-                        "openapi": {
-                          "source": "openapi-v2.yaml",
-                          "directory": "api-reference/v2"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "group": "v1 Cloud API (deprecated)",
-                    "pages": [
-                      "development/cloud/overview",
-                      "development/cloud/api-reference",
-                      "development/cloud/openapi",
-                      {
-                        "group": "Cloud API Reference",
-                        "openapi": {
-                          "source": "openapi-cloud.yaml",
-                          "directory": "api-reference/cloud"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
                 "group": "Run Workflows",
                 "pages": [
                   "development/api-development/sdks",
                   "development/serverless/overview",
+                  {
+                    "group": "Comfy API",
+                    "pages": [
+                      "development/comfy-api/overview",
+                      {
+                        "group": "v2",
+                        "pages": [
+                          "api-reference/v2/overview",
+                          {
+                            "group": "API Reference",
+                            "openapi": {
+                              "source": "openapi-v2.yaml",
+                              "directory": "api-reference/v2"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "group": "v1 Cloud API (deprecated)",
+                        "pages": [
+                          "development/cloud/overview",
+                          "development/cloud/api-reference",
+                          "development/cloud/openapi",
+                          {
+                            "group": "Cloud API Reference",
+                            "openapi": {
+                              "source": "openapi-cloud.yaml",
+                              "directory": "api-reference/cloud"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
                   "development/api-development/sdks-design",
                   "development/api-development/workflow-api-format",
                   "development/api-development/workflow-metadata"


### PR DESCRIPTION
## Summary
Restructured the API documentation to clearly distinguish between Comfy API v2 (the new versioned interface) and v1 Cloud API (the legacy Cloud-specific surface), while reorganizing the sidebar navigation to improve discoverability and logical grouping.

## Key Changes

- **Reorganized sidebar navigation** in `docs.json`:
  - Moved API development overview and getting-an-API-key under "Develop with Comfy"
  - Created new "Comfy API" section with v2 and v1 Cloud API subsections
  - Moved self-hosted server documentation to its own top-level section
  - Consolidated v2 OpenAPI reference under the v2 subsection

- **Updated API overview pages** to clarify the v1/v2 distinction:
  - Renamed "Cloud API Overview" to "v1 Cloud API Overview" in `development/cloud/overview.mdx`
  - Added explanation that v1 is Cloud-specific (queue management, models, accounts) while v2 is portable
  - Updated `api-reference/v2/overview.mdx` with new "Where v2 Runs" section explaining the three surfaces: Comfy Cloud, serverless deployments, and self-hosted ComfyUI via proxy
  - Added details about `comfy-api-proxy` for self-hosted deployments

- **Updated navigation and cross-references** across multiple pages:
  - Changed "Cloud API" references to "v1 Cloud API" for clarity
  - Updated `development/overview.mdx` to emphasize v2 as the primary API with v1 as Cloud-specific
  - Updated `development/api-development/overview.mdx` comparison table to use "v1 Cloud API" terminology
  - Added `sidebarTitle` fields to improve sidebar display

## Implementation Details

The changes maintain backward compatibility while making the documentation structure more intuitive. The v2 API is now positioned as the primary, portable interface for new integrations, with v1 Cloud API clearly marked as the legacy, Cloud-specific surface. The sidebar reorganization groups related content and reduces cognitive load when navigating between different API options.

https://claude.ai/code/session_01B8JBWRivW5FGzSiaprq4eG