### PR TITLE
docs: move Pixal3D and TRELLIS.2 under the 3D category; rename titles to Image to 3D Model

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -282,11 +282,11 @@
                     "group": "3D",
                     "pages": [
                       "tutorials/3d/triposplat",
-                      "tutorials/3d/hunyuan3D-2"
+                      "tutorials/3d/hunyuan3D-2",
+                      "tutorials/3d/pixal3d",
+                      "tutorials/3d/trellis2"
                     ]
                   },
-                  "tutorials/3d/pixal3d",
-                  "tutorials/3d/trellis2",
                   {
                     "group": "LLM",
                     "pages": [
@@ -3887,11 +3887,11 @@
                     "group": "3D",
                     "pages": [
                       "zh/tutorials/3d/triposplat",
-                      "zh/tutorials/3d/hunyuan3D-2"
+                      "zh/tutorials/3d/hunyuan3D-2",
+                      "zh/tutorials/3d/pixal3d",
+                      "zh/tutorials/3d/trellis2"
                     ]
                   },
-                  "zh/tutorials/3d/pixal3d",
-                  "zh/tutorials/3d/trellis2",
                   {
                     "group": "LLM",
                     "pages": [
@@ -7124,11 +7124,11 @@
                     "group": "3D",
                     "pages": [
                       "ja/tutorials/3d/triposplat",
-                      "ja/tutorials/3d/hunyuan3D-2"
+                      "ja/tutorials/3d/hunyuan3D-2",
+                      "ja/tutorials/3d/pixal3d",
+                      "ja/tutorials/3d/trellis2"
                     ]
                   },
-                  "ja/tutorials/3d/pixal3d",
-                  "ja/tutorials/3d/trellis2",
                   {
                     "group": "LLM",
                     "pages": [
@@ -10374,11 +10374,11 @@
                     "group": "3D",
                     "pages": [
                       "ko/tutorials/3d/triposplat",
-                      "ko/tutorials/3d/hunyuan3D-2"
+                      "ko/tutorials/3d/hunyuan3D-2",
+                      "ko/tutorials/3d/pixal3d",
+                      "ko/tutorials/3d/trellis2"
                     ]
                   },
-                  "ko/tutorials/3d/pixal3d",
-                  "ko/tutorials/3d/trellis2",
                   {
                     "group": "LLM",
                     "pages": [

--- a/ja/tutorials/3d/pixal3d.mdx
+++ b/ja/tutorials/3d/pixal3d.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Pixal3D 画像からモデルへの ComfyUI ワークフロー例"
+title: "Pixal3D 画像から3Dモデルへの ComfyUI ワークフロー例"
 description: "Pixal3D を使用して、1枚の画像からフル PBR テクスチャ付きの高忠実度 3Dモデルを生成します。Pixal3D は、Tencent ARC によるピクセル位置合わせ型の画像から 3Dモデルへの変換モデルです。"
 sidebarTitle: "Pixal3D"
-translationSourceHash: b46ae7b5
+translationSourceHash: ad40ed68
 translationFrom: tutorials/3d/pixal3d.mdx
 translationBlockHashes:
-  "_intro": ebe506d7
+  "_intro": 0cc856ed
   "How it works": 30b7a245
   "Steps to run": 1a7d044c
   "Model downloads": 890d9666
@@ -16,7 +16,7 @@ import UpdateReminder from "/snippets/ja/tutorials/update-reminder.mdx"
 
 ほとんどの3Dネイティブジェネレーターは、正準空間で形を合成し、アテンションを通じて画像の手がかりを注入するため、ピクセルと3Dの対応関係があいまいになります。一方、Pixal3D はピクセル整合生成を採用しています。バックプロジェクションによってピクセルと3Dの直接的な対応関係を確立するため、生成済みモデルの正面は入力画像と1:1で一致し、テクスチャのゆがみやずれが発生しません。
 
-### Pixal3D: 画像からモデルへ {#pixal3d}
+### Pixal3D: 画像から3Dモデルへ {#pixal3d}
 
 単一の画像をアップロードします。入力ビューに合わせて、完全なPBRテクスチャを持つ高忠実度の3Dモデルを生成します。
 

--- a/ja/tutorials/3d/trellis2.mdx
+++ b/ja/tutorials/3d/trellis2.mdx
@@ -1,11 +1,11 @@
 ---
-title: "TRELLIS.2 画像からモデルへの ComfyUI ワークフロー例"
+title: "TRELLIS.2 画像から3Dモデルへの ComfyUI ワークフロー例"
 description: "Microsoft のオープンソースである 4B パラメータの画像から 3D モデルへの変換モデル TRELLIS.2 を使用して、1 枚の画像からフル PBR テクスチャ付きの高忠実度 3D モデルを生成します。"
 sidebarTitle: "TRELLIS.2"
-translationSourceHash: 67712115
+translationSourceHash: ec22c0fe
 translationFrom: tutorials/3d/trellis2.mdx
 translationBlockHashes:
-  "_intro": 62475cee
+  "_intro": 5168e8d6
   "How it works": e79c0e78
   "Steps to run": f899f7e5
   "Model downloads": 125142da

--- a/ko/tutorials/3d/pixal3d.mdx
+++ b/ko/tutorials/3d/pixal3d.mdx
@@ -2,10 +2,10 @@
 title: "Pixal3D 이미지 기반 3D 모델 생성 ComfyUI 워크플로 예제"
 description: "Tencent ARC의 픽셀 정렬 이미지 기반 3D 생성 모델인 Pixal3D를 사용해 단일 이미지에서 전체 PBR 텍스처가 포함된 고충실도 3D 모델을 생성하세요."
 sidebarTitle: "Pixal3D"
-translationSourceHash: b46ae7b5
+translationSourceHash: ad40ed68
 translationFrom: tutorials/3d/pixal3d.mdx
 translationBlockHashes:
-  "_intro": ebe506d7
+  "_intro": 0cc856ed
   "How it works": 30b7a245
   "Steps to run": 1a7d044c
   "Model downloads": 890d9666

--- a/ko/tutorials/3d/trellis2.mdx
+++ b/ko/tutorials/3d/trellis2.mdx
@@ -1,11 +1,11 @@
 ---
-title: "TRELLIS.2 이미지 기반 3D 생성 ComfyUI 워크플로 예제"
+title: "TRELLIS.2 이미지 기반 3D 모델 생성 ComfyUI 워크플로 예제"
 description: "Microsoft의 오픈소스 4B 파라미터 이미지 기반 3D 생성 모델인 TRELLIS.2를 사용하여 단일 이미지에서 전체 PBR 텍스처가 포함된 고품질 3D 모델을 생성합니다."
 sidebarTitle: "TRELLIS.2"
-translationSourceHash: 67712115
+translationSourceHash: ec22c0fe
 translationFrom: tutorials/3d/trellis2.mdx
 translationBlockHashes:
-  "_intro": 62475cee
+  "_intro": 5168e8d6
   "How it works": e79c0e78
   "Steps to run": f899f7e5
   "Model downloads": 125142da
@@ -17,7 +17,7 @@ import UpdateReminder from "/snippets/ko/tutorials/update-reminder.mdx"
 
 TRELLIS.2는 Pixal3D와 기본 아키텍처를 공유합니다. 두 모델 모두 동일한 DINOv3 이미지 인코더, 동일한 형태 및 텍스처 VAE, 동일한 구조·형태·텍스처 생성 단계를 사용합니다. 주요 diffusion 모델과 조건화 형식만 다릅니다. [Pixal3D 워크플로](/ko/tutorials/3d/pixal3d)를 실행해 본 적이 있다면 모델 설정은 거의 동일합니다.
 
-### TRELLIS.2: 이미지를 모델로 {#trellis2}
+### TRELLIS.2: 이미지를 3D 모델로 {#trellis2}
 
 단일 이미지를 업로드하세요. TRELLIS.2를 사용하여 전체 PBR 텍스처가 포함된 고품질 3D 모델을 생성하세요.
 

--- a/tutorials/3d/pixal3d.mdx
+++ b/tutorials/3d/pixal3d.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Pixal3D Image to Model ComfyUI Workflow Example"
+title: "Pixal3D Image to 3D Model ComfyUI Workflow Example"
 description: "Generate high-fidelity 3D models with full PBR textures from a single image using Pixal3D, a pixel-aligned image-to-3D model from Tencent ARC."
 sidebarTitle: "Pixal3D"
 ---
@@ -10,7 +10,7 @@ import UpdateReminder from '/snippets/tutorials/update-reminder.mdx'
 
 Most 3D-native generators synthesize shapes in a canonical space and inject image cues through attention, which leaves pixel-to-3D associations ambiguous. Pixal3D instead uses pixel-aligned generation: it establishes direct pixel-to-3D correspondence through back-projection, so the front of the generated model matches your input image 1:1, with no warped or misaligned textures.
 
-### Pixal3D: Image to Model {#pixal3d}
+### Pixal3D: Image to 3D Model {#pixal3d}
 
 Upload a single image. Generate a high-fidelity 3D model with full PBR textures, aligned to your input view.
 

--- a/tutorials/3d/trellis2.mdx
+++ b/tutorials/3d/trellis2.mdx
@@ -1,5 +1,5 @@
 ---
-title: "TRELLIS.2 Image to Model ComfyUI Workflow Example"
+title: "TRELLIS.2 Image to 3D Model ComfyUI Workflow Example"
 description: "Generate high-fidelity 3D models with full PBR textures from a single image using TRELLIS.2, Microsoft's open-source 4B-parameter image-to-3D model."
 sidebarTitle: "TRELLIS.2"
 ---
@@ -10,7 +10,7 @@ import UpdateReminder from '/snippets/tutorials/update-reminder.mdx'
 
 TRELLIS.2 shares its base architecture with Pixal3D: both use the same DINOv3 image encoder, the same shape and texture VAEs, and the same structure, shape, and texture generation stages. Only the main diffusion model and the conditioning format differ. If you have run the [Pixal3D workflow](/tutorials/3d/pixal3d), the model setup is almost identical.
 
-### TRELLIS.2: Image to Model {#trellis2}
+### TRELLIS.2: Image to 3D Model {#trellis2}
 
 Upload a single image. Generate a high-fidelity 3D model with full PBR textures using TRELLIS.2.
 

--- a/zh/tutorials/3d/pixal3d.mdx
+++ b/zh/tutorials/3d/pixal3d.mdx
@@ -2,10 +2,10 @@
 title: "Pixal3D 图像到3D模型 ComfyUI 工作流示例"
 description: "使用 Pixal3D（腾讯 ARC 推出的像素对齐图像到3D模型），从单张图像生成具有完整 PBR 纹理的高保真 3D 模型。"
 sidebarTitle: "Pixal3D"
-translationSourceHash: b46ae7b5
+translationSourceHash: ad40ed68
 translationFrom: tutorials/3d/pixal3d.mdx
 translationBlockHashes:
-  "_intro": ebe506d7
+  "_intro": 0cc856ed
   "How it works": 30b7a245
   "Steps to run": 1a7d044c
   "Model downloads": 890d9666
@@ -16,7 +16,7 @@ import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx"
 
 大多数3D原生生成器在规范空间中合成形状，并通过注意力注入图像线索，这导致像素与3D之间的关联不明确。Pixal3D 则采用像素对齐生成：通过反投影建立像素与3D的直接对应关系，因此已生成模型的正面与你的输入图像1:1匹配，不会出现纹理扭曲或错位。
 
-### Pixal3D：图像到模型 {#pixal3d}
+### Pixal3D：图像到3D模型 {#pixal3d}
 
 上传单张图像。生成一个具有完整PBR纹理的高保真3D模型，并与你的输入视角对齐。
 

--- a/zh/tutorials/3d/trellis2.mdx
+++ b/zh/tutorials/3d/trellis2.mdx
@@ -1,11 +1,11 @@
 ---
-title: "TRELLIS.2 图像到模型 ComfyUI 工作流示例"
+title: "TRELLIS.2 图像到3D模型 ComfyUI 工作流示例"
 description: "使用 TRELLIS.2（微软的开源 4B 参数图像到 3D 模型），从单个图像生成具有完整 PBR 纹理的高保真 3D 模型。"
 sidebarTitle: "TRELLIS.2"
-translationSourceHash: 67712115
+translationSourceHash: ec22c0fe
 translationFrom: tutorials/3d/trellis2.mdx
 translationBlockHashes:
-  "_intro": 62475cee
+  "_intro": 5168e8d6
   "How it works": e79c0e78
   "Steps to run": f899f7e5
   "Model downloads": 125142da
@@ -17,7 +17,7 @@ import UpdateReminder from "/snippets/zh/tutorials/update-reminder.mdx"
 
 TRELLIS.2 与 Pixal3D 共享基础架构：两者使用相同的 DINOv3 图像编码器、相同的形状和纹理 VAE，以及相同的结构、形状和纹理生成阶段。只有主要的扩散模型和条件格式有所不同。如果你已经运行过 [Pixal3D 工作流](/zh/tutorials/3d/pixal3d)，模型设置几乎完全相同。
 
-### TRELLIS.2：图像到模型 {#trellis2}
+### TRELLIS.2：图像到3D模型 {#trellis2}
 
 上传单张图像。使用 TRELLIS.2 生成带有完整 PBR 纹理的高保真3D模型。
 


### PR DESCRIPTION
## Summary

Follow-up from [Slack](https://comfy-organization.slack.com/archives/C09NWURUPMF/p1788296082529029): move the Pixal3D and TRELLIS.2 tutorials under the **3D** category in the docs nav, and rename their titles from "Image to Model" to "Image to 3D Model".

### Changes
- **docs.json** (en/zh/ja/ko): nested `tutorials/3d/pixal3d` and `tutorials/3d/trellis2` inside the `3D` nav group (previously loose top-level entries)
- **tutorial titles** (en/zh/ja/ko): `Pixal3D Image to 3D Model ComfyUI Workflow Example` and `TRELLIS.2 Image to 3D Model ComfyUI Workflow Example`, plus the matching `###` section headings
- **Anchors unchanged** (`#pixal3d`, `#trellis2`): page paths and URLs stay the same, so existing links are not affected
- **i18n**: translation hashes synced for the 6 localized copies

### Verification
- `sync-hash-i18n.ts --verify`: all 6 translations already in sync
- `validate-links.py`: all link validations passed
- anchors intact per `check-anchors.py`
