### PR TITLE
docs: add the MiniMax commercial license pricing table to the H3 tutorial

### DIFF
--- a/ja/tutorials/video/minimax/minimax-h3.mdx
+++ b/ja/tutorials/video/minimax/minimax-h3.mdx
@@ -2,16 +2,17 @@
 title: "MiniMax H3 ComfyUIチュートリアル | AI動画生成ワークフローガイド"
 description: "MiniMax H3は、T2V、I2V、R2VワークフローによるComfyUIでのAI動画生成を実現します。モデル設定、動画生成、ネイティブステレオ音声生成機能について紹介します。"
 sidebarTitle: "MiniMax H3"
-translationSourceHash: f5234ad3
+translationSourceHash: 42f026f9
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
-  "_intro": 4c7a3600
+  "_intro": d7ad1d5d
   "Key features": 7bfa7de1
   "Getting started": fddf949c
   "Setting the output resolution": b3a75643
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
+  "Commercial licensing": ace612cc
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3) は、MiniMaxの汎用オムニモーダル生成モデルで、現在はオープンウェイトとして公開されています。テキスト、画像、ビデオ、オーディオを単一のコンテキストで統合的に理解し、**ネイティブステレオオーディオ**付きのビデオを生成します。つまり、音声、サウンドエフェクト、音楽は、後から重ね合わせるのではなく、単一のフォワードパスでまとめてモデル化されます。出力は最大2K解像度、24fps、約15秒です。
@@ -25,6 +26,9 @@ ComfyUI は MiniMax H3 をネイティブにサポートしています。テン
 これら 3 つはサンプルテンプレートであり、モデルの全機能を網羅したものではありません。ネイティブの MiniMax H3 ノードを使うと、より多くの生成モードに対応できます：`MiniMaxH3ImageToVideo` ノードによる先頭/末尾フレームの画像からビデオ生成（fl2va）、`MiniMaxH3ReferenceToVideo` ノードによる画像・ビデオ・オーディオ参照駆動の生成（ref2va）。これらのノードで追加のワークフローを構築することもできます。
 
 <UpdateReminder/>
+<Note>
+H3 のオープンウェイトはローカルで実行できます。ローカル生成した出力を商用利用するには、唯一の公式販売代理店である Comfy を通じて [MiniMax 商用ライセンス](https://comfy.org/minimax/license) が必要です。Comfy Cloud 上の生成にはすでに商用利用権が含まれています。ティアと料金は [商用ライセンス](#商用ライセンス) を参照してください。
+</Note>
 
 ## 主な機能
 
@@ -336,3 +340,22 @@ MiniMax H3 ノードの `positive` 出力と latent 出力を `MiniMaxH3AddGuide
 
 - Sage Attention は float16 または bfloat16 テンソルを必要とします。MiniMax H3 の一部のレイヤーは他の dtype で実行されるため、コンソールに "Input tensors must be in dtype of torch.float16 or torch.bfloat16, using pytorch attention instead" というメッセージが表示されることがあります。これは正常です。影響を受けるレイヤーは標準アテンションにフォールバックし、生成は正常に動作します。
 - 別の方法として、ノードを追加せずに `--use-sage-attention` フラグ付きで ComfyUI を起動して、Sage Attention をグローバルに有効にすることもできます。
+
+## 商用ライセンス
+
+H3 のオープンウェイトは無料でダウンロードして実行できます。ローカル生成した出力を商用利用するには、唯一の公式販売代理店である Comfy を通じて販売される [MiniMax 商用ライセンス](https://comfy.org/minimax/license) が必要です。Comfy Cloud 上の生成にはすでに商用利用権が含まれているため、ライセンスが必要になるのはローカル利用の場合のみです。
+
+ライセンスは 2 つのティアがあります：
+
+|                           | Professional           | Enterprise                                                   |
+| ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| 料金                      | 月額 $5,000            | 年額 $240,000 から                                           |
+| 契約期間                  | 月次                   | 最短 12 か月                                                 |
+| ライセンスユーザー        | 最大 10 人             | 上限なし                                                     |
+| ドメイン                  | 1                      | カスタム                                                     |
+| モデルバージョン          | Distilled オープンウェイト | 全バージョン（非 Distilled ウェイトと新リリースを含む） |
+| 出力の商用利用            | 完全な商用利用権       | 完全な商用利用権                                             |
+| ファインチューニングと LoRA | 含む                 | 含む                                                         |
+| クライアントおよび下流の作業 | 含む                  | 含む                                                         |
+
+Enterprise 契約は年額 $240,000 からで、生成量とチーム規模に応じて決まります。いずれのティアも、1 つの契約で MiniMax H3 と MiniMax Audio & Music をカバーします。[ライセンスをリクエスト](https://comfy.org/contact) して見積もりを取得してください。

--- a/ja/tutorials/video/minimax/minimax-h3.mdx
+++ b/ja/tutorials/video/minimax/minimax-h3.mdx
@@ -2,7 +2,7 @@
 title: "MiniMax H3 ComfyUIチュートリアル | AI動画生成ワークフローガイド"
 description: "MiniMax H3は、T2V、I2V、R2VワークフローによるComfyUIでのAI動画生成を実現します。モデル設定、動画生成、ネイティブステレオ音声生成機能について紹介します。"
 sidebarTitle: "MiniMax H3"
-translationSourceHash: 42f026f9
+translationSourceHash: 34a4d722
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
   "_intro": d7ad1d5d
@@ -12,7 +12,7 @@ translationBlockHashes:
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
-  "Commercial licensing": ace612cc
+  "Commercial licensing": 201e2de5
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3) は、MiniMaxの汎用オムニモーダル生成モデルで、現在はオープンウェイトとして公開されています。テキスト、画像、ビデオ、オーディオを単一のコンテキストで統合的に理解し、**ネイティブステレオオーディオ**付きのビデオを生成します。つまり、音声、サウンドエフェクト、音楽は、後から重ね合わせるのではなく、単一のフォワードパスでまとめてモデル化されます。出力は最大2K解像度、24fps、約15秒です。
@@ -345,11 +345,17 @@ MiniMax H3 ノードの `positive` 出力と latent 出力を `MiniMaxH3AddGuide
 
 H3 のオープンウェイトは無料でダウンロードして実行できます。ローカル生成した出力を商用利用するには、唯一の公式販売代理店である Comfy を通じて販売される [MiniMax 商用ライセンス](https://comfy.org/minimax/license) が必要です。Comfy Cloud 上の生成にはすでに商用利用権が含まれているため、ライセンスが必要になるのはローカル利用の場合のみです。
 
+ライセンスは必要ですか？
+
+- **Comfy Cloud**：商用利用が含まれています。購入は不要です。
+- **米国、EU、英国、韓国以外で自社ハードウェア上で実行し、年間売上が 2,000 万米ドル未満**：MiniMax の無料コミュニティライセンスで商用利用がカバーされます。"Powered by MiniMax H3" のクレジットを表示してください。同じ地域ルールは出力の利用地にも適用されます。
+- **米国、EU、英国、韓国で自社ハードウェア上で実行する、または年間売上が 2,000 万米ドル超**：以下の 2 つのライセンスのいずれかが必要です。
+
 ライセンスは 2 つのティアがあります：
 
 |                           | Professional           | Enterprise                                                   |
 | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| 料金                      | 月額 $5,000            | 年額 $240,000 から                                           |
+| 価格                      | 月額 $5,000 から       | カスタム。年間契約、利用量に応じた価格                       |
 | 契約期間                  | 月次                   | 最短 12 か月                                                 |
 | ライセンスユーザー        | 最大 10 人             | 上限なし                                                     |
 | ドメイン                  | 1                      | カスタム                                                     |
@@ -358,4 +364,4 @@ H3 のオープンウェイトは無料でダウンロードして実行でき�
 | ファインチューニングと LoRA | 含む                 | 含む                                                         |
 | クライアントおよび下流の作業 | 含む                  | 含む                                                         |
 
-Enterprise 契約は年額 $240,000 からで、生成量とチーム規模に応じて決まります。いずれのティアも、1 つの契約で MiniMax H3 と MiniMax Audio & Music をカバーします。[ライセンスをリクエスト](https://comfy.org/contact) して見積もりを取得してください。
+Professional は月額 $5,000 からです。Enterprise には定価がなく、生成量とチーム規模に応じて見積もります。いずれのティアも、1 つの契約で MiniMax H3 と MiniMax Audio & Music をカバーします。[ライセンスをリクエスト](https://comfy.org/contact) して見積もりを取得してください。

--- a/ko/tutorials/video/minimax/minimax-h3.mdx
+++ b/ko/tutorials/video/minimax/minimax-h3.mdx
@@ -2,16 +2,17 @@
 title: "ComfyUI에서 MiniMax H3 사용: T2V, I2V, R2V 비디오 워크플로"
 description: "ComfyUI에서 오픈 가중치 MiniMax H3를 사용하는 방법을 알아보세요. 텍스트 기반, 이미지 기반, 레퍼런스 기반 비디오 생성을 위한 네이티브 워크플로를 제공하며 스테레오 오디오를 지원합니다."
 sidebarTitle: "MiniMax H3"
-translationSourceHash: f5234ad3
+translationSourceHash: 42f026f9
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
-  "_intro": 4c7a3600
+  "_intro": d7ad1d5d
   "Key features": 7bfa7de1
   "Getting started": fddf949c
   "Setting the output resolution": b3a75643
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
+  "Commercial licensing": ace612cc
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3)는 MiniMax의 범용 옴니모달 생성 모델로, 현재 오픈 가중치로 제공됩니다. 이 모델은 단일 컨텍스트에서 텍스트, 이미지, 비디오, 오디오를 함께 이해하며, **네이티브 스테레오 오디오**로 비디오를 생성합니다. 음성, 사운드 효과, 음악이 이후에 덧붙여지는 대신 단일 포워드 패스에서 함께 모델링됩니다. 출력은 최대 2K 해상도, 24fps, 약 15초입니다.
@@ -25,6 +26,9 @@ ComfyUI는 MiniMax H3를 네이티브로 지원합니다. 템플릿 라이브러
 이 세 가지는 예제 템플릿이며 모델의 전체 기능을 나열한 것이 아닙니다. 네이티브 MiniMax H3 노드를 통해 더 많은 생성 모드를 사용할 수 있습니다: `MiniMaxH3ImageToVideo` 노드로 첫 번째/마지막 프레임 이미지-비디오 생성(fl2va), `MiniMaxH3ReferenceToVideo` 노드로 이미지, 비디오, 오디오 레퍼런스 기반 생성(ref2va)이 가능합니다. 이 노드들로 추가 워크플로를 직접 구축할 수도 있습니다.
 
 <UpdateReminder/>
+<Note>
+H3의 오픈 가중치는 로컬에서 실행할 수 있습니다. 로컬에서 생성한 출력물을 상업적으로 사용하려면 Comfy(유일한 공식 유통사)를 통해 [MiniMax 상업용 라이선스](https://comfy.org/minimax/license)가 필요합니다. Comfy Cloud에서 생성한 결과물에는 이미 상업적 사용 권한이 포함되어 있습니다. 티어와 가격은 [상업적 라이선스](#상업적-라이선스)를 참조하세요.
+</Note>
 
 ## 주요 기능
 
@@ -336,3 +340,22 @@ MiniMax H3 노드의 `positive` 출력과 latent 출력을 `MiniMaxH3AddGuide`�
 
 - Sage Attention은 float16 또는 bfloat16 텐서가 필요합니다. MiniMax H3의 일부 레이어는 다른 dtype으로 실행되므로 콘솔에 "Input tensors must be in dtype of torch.float16 or torch.bfloat16, using pytorch attention instead" 메시지가 표시될 수 있습니다. 이는 정상입니다. 영향을 받는 레이어는 표준 어텐션으로 대체되며 생성은 계속 정상 작동합니다.
 - 또는 노드를 추가하는 대신 `--use-sage-attention` 플래그로 ComfyUI를 시작하여 Sage Attention을 전역적으로 활성화할 수도 있습니다.
+
+## 상업적 라이선스
+
+H3의 오픈 가중치는 무료로 다운로드하고 실행할 수 있습니다. 로컬에서 생성한 출력물을 상업적으로 사용하려면 Comfy(유일한 공식 유통사)를 통해 판매되는 [MiniMax 상업용 라이선스](https://comfy.org/minimax/license)가 필요합니다. Comfy Cloud에서 생성한 결과물에는 이미 상업적 사용 권한이 포함되어 있으므로, 라이선스가 필요한 것은 로컬 사용의 경우뿐입니다.
+
+라이선스는 두 가지 티어로 제공됩니다:
+
+|                           | Professional           | Enterprise                                                   |
+| ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| 가격                      | 월 $5,000              | 연 $240,000부터                                              |
+| 계약 기간                 | 월 단위                | 최소 12개월                                                  |
+| 라이선스 사용자           | 최대 10명              | 상한 없음                                                    |
+| 도메인                    | 1                      | 맞춤 설정                                                    |
+| 모델 버전                 | Distilled 오픈 가중치  | 모든 버전, undistilled 가중치 및 신규 릴리스 포함            |
+| 출력물의 상업적 사용      | 완전한 상업적 사용 권한 | 완전한 상업적 사용 권한                                     |
+| 파인튜닝 및 LoRA          | 포함                   | 포함                                                         |
+| 클라이언트 및 다운스트림 작업 | 포함                 | 포함                                                         |
+
+Enterprise 계약은 연 $240,000부터이며, 생성량과 팀 규모에 따라 산정됩니다. 두 티어 모두 하나의 계약으로 MiniMax H3와 MiniMax Audio & Music을 포함합니다. [라이선스 요청](https://comfy.org/contact)으로 견적을 받으세요.

--- a/ko/tutorials/video/minimax/minimax-h3.mdx
+++ b/ko/tutorials/video/minimax/minimax-h3.mdx
@@ -2,7 +2,7 @@
 title: "ComfyUI에서 MiniMax H3 사용: T2V, I2V, R2V 비디오 워크플로"
 description: "ComfyUI에서 오픈 가중치 MiniMax H3를 사용하는 방법을 알아보세요. 텍스트 기반, 이미지 기반, 레퍼런스 기반 비디오 생성을 위한 네이티브 워크플로를 제공하며 스테레오 오디오를 지원합니다."
 sidebarTitle: "MiniMax H3"
-translationSourceHash: 42f026f9
+translationSourceHash: 34a4d722
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
   "_intro": d7ad1d5d
@@ -12,7 +12,7 @@ translationBlockHashes:
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
-  "Commercial licensing": ace612cc
+  "Commercial licensing": 201e2de5
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3)는 MiniMax의 범용 옴니모달 생성 모델로, 현재 오픈 가중치로 제공됩니다. 이 모델은 단일 컨텍스트에서 텍스트, 이미지, 비디오, 오디오를 함께 이해하며, **네이티브 스테레오 오디오**로 비디오를 생성합니다. 음성, 사운드 효과, 음악이 이후에 덧붙여지는 대신 단일 포워드 패스에서 함께 모델링됩니다. 출력은 최대 2K 해상도, 24fps, 약 15초입니다.
@@ -345,11 +345,17 @@ MiniMax H3 노드의 `positive` 출력과 latent 출력을 `MiniMaxH3AddGuide`�
 
 H3의 오픈 가중치는 무료로 다운로드하고 실행할 수 있습니다. 로컬에서 생성한 출력물을 상업적으로 사용하려면 Comfy(유일한 공식 유통사)를 통해 판매되는 [MiniMax 상업용 라이선스](https://comfy.org/minimax/license)가 필요합니다. Comfy Cloud에서 생성한 결과물에는 이미 상업적 사용 권한이 포함되어 있으므로, 라이선스가 필요한 것은 로컬 사용의 경우뿐입니다.
 
+라이선스가 필요한가요?
+
+- **Comfy Cloud**: 상업적 사용이 포함되어 있습니다. 별도 구매가 필요 없습니다.
+- **미국, EU, 영국, 한국 외 지역의 자체 하드웨어에서 실행하고 연 매출이 2,000만 달러 미만**: MiniMax 무료 커뮤니티 라이선스로 상업적 사용이 가능합니다. "Powered by MiniMax H3" 크레딧을 표시하세요. 동일한 지역 규칙이 결과물의 사용 지역에도 적용됩니다.
+- **미국, EU, 영국 또는 한국의 자체 하드웨어에서 실행하거나 연 매출이 2,000만 달러 초과**: 아래 두 라이선스 중 하나가 필요합니다.
+
 라이선스는 두 가지 티어로 제공됩니다:
 
 |                           | Professional           | Enterprise                                                   |
 | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| 가격                      | 월 $5,000              | 연 $240,000부터                                              |
+| 가격                      | 월 $5,000부터          | 맞춤형, 연간 계약, 사용량 기준 가격                          |
 | 계약 기간                 | 월 단위                | 최소 12개월                                                  |
 | 라이선스 사용자           | 최대 10명              | 상한 없음                                                    |
 | 도메인                    | 1                      | 맞춤 설정                                                    |
@@ -358,4 +364,4 @@ H3의 오픈 가중치는 무료로 다운로드하고 실행할 수 있습니�
 | 파인튜닝 및 LoRA          | 포함                   | 포함                                                         |
 | 클라이언트 및 다운스트림 작업 | 포함                 | 포함                                                         |
 
-Enterprise 계약은 연 $240,000부터이며, 생성량과 팀 규모에 따라 산정됩니다. 두 티어 모두 하나의 계약으로 MiniMax H3와 MiniMax Audio & Music을 포함합니다. [라이선스 요청](https://comfy.org/contact)으로 견적을 받으세요.
+Professional은 월 $5,000부터입니다. Enterprise는 정가가 없으며 생성량과 팀 규모에 따라 견적을 제공합니다. 두 티어 모두 하나의 계약으로 MiniMax H3와 MiniMax Audio & Music을 포함합니다. [라이선스 요청](https://comfy.org/contact)으로 견적을 받으세요.

--- a/tutorials/video/minimax/minimax-h3.mdx
+++ b/tutorials/video/minimax/minimax-h3.mdx
@@ -16,7 +16,7 @@ These three are example templates, not an exhaustive list. The model supports mo
 
 <UpdateReminder/>
 <Note>
-H3's open weights let you run the model locally. Commercial use of locally generated outputs requires a [MiniMax commercial license](https://comfy.org/minimax/license), available through Comfy, the only official reseller. Generations on Comfy Cloud already include commercial rights.
+H3's open weights let you run the model locally. Commercial use of locally generated outputs requires a [MiniMax commercial license](https://comfy.org/minimax/license), available through Comfy, the only official reseller. Generations on Comfy Cloud already include commercial rights. See [Commercial licensing](#commercial-licensing) for tiers and pricing.
 </Note>
 
 ## Key features
@@ -329,3 +329,22 @@ Notes:
 
 - Sage Attention requires float16 or bfloat16 tensors. MiniMax H3 runs some layers in other dtypes, so you may see "Input tensors must be in dtype of torch.float16 or torch.bfloat16, using pytorch attention instead" messages in the console. These are expected; the affected layers fall back to standard attention and generation still works.
 - Alternatively, you can enable Sage Attention globally by launching ComfyUI with the `--use-sage-attention` flag instead of adding the node.
+
+## Commercial licensing
+
+H3's open weights are free to download and run. Using locally generated outputs commercially requires a [MiniMax commercial license](https://comfy.org/minimax/license), sold through Comfy, the only official reseller. Generations on Comfy Cloud already include commercial rights, so a license is only needed for local use.
+
+Licenses come in two tiers:
+
+|                           | Professional           | Enterprise                                                   |
+| ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| Price                     | $5,000 per month       | Custom, annual agreement                                     |
+| Term                      | Monthly                | 12-month minimum                                             |
+| Licensed users            | Up to 10               | No cap                                                       |
+| Domains                   | 1                      | Custom                                                       |
+| Model versions            | Distilled open weights | All versions, undistilled weights and new releases included  |
+| Commercial use of outputs | Full commercial rights | Full commercial rights                                       |
+| Fine-tuning and LoRA      | Included               | Included                                                     |
+| Client and downstream work | Included              | Included                                                     |
+
+Enterprise pricing is sized to your generation volume and team. Both tiers cover MiniMax H3 plus MiniMax Audio & Music under one agreement. [Request a license](https://comfy.org/contact) to get a quote.

--- a/tutorials/video/minimax/minimax-h3.mdx
+++ b/tutorials/video/minimax/minimax-h3.mdx
@@ -334,11 +334,17 @@ Notes:
 
 H3's open weights are free to download and run. Using locally generated outputs commercially requires a [MiniMax commercial license](https://comfy.org/minimax/license), sold through Comfy, the only official reseller. Generations on Comfy Cloud already include commercial rights, so a license is only needed for local use.
 
+Do you need one?
+
+- **Comfy Cloud**: commercial use is included. Nothing to buy.
+- **Your own hardware, outside the US, EU, UK, and Korea, under $20M in yearly revenue**: the free MiniMax community license covers commercial use. Show a "Powered by MiniMax H3" credit; the same territory rule applies to where your outputs are used.
+- **Your own hardware in the US, EU, UK, or Korea, or over $20M in yearly revenue**: you need one of the two licenses below.
+
 Licenses come in two tiers:
 
 |                           | Professional           | Enterprise                                                   |
 | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| Price                     | $5,000 per month       | From $240,000 per year                                       |
+| Price                     | From $5,000 per month  | Custom, annual agreement, priced to your volume              |
 | Term                      | Monthly                | 12-month minimum                                             |
 | Licensed users            | Up to 10               | No cap                                                       |
 | Domains                   | 1                      | Custom                                                       |
@@ -347,4 +353,4 @@ Licenses come in two tiers:
 | Fine-tuning and LoRA      | Included               | Included                                                     |
 | Client and downstream work | Included              | Included                                                     |
 
-Enterprise agreements start at $240,000 per year, sized to your generation volume and team. Both tiers cover MiniMax H3 plus MiniMax Audio & Music under one agreement. [Request a license](https://comfy.org/contact) to get a quote.
+Professional starts at $5,000 per month. Enterprise has no flat list price; it is quoted to your generation volume and team. Both tiers cover MiniMax H3 plus MiniMax Audio & Music under one agreement. [Request a license](https://comfy.org/contact) to get a quote.

--- a/tutorials/video/minimax/minimax-h3.mdx
+++ b/tutorials/video/minimax/minimax-h3.mdx
@@ -338,7 +338,7 @@ Licenses come in two tiers:
 
 |                           | Professional           | Enterprise                                                   |
 | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| Price                     | $5,000 per month       | Custom, annual agreement                                     |
+| Price                     | $5,000 per month       | From $240,000 per year                                       |
 | Term                      | Monthly                | 12-month minimum                                             |
 | Licensed users            | Up to 10               | No cap                                                       |
 | Domains                   | 1                      | Custom                                                       |
@@ -347,4 +347,4 @@ Licenses come in two tiers:
 | Fine-tuning and LoRA      | Included               | Included                                                     |
 | Client and downstream work | Included              | Included                                                     |
 
-Enterprise pricing is sized to your generation volume and team. Both tiers cover MiniMax H3 plus MiniMax Audio & Music under one agreement. [Request a license](https://comfy.org/contact) to get a quote.
+Enterprise agreements start at $240,000 per year, sized to your generation volume and team. Both tiers cover MiniMax H3 plus MiniMax Audio & Music under one agreement. [Request a license](https://comfy.org/contact) to get a quote.

--- a/zh/tutorials/video/minimax/minimax-h3.mdx
+++ b/zh/tutorials/video/minimax/minimax-h3.mdx
@@ -2,16 +2,17 @@
 title: "在 ComfyUI 中使用 MiniMax H3：T2V、I2V 和 R2V 视频工作流"
 description: "了解如何在 ComfyUI 中使用开放权重的 MiniMax H3，通过原生工作流实现文生视频、图生视频和参考生视频，支持立体声音频。"
 sidebarTitle: "MiniMax H3"
-translationSourceHash: f5234ad3
+translationSourceHash: 42f026f9
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
-  "_intro": 4c7a3600
+  "_intro": d7ad1d5d
   "Key features": 7bfa7de1
   "Getting started": fddf949c
   "Setting the output resolution": b3a75643
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
+  "Commercial licensing": ace612cc
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3) 是 MiniMax 推出的通用全模态生成模型，现已以开放权重形式提供。它能在单一上下文中联合理解文本、图像、视频和音频，并生成带**原生立体声音频**的视频：语音、音效和音乐在单次前向传播中一并建模，而非事后叠加。输出最高支持 2K 分辨率、24fps，时长约 15 秒。
@@ -25,6 +26,9 @@ ComfyUI 原生支持 MiniMax H3。模板库目前提供三个示例工作流，�
 这三个是示例模板，并非模型能力的完整清单。通过原生 MiniMax H3 节点可以覆盖更多生成模式：`MiniMaxH3ImageToVideo` 节点支持首帧/末帧图生视频（fl2va），`MiniMaxH3ReferenceToVideo` 节点支持图像、视频和音频参考驱动的生成（ref2va）。你也可以用这些节点搭建其他工作流。
 
 <UpdateReminder/>
+<Note>
+H3 的开放权重可在本地运行。对本地生成的输出进行商业使用，需要通过 Comfy（唯一官方经销商）购买 [MiniMax 商业许可](https://comfy.org/minimax/license)。Comfy Cloud 上的生成已包含商业使用权。档位与定价见 [商业许可](#商业许可)。
+</Note>
 
 ## 主要功能
 
@@ -336,3 +340,22 @@ MiniMax 官方发布了针对参考驱动生成（R2V）的[全参考模式提�
 
 - Sage Attention 要求 float16 或 bfloat16 张量。MiniMax H3 的部分层使用其他数据类型，因此你可能会在控制台看到 "Input tensors must be in dtype of torch.float16 or torch.bfloat16, using pytorch attention instead" 消息。这是正常现象；受影响的层会回退到标准注意力，生成仍然可以正常工作。
 - 另一种方式是使用 `--use-sage-attention` 启动参数启动 ComfyUI 来全局启用 Sage Attention，无需添加节点。
+
+## 商业许可
+
+H3 的开放权重可免费下载和运行。对本地生成的输出进行商业使用，需要通过 Comfy（唯一官方经销商）购买 [MiniMax 商业许可](https://comfy.org/minimax/license)。Comfy Cloud 上的生成已包含商业使用权，因此许可仅在本地使用时需要。
+
+许可分为两个档位：
+
+|                           | Professional           | Enterprise                                                   |
+| ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| 价格                      | 每月 $5,000            | 每年起 $240,000                                              |
+| 期限                      | 按月                   | 最短 12 个月                                                 |
+| 授权用户                  | 最多 10 人             | 不设上限                                                     |
+| 域名                      | 1                      | 可定制                                                       |
+| 模型版本                  | 蒸馏版开放权重         | 全部版本，含非蒸馏权重及后续新版本                           |
+| 输出的商业使用            | 完整商业权利           | 完整商业权利                                                 |
+| 微调与 LoRA               | 包含                   | 包含                                                         |
+| 客户与下游工作            | 包含                   | 包含                                                         |
+
+Enterprise 协议每年起价 $240,000，按生成量和团队规模定价。两个档位均在一份协议中覆盖 MiniMax H3 以及 MiniMax Audio & Music。[申请许可](https://comfy.org/contact) 以获取报价。

--- a/zh/tutorials/video/minimax/minimax-h3.mdx
+++ b/zh/tutorials/video/minimax/minimax-h3.mdx
@@ -2,7 +2,7 @@
 title: "在 ComfyUI 中使用 MiniMax H3：T2V、I2V 和 R2V 视频工作流"
 description: "了解如何在 ComfyUI 中使用开放权重的 MiniMax H3，通过原生工作流实现文生视频、图生视频和参考生视频，支持立体声音频。"
 sidebarTitle: "MiniMax H3"
-translationSourceHash: 42f026f9
+translationSourceHash: 34a4d722
 translationFrom: tutorials/video/minimax/minimax-h3.mdx
 translationBlockHashes:
   "_intro": d7ad1d5d
@@ -12,7 +12,7 @@ translationBlockHashes:
   "ComfyUI Native Workflows": 0694f12e
   "Advanced workflows with the native nodes": c253e65c
   "Speeding up generation with Sage Attention": 1b231e7c
-  "Commercial licensing": ace612cc
+  "Commercial licensing": 201e2de5
 ---
 
 [MiniMax H3](https://www.minimax.io/blog/minimax-h3) 是 MiniMax 推出的通用全模态生成模型，现已以开放权重形式提供。它能在单一上下文中联合理解文本、图像、视频和音频，并生成带**原生立体声音频**的视频：语音、音效和音乐在单次前向传播中一并建模，而非事后叠加。输出最高支持 2K 分辨率、24fps，时长约 15 秒。
@@ -345,11 +345,17 @@ MiniMax 官方发布了针对参考驱动生成（R2V）的[全参考模式提�
 
 H3 的开放权重可免费下载和运行。对本地生成的输出进行商业使用，需要通过 Comfy（唯一官方经销商）购买 [MiniMax 商业许可](https://comfy.org/minimax/license)。Comfy Cloud 上的生成已包含商业使用权，因此许可仅在本地使用时需要。
 
+需要购买吗？
+
+- **Comfy Cloud**：已包含商业使用权，无需购买。
+- **在美国、欧盟、英国和韩国之外的自有硬件上运行，且年收入低于 2,000 万美元**：MiniMax 免费的社区许可即可覆盖商业使用。请标注 "Powered by MiniMax H3"；同样的地区规则也适用于产出的使用地。
+- **在美国、欧盟、英国或韩国的自有硬件上运行，或年收入超过 2,000 万美元**：需要以下两种许可之一。
+
 许可分为两个档位：
 
 |                           | Professional           | Enterprise                                                   |
 | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| 价格                      | 每月 $5,000            | 每年起 $240,000                                              |
+| 价格                      | 每月 $5,000 起         | 定制，年度协议，按用量定价                                   |
 | 期限                      | 按月                   | 最短 12 个月                                                 |
 | 授权用户                  | 最多 10 人             | 不设上限                                                     |
 | 域名                      | 1                      | 可定制                                                       |
@@ -358,4 +364,4 @@ H3 的开放权重可免费下载和运行。对本地生成的输出进行商�
 | 微调与 LoRA               | 包含                   | 包含                                                         |
 | 客户与下游工作            | 包含                   | 包含                                                         |
 
-Enterprise 协议每年起价 $240,000，按生成量和团队规模定价。两个档位均在一份协议中覆盖 MiniMax H3 以及 MiniMax Audio & Music。[申请许可](https://comfy.org/contact) 以获取报价。
+Professional 每月 $5,000 起。Enterprise 不设固定标价，按生成量和团队规模报价。两个档位均在一份协议中覆盖 MiniMax H3 以及 MiniMax Audio & Music。[申请许可](https://comfy.org/contact) 以获取报价。


### PR DESCRIPTION
Adds a Commercial licensing section to the MiniMax H3 tutorial: a "Do you need one?" list (Comfy Cloud already covered; the free MiniMax community license covers own-hardware use outside the US, EU, UK, and Korea under $20M in yearly revenue; a paid license is needed inside those territories or above that line), then the two-tier table with Professional from $5,000 per month and Enterprise as custom on an annual agreement, priced to volume, plus the terms each tier carries (users, domains, model versions, commercial rights, fine-tuning, client work). The top-of-page license Note links down to it.

Matches the rate card on comfy.org/minimax/license and /cloud/pricing in Comfy-Org/ComfyUI_frontend#16170. Deliberately off the page: the Enterprise price (no number until pricing is settled, per Nav 08-28), per-video-second rates, bundle volumes, and overage mechanics.

zh/ja/ko carry the same section, hand-translated, with translationSourceHash and the "Commercial licensing" block hash recomputed against the new English.
