### PR TITLE
Move Self-Hosted Server API under Self-Hosting Options and rename Comfy API group

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3259,7 +3259,23 @@
                   "development/deploy/overview",
                   "development/serverless/overview",
                   "development/deploy/cloud",
-                  "development/deploy/self-hosting"
+                  {
+                    "group": "Self-Hosting Options",
+                    "pages": [
+                      "development/deploy/self-hosting",
+                      {
+                        "group": "Self-Hosted Server API",
+                        "pages": [
+                          "development/comfyui-server/comms_overview",
+                          "development/comfyui-server/api-examples",
+                          "development/comfyui-server/comms_routes",
+                          "development/comfyui-server/comms_messages",
+                          "development/comfyui-server/startup-flags",
+                          "development/comfyui-server/api-key-integration"
+                        ]
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3271,7 +3287,7 @@
                   "development/api-development/workflow-api-format",
                   "development/api-development/workflow-metadata",
                   {
-                    "group": "Comfy API",
+                    "group": "Comfy API Reference",
                     "pages": [
                       "development/comfy-api/overview",
                       {
@@ -3305,17 +3321,6 @@
                       }
                     ]
                   }
-                ]
-              },
-              {
-                "group": "Self-Hosted Server API",
-                "pages": [
-                  "development/comfyui-server/comms_overview",
-                  "development/comfyui-server/api-examples",
-                  "development/comfyui-server/comms_routes",
-                  "development/comfyui-server/comms_messages",
-                  "development/comfyui-server/startup-flags",
-                  "development/comfyui-server/api-key-integration"
                 ]
               },
               {


### PR DESCRIPTION
## Summary

Restructures the English navigation in `docs.json` (API Development tab):

- Nests the **Self-Hosted Server API** pages under a new **Self-Hosting Options** group inside **Deploy ComfyUI**, alongside the existing self-hosting page. The old standalone top-level group is removed. The sidebar now reads: Deploy ComfyUI → Self-Hosting Options → Self-Hosted Server API.
- Renames the **Comfy API** group in **Run Workflows** to **Comfy API Reference**.

No pages were added or removed; only navigation grouping changed. The ja/zh/ko navigations are untouched and will be updated through the i18n pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B82uuddgPdGiMvyRCAZWgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B82uuddgPdGiMvyRCAZWgk)_