### PR TITLE
docs(partner-nodes): update HeyGen Avatar Video pricing for Aug 28 rate change

### DIFF
--- a/ja/tutorials/partner-nodes/pricing.mdx
+++ b/ja/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 価格"
 description: "Anthropic、OpenAI、Kling、Luma など全プロバイダーの Partner Node クレジット価格。モデル、トークン種別、生成種別ごとに分類。"
 sidebarTitle: "料金"
 mode: "wide"
-translationSourceHash: 327beea6
+translationSourceHash: 46cd9f27
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -17,7 +17,7 @@ translationBlockHashes:
   "Magnific": 4000e7e1
   "Google": ac4f3be4
   "HappyHorse": bceb584a
-  "HeyGen": 47d0a040
+  "HeyGen": a9d500ca
   "Hitpaw": 320c0537
   "Ideogram": 6e28cecc
   "Krea": fb20c257
@@ -41,7 +41,7 @@ translationBlockHashes:
   "Topaz": 5d08cf76
   "Tripo": 0d9ddbf9
   "Vidu": 8ae05bc9
-  "Wan": da2dc2ad
+  "Wan": 400991a5
   "WaveSpeed": 349a7c9d
   "xAI": 3a2a47a7
   "Cloud GPU": e228bb68
@@ -414,8 +414,8 @@ Seedream 5.0 Proは解像度ベースの課金方式を採用しています：*
 | HeyGen Avatar Video         | Avatar III, Photo Avatar                       | 13.06 / 秒       |
 | HeyGen Avatar Video         | Avatar III, Digital Twin / Studio Avatar        | 5.04 / 秒        |
 | HeyGen Avatar Video         | Avatar IV, Photo Avatar                        | 15.09 / 秒       |
-| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 20.13 / 秒       |
-| HeyGen Avatar Video         | Avatar V                                       | 20.13 / 秒       |
+| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 24.29 / 秒       |
+| HeyGen Avatar Video         | Avatar V                                       | 36.21 / 秒       |
 | HeyGen Create Avatar        | N/A                                            | 301.73 / 実行      |
 | HeyGen Video Translate      | スピードモード                                  | 10.05 / 秒       |
 | HeyGen Video Translate      | プレシジョンモード                              | 20.13 / 秒       |

--- a/ko/tutorials/partner-nodes/pricing.mdx
+++ b/ko/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 가격"
 description: "Anthropic, OpenAI, Kling, Luma 등 모든 제공업체의 Partner Node 크레딧 가격을 모델, 토큰 유형, 생성 유형별로 구분합니다."
 sidebarTitle: "가격 정책"
 mode: "wide"
-translationSourceHash: 327beea6
+translationSourceHash: 46cd9f27
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -17,7 +17,7 @@ translationBlockHashes:
   "Magnific": 4000e7e1
   "Google": ac4f3be4
   "HappyHorse": bceb584a
-  "HeyGen": 47d0a040
+  "HeyGen": a9d500ca
   "Hitpaw": 320c0537
   "Ideogram": 6e28cecc
   "Krea": fb20c257
@@ -41,7 +41,7 @@ translationBlockHashes:
   "Topaz": 5d08cf76
   "Tripo": 0d9ddbf9
   "Vidu": 8ae05bc9
-  "Wan": da2dc2ad
+  "Wan": 400991a5
   "WaveSpeed": 349a7c9d
   "xAI": 3a2a47a7
   "Cloud GPU": e228bb68
@@ -414,8 +414,8 @@ Seedream 5.0 Pro는 해상도 기반 요금제를 사용합니다: **1K** (≤2.
 | HeyGen Avatar Video         | Avatar III, Photo Avatar                       | 13.06 / 초       |
 | HeyGen Avatar Video         | Avatar III, Digital Twin / Studio Avatar        | 5.04 / 초        |
 | HeyGen Avatar Video         | Avatar IV, Photo Avatar                        | 15.09 / 초       |
-| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 20.13 / 초       |
-| HeyGen Avatar Video         | Avatar V                                       | 20.13 / 초       |
+| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 24.29 / 초       |
+| HeyGen Avatar Video         | Avatar V                                       | 36.21 / 초       |
 | HeyGen Create Avatar        | N/A                                            | 301.73 / 실행      |
 | HeyGen Video Translate      | speed mode                                     | 10.05 / 초       |
 | HeyGen Video Translate      | precision mode                                 | 20.13 / 초       |

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -366,8 +366,8 @@ Prices are set per-second or per-run.
 | HeyGen Avatar Video         | Avatar III, Photo Avatar                       | 13.06 / sec       |
 | HeyGen Avatar Video         | Avatar III, Digital Twin / Studio Avatar        | 5.04 / sec        |
 | HeyGen Avatar Video         | Avatar IV, Photo Avatar                        | 15.09 / sec       |
-| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 20.13 / sec       |
-| HeyGen Avatar Video         | Avatar V                                       | 20.13 / sec       |
+| HeyGen Avatar Video         | Avatar IV, Digital Twin / Studio Avatar         | 24.29 / sec       |
+| HeyGen Avatar Video         | Avatar V                                       | 36.21 / sec       |
 | HeyGen Create Avatar        | N/A                                            | 301.73 / run      |
 | HeyGen Video Translate      | speed mode                                     | 10.05 / sec       |
 | HeyGen Video Translate      | precision mode                                 | 20.13 / sec       |

--- a/zh/tutorials/partner-nodes/pricing.mdx
+++ b/zh/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 定价"
 description: "各提供商（包括 Anthropic、OpenAI、Kling 和 Luma）的 Partner Node 积分定价，按模型、令牌类型和生成类型细分。"
 sidebarTitle: "定价"
 mode: "wide"
-translationSourceHash: 327beea6
+translationSourceHash: 46cd9f27
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -17,7 +17,7 @@ translationBlockHashes:
   "Magnific": 4000e7e1
   "Google": ac4f3be4
   "HappyHorse": bceb584a
-  "HeyGen": 47d0a040
+  "HeyGen": a9d500ca
   "Hitpaw": 320c0537
   "Ideogram": 6e28cecc
   "Krea": fb20c257
@@ -41,7 +41,7 @@ translationBlockHashes:
   "Topaz": 5d08cf76
   "Tripo": 0d9ddbf9
   "Vidu": 8ae05bc9
-  "Wan": da2dc2ad
+  "Wan": 400991a5
   "WaveSpeed": 349a7c9d
   "xAI": 3a2a47a7
   "Cloud GPU": e228bb68
@@ -414,8 +414,8 @@ Seedream 5.0 Pro 使用基于分辨率的计费方式：**1K**（≤2.61 百�
 | HeyGen Avatar Video         | Avatar III, Photo Avatar                       | 13.06 / 秒       |
 | HeyGen Avatar Video         | Avatar III, 数字分身 / Studio Avatar        | 5.04 / 秒        |
 | HeyGen Avatar Video         | Avatar IV, Photo Avatar                        | 15.09 / 秒       |
-| HeyGen Avatar Video         | Avatar IV, 数字分身 / Studio Avatar         | 20.13 / 秒       |
-| HeyGen Avatar Video         | Avatar V                                       | 20.13 / 秒       |
+| HeyGen Avatar Video         | Avatar IV, 数字分身 / Studio Avatar         | 24.29 / 秒       |
+| HeyGen Avatar Video         | Avatar V                                       | 36.21 / 秒       |
 | HeyGen Create Avatar        | N/A                                            | 301.73 / 次      |
 | HeyGen Video Translate      | 速度模式                                     | 10.05 / 秒       |
 | HeyGen Video Translate      | 精确模式                                 | 20.13 / 秒       |


### PR DESCRIPTION
Update HeyGen Avatar Video pricing in the partner-nodes pricing table for the Aug 28 HeyGen rate change. Source: Comfy-Org/ComfyUI#15945.

Updated in all four locales (en, zh, ja, ko); i18n block hashes re-synced.
