### PR TITLE
Add billing FAQ to serverless deployments page

### DIFF
--- a/development/comfy-router/limitations.mdx
+++ b/development/comfy-router/limitations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Comfy Router limitations"
+sidebarTitle: "Limitations"
 description: "What Comfy Router does not do today, what to use instead where an alternative exists, and which of those limits are expected to change."
 ---
 

--- a/development/comfy-router/quickstart.mdx
+++ b/development/comfy-router/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Comfy Router quickstart"
+sidebarTitle: "Quickstart"
 description: "From nothing to a generated image in about five minutes, in Python and TypeScript, against the Comfy Router."
 ---
 

--- a/development/comfy-router/reference.mdx
+++ b/development/comfy-router/reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Comfy Router API reference"
+sidebarTitle: "API Reference"
 description: "Every Comfy Router endpoint, parameter, response body and error bucket, generated from the Comfy API contract."
 ---
 

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -229,11 +229,11 @@ comfy deploy events --deployment dep_123456
   </Accordion>
 
   <Accordion title="How are active workers billed, and at what hourly rates?">
-    `--min` sets the number of **active workers**: workers that stay running at all times so requests never wait for a cold start. An active worker is billed per second for the entire time it is running, whether or not it is processing jobs. One active worker on an H100 SXM, for example, bills around $115 per day (24 hours at $4.79 per hour) even with no traffic.
+    `--min` sets the number of **active workers**: workers that stay running at all times so requests never wait for a cold start. An active worker is billed per second for the entire time it is running, whether or not it is processing jobs.
 
     Workers above `--min`, up to `--max`, are **flex workers**. A flex worker is billed per second from the moment it starts (including startup and model loading), through job processing, plus a short idle window (currently 30 seconds) before it scales back down. When flex workers are scaled down, they cost nothing. With `--min 0` the whole deployment scales to zero and bills no compute while idle, at the cost of a cold start on the first request.
 
-    Billing meters actual per-second worker usage, multiplied by the number of workers running. Usage is aggregated hourly, debited from your workspace credits, and appears on your account within about an hour. If your workspace runs out of credits, deployments are stopped automatically.
+    Billing meters actual per-second worker usage, multiplied by the number of workers running. If your workspace runs out of credits, deployments are stopped automatically.
 
     Current published per-worker rates:
 

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Comfy API: Serverless deployments"
+sidebarTitle: "Comfy API"
 description: "Build a versioned ComfyUI environment, deploy it as a managed endpoint, and run workflows through the API."
 icon: "cloud-arrow-up"
 ---

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -224,15 +224,7 @@ comfy deploy events --deployment dep_123456
     - Each worker also gets a fixed 50 GB container disk. It is ephemeral and is only billed while the worker is running, as part of the worker's compute cost.
     - Deleting a deployment releases its compute. Staged network storage is cleaned up shortly after the last deployment using it in that region is deleted, and billing for it ends.
 
-    Current published storage rates:
-
-    | Storage | Rate |
-    |---|---|
-    | Network storage (standard, under 1 TB) | $0.091 per GB-month |
-    | Network storage (standard, 1 TB and above) | $0.065 per GB-month |
-    | Container disk | $0.13 per GB-month, only while a worker runs |
-
-    Rates can change. The compute catalog (`comfy deploy refs compute`) and the deploy dialog always show the current rates.
+    For current storage rates, see [comfy.org/pricing](https://www.comfy.org/pricing). The compute catalog (`comfy deploy refs compute`) and the deploy dialog also show the rates that apply to a deployment.
   </Accordion>
 
   <Accordion title="How are active workers billed, and at what hourly rates?">

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -212,6 +212,49 @@ comfy deploy events --deployment dep_123456
   Deleting a deployment and deleting a Build are separate irreversible operations. Confirm the target before using `comfy deploy delete --yes` or `comfy build delete --id bld_123456 --yes`.
 </Warning>
 
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Am I charged for storing Builds that are not deployed?">
+    No. Builds and their releases are stored on your account at no charge. You are not billed for the storage footprint of a Build until you deploy it.
+
+    Storage billing starts with a deployment:
+
+    - When you deploy a release, its models are staged onto network storage in the deployment's region. That storage is billed per GB-month for as long as any deployment of the Build exists in that region, including while a deployment is paused with `comfy deploy stop`.
+    - Each worker also gets a fixed 50 GB container disk. It is ephemeral and is only billed while the worker is running, as part of the worker's compute cost.
+    - Deleting a deployment releases its compute. Staged network storage is cleaned up shortly after the last deployment using it in that region is deleted, and billing for it ends.
+
+    Current published storage rates:
+
+    | Storage | Rate |
+    |---|---|
+    | Network storage (standard, under 1 TB) | $0.091 per GB-month |
+    | Network storage (standard, 1 TB and above) | $0.065 per GB-month |
+    | Container disk | $0.13 per GB-month, only while a worker runs |
+
+    Rates can change. The compute catalog (`comfy deploy refs compute`) and the deploy dialog always show the current rates.
+  </Accordion>
+
+  <Accordion title="How are active workers billed, and at what hourly rates?">
+    `--min` sets the number of **active workers**: workers that stay running at all times so requests never wait for a cold start. An active worker is billed per second for the entire time it is running, whether or not it is processing jobs. One active worker on an H100 SXM, for example, bills around $115 per day (24 hours at $4.79 per hour) even with no traffic.
+
+    Workers above `--min`, up to `--max`, are **flex workers**. A flex worker is billed per second from the moment it starts (including startup and model loading), through job processing, plus a short idle window (currently 30 seconds) before it scales back down. When flex workers are scaled down, they cost nothing. With `--min 0` the whole deployment scales to zero and bills no compute while idle, at the cost of a cold start on the first request.
+
+    Billing meters actual per-second worker usage, multiplied by the number of workers running. Usage is aggregated hourly, debited from your workspace credits, and appears on your account within about an hour. If your workspace runs out of credits, deployments are stopped automatically.
+
+    Current published per-worker rates:
+
+    | GPU | VRAM | Rate per worker-hour |
+    |---|---|---|
+    | RTX PRO 6000 | 96 GB | $3.49 |
+    | H100 SXM | 80 GB | $4.79 |
+    | H200 SXM | 141 GB | $5.93 |
+    | B200 | 180 GB | $8.64 |
+
+    Rates are billed per second at the hourly rate divided by 3600. Availability and pricing per region come from the compute catalog: run `comfy deploy refs compute` for the current list.
+  </Accordion>
+</AccordionGroup>
+
 ## Next steps
 
 - [Comfy SDKs](/development/api-development/sdks)

--- a/development/serverless/overview.mdx
+++ b/development/serverless/overview.mdx
@@ -235,16 +235,7 @@ comfy deploy events --deployment dep_123456
 
     Billing meters actual per-second worker usage, multiplied by the number of workers running. If your workspace runs out of credits, deployments are stopped automatically.
 
-    Current published per-worker rates:
-
-    | GPU | VRAM | Rate per worker-hour |
-    |---|---|---|
-    | RTX PRO 6000 | 96 GB | $3.49 |
-    | H100 SXM | 80 GB | $4.79 |
-    | H200 SXM | 141 GB | $5.93 |
-    | B200 | 180 GB | $8.64 |
-
-    Rates are billed per second at the hourly rate divided by 3600. Availability and pricing per region come from the compute catalog: run `comfy deploy refs compute` for the current list.
+    For current per-worker GPU rates, see [comfy.org/pricing](https://www.comfy.org/pricing). Rates are quoted per worker-hour and billed per second. GPU availability per region comes from the compute catalog: run `comfy deploy refs compute` for the current list.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Adds an FAQ section to the Comfy API serverless deployments page (`development/serverless/overview.mdx`) answering two recurring customer questions about deployments and builds:

- **Storage for undeployed Builds**: Builds and releases stored on an account are not billed. Storage billing starts at deploy time: staged network storage (which continues while a deployment is stopped and ends after the last deployment using it is deleted), plus per-worker container disk billed only while a worker runs.
- **Active worker pricing**: `--min` workers are always on and billed per second whether or not they process jobs; flex workers bill from startup through processing plus a 30-second idle window.

No rates are inlined; both answers point readers to [comfy.org/pricing](https://www.comfy.org/pricing) and `comfy deploy refs compute` so the docs cannot go stale against the pricing page.

Also shortens sidebar titles via frontmatter `sidebarTitle`: the serverless page shows as "Comfy API", and the three Comfy Router pages drop the redundant group prefix (Quickstart, API Reference, Limitations).

Billing mechanics are grounded in `Comfy-Org/cloud` (the `comfy-deploy` provider adapter and usage metering). The underlying compute provider is deliberately not named. Uses the same `AccordionGroup` FAQ style as `interface/credits.mdx` and follows the repo prose rules (no em dashes). English only; translations go through the separate i18n pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Veq6GJiNTM1Pve9EqZeGA