### PR TITLE
docs: add release-held In-App Agent user guide

### DIFF
--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -1,15 +1,59 @@
 ---
 title: "Comfy In-App Agent"
 sidebarTitle: "In-App Agent"
-description: "Join the private alpha waitlist for Comfy In-App Agent on Comfy Cloud."
+description: "Build, edit, and run Comfy Cloud workflows by chatting with Comfy In-App Agent."
 icon: "comments"
 ---
 
 <Note>
-  **Private alpha.** Comfy In-App Agent is rolling out to a limited set of users. Public docs and website pages are not available yet. Join the waitlist to request access.
+  **Limited access.** Comfy In-App Agent is available to selected Comfy Cloud users. If you do not have access, [join the waitlist](#join-the-waitlist).
 </Note>
 
-**Comfy In-App Agent** is the agent experience inside Comfy Cloud: prompt in chat, and the agent can build or edit workflows on your graph.
+**Comfy In-App Agent** helps you create and update workflows without leaving the Comfy Cloud canvas. Describe the result you want, and the agent can add nodes, connect them, change settings, and run the workflow for you.
+
+## Start a chat
+
+1. Open a workflow in [Comfy Cloud](https://cloud.comfy.org).
+2. Select **Ask Comfy Agent** in the workflow bar.
+3. Choose the workflow you want the agent to edit.
+4. Describe what you want to create or change, then send your message.
+5. Check the workflow and its output. The agent can make mistakes, so review changes before you use or share the result.
+
+For example, you can ask the agent to:
+
+- Build a workflow from a description
+- Add or connect nodes in an existing workflow
+- Adjust a workflow to produce a different result
+- Explain part of a workflow
+- Run a workflow and show you the output
+
+## Give the agent context
+
+The agent works with the workflow selected at the top of the chat. Check this selection before you request a change. For a question that does not require a workflow, select **Don't work in a workflow**.
+
+You can include more context with your message:
+
+- Type `@` to reference a node.
+- Select **Add nodes from graph** to include one or more nodes.
+- Attach an image, video, audio file, 3D model, or text file.
+
+Tell the agent what outcome you want and any requirements it should follow. For example: "Add an image upscale step and keep the final image at 2048 × 2048 pixels."
+
+## Choose when workflows run
+
+Use the control beside the send button to choose when the agent can run a workflow:
+
+- **Ask before a workflow runs** requires your approval for every run.
+- **Auto-run without approval** lets the agent run workflows without asking.
+- **Auto-run with limits** asks for approval when a run would exceed the credit limit you set.
+
+This setting controls workflow runs only. The agent can still edit the selected workflow after you send your message. If you want to review every run first, choose **Ask before a workflow runs**.
+
+## Continue an earlier chat
+
+The agent keeps separate chats for your workflow tabs. Open **Chat history** to return to an earlier chat, rename it, or copy it as Markdown.
+
+If a response stops before the task is complete, send a new message with what you want the agent to do next. If the panel loses its connection, wait for it to reconnect and check the workflow before continuing.
 
 ## Join the waitlist
 


### PR DESCRIPTION
Draft only. Hold until the In-App Agent private beta or release.

Rewrites the guide around user tasks and outcomes. Removes internal rollout labels, implementation details, and unexplained program language.

<details><summary>Full context for agent readers</summary>

## Release hold

Do not ready or merge this PR until Christian confirms that the In-App Agent private beta or release documentation may publish. The PR must remain a draft while this hold is active.

## What changed

- Starts with the result users can achieve in Comfy Cloud.
- Organizes instructions around starting a chat, providing context, controlling workflow runs, and continuing earlier work.
- Keeps user-visible safety guidance and removes feature-flag, offline-conflict, internal-program, and "creator-facing" language.
- Leaves translations for the repository's separate automated translation pipeline.

## Writing approach

The rewrite follows:

- [Google Technical Writing: Audience](https://developers.google.com/tech-writing/one/audience): provide the knowledge users need to complete tasks and match vocabulary to their existing knowledge.
- [Diátaxis: How-to guides](https://diataxis.fr/how-to-guides/): guide readers toward concrete results.
- [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome): use simple, direct, human language.
- The repository's `AGENTS.md` and `.cursor/rules/docs-prose.mdc` guidance.

## Evidence

- `pnpm install --frozen-lockfile` under Node 25.9.0: passed.
- `pnpm exec mint validate` under Node 22.22.2 LTS: build validation passed. Mint rejects Node 25 and requires an LTS runtime.
- `pnpm exec mint broken-links` under Node 22.22.2 LTS: no broken links found.
- `python3 .github/scripts/validate-links.py`: all 5,662 documentation files passed link validation.
- `curl -fsSIL` for Comfy Cloud, alpha waitlist, and feedback URLs: passed.
- `git diff --check`: passed.
- Prose checks for no em dashes and no internal implementation terms: passed.

</details>

<!-- authored-by:agent ecw-141 -->
