### PR TITLE
docs(partner-nodes): add Gemini Omni 1.1 Flash pricing and fix Omni per-second rates

### DIFF
--- a/ja/tutorials/partner-nodes/pricing.mdx
+++ b/ja/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 価格"
 description: "Anthropic、OpenAI、Kling、Luma など全プロバイダーの Partner Node クレジット価格。モデル、トークン種別、生成種別ごとに分類。"
 sidebarTitle: "料金"
 mode: "wide"
-translationSourceHash: 46cd9f27
+translationSourceHash: b4eb8be0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -15,7 +15,7 @@ translationBlockHashes:
   "ElevenLabs": 166ecbf9
   "FishAudio": 5f2fee86
   "Magnific": 4000e7e1
-  "Google": ac4f3be4
+  "Google": 96a618e3
   "HappyHorse": bceb584a
   "HeyGen": a9d500ca
   "Hitpaw": 320c0537
@@ -364,11 +364,15 @@ Seedream 5.0 Proは解像度ベースの課金方式を採用しています：*
 
 ### 動画: Google Gemini Omni
 
-トークンベースの課金。テキストと動画出力トークンで異なるレートが適用されます。おおよそのコスト: **~30.8クレジット/秒**（~$0.146/秒）。
+生成された動画の秒数で課金されます。レートは概算です。
 
-| モデル                                                           | 入力クレジット / 1K | 出力（テキスト）クレジット / 1K | 出力（動画）クレジット / 1K |
-| :------------------------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
-| Gemini Omni Flash（`gemini-omni-flash-preview`）               |              0.453 |                      2.716 | 5.28                        |
+| モデル                                       | 解像度 | クレジット / 秒 |
+| :-------------------------------------------- | :----- | :------------- |
+| Gemini Omni Flash（`gemini-omni-flash-preview`） | —      | 30.57          |
+| Gemini Omni Flash 1.1（`gemini-omni-1.1-flash`） | 360p   | 10.19          |
+|                                               | 720p   | 30.57          |
+|                                               | 1080p  | 45.87          |
+|                                               | 4k     | 91.76          |
 
 ### 動画: Google Veo
 

--- a/ko/tutorials/partner-nodes/pricing.mdx
+++ b/ko/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 가격"
 description: "Anthropic, OpenAI, Kling, Luma 등 모든 제공업체의 Partner Node 크레딧 가격을 모델, 토큰 유형, 생성 유형별로 구분합니다."
 sidebarTitle: "가격 정책"
 mode: "wide"
-translationSourceHash: 46cd9f27
+translationSourceHash: b4eb8be0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -15,7 +15,7 @@ translationBlockHashes:
   "ElevenLabs": 166ecbf9
   "FishAudio": 5f2fee86
   "Magnific": 4000e7e1
-  "Google": ac4f3be4
+  "Google": 96a618e3
   "HappyHorse": bceb584a
   "HeyGen": a9d500ca
   "Hitpaw": 320c0537
@@ -364,11 +364,15 @@ Seedream 5.0 Pro는 해상도 기반 요금제를 사용합니다: **1K** (≤2.
 
 ### 비디오: Google Gemini Omni
 
-토큰 기반 요금제이며 텍스트 및 비디오 출력 토큰 요율이 다릅니다. 예상 비용: **~30.8 크레딧/초** (약 $0.146/초).
+생성된 비디오의 초 단위로 요금이 부과됩니다. 요율은 추정치입니다.
 
-| 모델                                                          | 입력 크레딧 / 1K | 출력 (텍스트) 크레딧 / 1K | 출력 (비디오) 크레딧 / 1K |
-| :------------------------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
-| Gemini Omni Flash (`gemini-omni-flash-preview`)                |              0.453 |                      2.716 | 5.28                        |
+| 모델                                          | 해상도 | 크레딧 / 초 |
+| :-------------------------------------------- | :----- | :--------- |
+| Gemini Omni Flash (`gemini-omni-flash-preview`) | —      | 30.57      |
+| Gemini Omni Flash 1.1 (`gemini-omni-1.1-flash`) | 360p   | 10.19      |
+|                                               | 720p   | 30.57      |
+|                                               | 1080p  | 45.87      |
+|                                               | 4k     | 91.76      |
 
 ### 비디오: Google Veo
 

--- a/tutorials/partner-nodes/pricing.mdx
+++ b/tutorials/partner-nodes/pricing.mdx
@@ -316,11 +316,15 @@ Token-based billing.
 
 ### Video: Google Gemini Omni
 
-Token-based billing with separate rates for text and video output tokens. Approximate cost: **~30.8 credits/second** (~$0.146/s).
+Billed per second of generated video. Rates are approximate.
 
-| Model                                                          | Input credits / 1K | Output (text) credits / 1K | Output (video) credits / 1K |
-| :------------------------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
-| Gemini Omni Flash (`gemini-omni-flash-preview`)                |              0.453 |                      2.716 | 5.28                        |
+| Model                                     | Resolution | Credits / sec |
+| :---------------------------------------- | :--------- | :----------- |
+| Gemini Omni Flash (`gemini-omni-flash-preview`) | —      | 30.57        |
+| Gemini Omni Flash 1.1 (`gemini-omni-1.1-flash`) | 360p   | 10.19        |
+|                                           | 720p       | 30.57        |
+|                                           | 1080p      | 45.87        |
+|                                           | 4k         | 91.76        |
 
 ### Video: Google Veo
 

--- a/zh/tutorials/partner-nodes/pricing.mdx
+++ b/zh/tutorials/partner-nodes/pricing.mdx
@@ -3,7 +3,7 @@ title: "Partner Node 定价"
 description: "各提供商（包括 Anthropic、OpenAI、Kling 和 Luma）的 Partner Node 积分定价，按模型、令牌类型和生成类型细分。"
 sidebarTitle: "定价"
 mode: "wide"
-translationSourceHash: 46cd9f27
+translationSourceHash: b4eb8be0
 translationFrom: tutorials/partner-nodes/pricing.mdx
 translationBlockHashes:
   "_intro": ada9999a
@@ -15,7 +15,7 @@ translationBlockHashes:
   "ElevenLabs": 166ecbf9
   "FishAudio": 5f2fee86
   "Magnific": 4000e7e1
-  "Google": ac4f3be4
+  "Google": 96a618e3
   "HappyHorse": bceb584a
   "HeyGen": a9d500ca
   "Hitpaw": 320c0537
@@ -364,11 +364,15 @@ Seedream 5.0 Pro 使用基于分辨率的计费方式：**1K**（≤2.61 百�
 
 ### 视频：Google Gemini Omni
 
-基于令牌计费，文本和视频输出令牌费率不同。大约成本：**~30.8 积分/秒**（约 $0.146/秒）。
+按生成视频的秒数计费，费率为近似值。
 
-| 模型                                                            | 输入积分 / 1K | 输出（文本）积分 / 1K | 输出（视频）积分 / 1K |
-| :------------------------------------------------------------- | -----------------: | -------------------------: | :-------------------------- |
-| Gemini Omni Flash (`gemini-omni-flash-preview`)                |              0.453 |                      2.716 | 5.28                        |
+| 模型                                          | 分辨率   | 积分 / 秒 |
+| :-------------------------------------------- | :------- | :-------- |
+| Gemini Omni Flash (`gemini-omni-flash-preview`) | —        | 30.57     |
+| Gemini Omni Flash 1.1 (`gemini-omni-1.1-flash`) | 360p     | 10.19     |
+|                                               | 720p     | 30.57     |
+|                                               | 1080p    | 45.87     |
+|                                               | 4k       | 91.76     |
 
 ### 视频：Google Veo
 


### PR DESCRIPTION
## Summary
- Add Google Gemini Omni 1.1 Flash (`gemini-omni-1.1-flash`) to the partner-nodes pricing table, with per-second credit rates across 360p / 720p / 1080p / 4k.
- Fix the existing Gemini Omni block: it previously listed token-based rates (Input/Output per 1K), but the node bills **per second of video** (`suffix:/second`). Replaced the table with the correct per-second structure.
- Updated the `gemini-omni-flash-preview` baseline rate to the current value.

## Details
The node price badges were taken as the source of truth (211 credits = $1):
- `gemini-omni-flash-preview`: ~30.57 credits/sec
- `gemini-omni-1.1-flash`: 360p ~10.19 / 720p ~30.57 / 1080p ~45.87 / 4k ~91.76 credits/sec

Rates are approximate and reflect the node's `PriceBadge` values. Updated EN + zh/ja/ko translations, with i18n hashes synced.

## Test plan
- [x] EN + zh/ja/ko pricing tables updated
- [x] i18n `translationBlockHashes` re-synced after edit
