### PR TITLE
Reorganize developer documentation sections

### DIFF
--- a/custom-nodes/intro.mdx
+++ b/custom-nodes/intro.mdx
@@ -4,6 +4,10 @@ sidebarTitle: "Overview"
 description: "Choose the right path for building, extending, and publishing ComfyUI custom nodes."
 ---
 
+<Note>
+This section only covers how to develop custom nodes. If you are interested in how to use custom nodes, see [Install Custom Nodes](/installation/install_custom_node) in the Get Started section.
+</Note>
+
 Custom Nodes extend ComfyUI with new server-side behavior, user-interface features, and integrations. Choose a path based on what you are trying to do.
 
 <CardGroup cols={2}>

--- a/docs.json
+++ b/docs.json
@@ -3244,7 +3244,7 @@
             ]
           },
           {
-            "tab": "API Development",
+            "tab": "Developers",
             "pages": [
               {
                 "group": "Develop with Comfy",

--- a/index.mdx
+++ b/index.mdx
@@ -157,18 +157,18 @@ The most powerful open source node-based application for generative AI
       Run ComfyUI locally, on a server, or in the cloud
     </Card>
     <Card
-      title="Contribute"
-      icon="code-pull-request"
-      href="/community/contributing#how-to-contribute"
-    >
-      Contribute to ComfyUI development
-    </Card>
-    <Card
       title="Run Workflows"
       icon="play"
       href="/development/run-workflows/overview"
     >
       Run workflows against a deployment from your application
+    </Card>
+    <Card
+      title="Contribute"
+      icon="code-pull-request"
+      href="/community/contributing#how-to-contribute"
+    >
+      Contribute to ComfyUI development
     </Card>
   </CardGroup>
 </div>

--- a/index.mdx
+++ b/index.mdx
@@ -145,44 +145,51 @@ The most powerful open source node-based application for generative AI
   </CardGroup>
 </div>
 
-{/* Development Section */}
+{/* Developers Section */}
 <div className="mb-12">
-  <h2 className="text-2xl font-bold mb-6 text-center">Development & Extension</h2>
+  <h2 className="text-2xl font-bold mb-6 text-center">Developers</h2>
   <CardGroup cols={3}>
     <Card
-      title="Development Guide"
-      icon="code"
+      title="Deploy ComfyUI"
+      icon="server"
       href="/development/overview"
+    >
+      Run ComfyUI locally, on a server, or in the cloud
+    </Card>
+    <Card
+      title="Contribute"
+      icon="code-pull-request"
+      href="/community/contributing#how-to-contribute"
     >
       Contribute to ComfyUI development
     </Card>
     <Card
-      title="Custom Nodes"
+      title="Run Workflows"
+      icon="play"
+      href="/development/run-workflows/overview"
+    >
+      Run workflows against a deployment from your application
+    </Card>
+  </CardGroup>
+</div>
+
+{/* Build Custom Nodes Section */}
+<div className="mb-12">
+  <h2 className="text-2xl font-bold mb-6 text-center">Build Custom Nodes</h2>
+  <CardGroup cols={3}>
+    <Card
+      title="Getting Started"
       icon="puzzle-piece"
-      href="/custom-nodes/overview"
+      href="/custom-nodes/walkthrough"
     >
-      Create and publish custom nodes
+      Create your first custom node step by step
     </Card>
     <Card
-      title="Local API"
-      icon="terminal"
-      href="/development/comfyui-server/comms_overview"
+      title="Publish my Custom Node"
+      icon="upload"
+      href="/registry/publishing"
     >
-      Integrate with local ComfyUI server
-    </Card>
-    <Card
-      title="Cloud API"
-      icon="cloud"
-      href="/development/cloud/overview"
-    >
-      Run workflows via ComfyUI Cloud API
-    </Card>
-    <Card
-      title="Cloud API Reference"
-      icon="book"
-      href="/development/cloud/api-reference"
-    >
-      Explore the ComfyUI Cloud API reference
+      Share your custom node on the Comfy Registry
     </Card>
   </CardGroup>
 </div>


### PR DESCRIPTION
## Summary
Restructured the developer-focused documentation sections on the landing page to better organize content by use case and skill level.

## Key Changes
- Renamed "Development & Extension" section to "Developers" with a focus on deployment and integration
- Reorganized cards to prioritize deployment options, contribution, and workflow execution
- Created new "Build Custom Nodes" section with dedicated cards for custom node development
- Updated card titles, icons, and descriptions to better reflect their purposes:
  - "Development Guide" → "Deploy ComfyUI" (server icon)
  - "Custom Nodes" → moved to new section with "Getting Started" card
  - "Local API" and "Cloud API" cards removed from main developers section
  - Added "Run Workflows" card for application integration
  - Added "Publish my Custom Node" card for registry publishing

## Implementation Details
- Split the original 5-card section into two focused sections
- Adjusted href paths to point to appropriate documentation pages
- Maintained responsive 3-column grid layout for both sections
- Improved information hierarchy by separating deployment/integration from custom node development

https://claude.ai/code/session_012FrAktUHaozbXhM1ysKZ4d