### PR TITLE
docs: add v0.34.3 changelog and CMS release notes

### DIFF
--- a/.cursor/skills/cms-changelog-sync/SKILL.md
+++ b/.cursor/skills/cms-changelog-sync/SKILL.md
@@ -3,9 +3,11 @@ name: cms-changelog-sync
 description: >-
   Sync ComfyUI release notes to Strapi CMS: LLM-simplify English changelog for
   in-app popup, translate to zh/ja/ko/fr/ru/es in staging, push drafts to CMS.
-  Use when updating changelog/index.mdx for CMS, running cms:prepare/cms:sync,
-  Strapi release-notes, published-versions.json, CMS staging, simplifying
-  release notes for the notification popup, or cms:publish to go live.
+  Resolves docs/local/cloud bullet URLs (blog.comfy.org, workflow_templates
+  index.json, Cloud ?template=, user UTM, GitHub PRs). Use when updating
+  changelog/index.mdx for CMS, running cms:prepare/cms:sync, Strapi
+  release-notes, published-versions.json, CMS staging, simplifying release
+  notes for the notification popup, or cms:publish to go live.
 ---
 
 # CMS Changelog Sync
@@ -101,6 +103,32 @@ Config: `.github/scripts/cms/cms-config.json` → `simplify`
 
 Style: principle-only prompt in `cms-simplify-prompt.ts` (no concrete version examples — avoids LLM contamination).
 
+`prepare:en` copies docs URLs and local-length copy into Cloud. After it runs, rewrite **Cloud EN** (links and wording) before translating. Never invent URLs.
+
+**Copy length (local vs Cloud):** Cloud popup users skim. After merge, shorten Cloud bullets so they do not list every node, mode, or task type. One short clause is enough: added the model, or one capability. Local CMS (`staging/en/`) and docs `changelog/index.mdx` can keep the fuller scope (which nodes, which modes). Do not shorten local to match Cloud.
+
+Example: docs/local may say H3 Max landed on text-to-video, first-last-frame, and reference nodes. Cloud: `Added H3 Max model support`.
+
+## Bullet links (docs, local CMS, Cloud CMS)
+
+Resolve each feature bullet **before** `cms:prepare:locales`. Search these sources every time a new version lands:
+
+| Source | Where |
+|--------|--------|
+| Template index | [templates/index.json](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) (raw: `https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/index.json`) |
+| Blog | [blog.comfy.org](https://blog.comfy.org/) ([archive](https://blog.comfy.org/archive)) |
+
+Match a template by `name`, `title`, or `models` to the changelog item. Match a blog post only if it covers **this** product or version (MiniMax H3 day-0 is not MiniMax H3 Max).
+
+**Video templates:** when several templates exist, pick one by suffix on `name`, in this order: **r2v → i2v → t2v**. Example: `api_minimax_h3_max_r2v` over `_i2v` / `_t2v`. If none of those suffixes exist, use the remaining matching template (`flf2v`, `edit`, and similar). Cloud URL shape: `https://cloud.comfy.org/?template=<name>` (no UTM unless the user supplied one).
+
+| Surface | Link priority (first match wins) |
+|---------|----------------------------------|
+| **Cloud** CMS (`staging/cloud/`) | 1. UTM / `links.comfy.org` URL **the user provided** 2. Cloud template URL from the index 3. GitHub PR 4. ComfyUI repo commit/tag/compare |
+| **Docs** `changelog/index.mdx` and **local** CMS (`staging/en/` etc.) | 1. Matching [blog.comfy.org](https://blog.comfy.org/) post 2. GitHub PR 3. ComfyUI repo commit/tag/compare |
+
+Do **not** put Cloud `?template=` URLs on docs or local popup. Do **not** copy local blog/PR links onto Cloud when a template (or user UTM) exists. After `prepare:en` merges comfyui → cloud, replace Cloud bullets that still point at PRs if the index has a template.
+
 ## ComfyUI-WIKI commits (omit from changelog)
 
 When curating `changelog/index.mdx` from ComfyUI git history, **do not add bullets** for commits routinely opened by **[ComfyUI-WIKI](https://github.com/Comfy-Org/ComfyUI-WIKI)** — they are dependency/content syncs, not core release features:
@@ -185,7 +213,7 @@ Requires **Bun**. Loads `.env.local` automatically.
 
 ### New release version
 
-1. Add full `<Update>` block to `changelog/index.mdx` (docs quality — unchanged).
+1. Add full `<Update>` block to `changelog/index.mdx` (docs quality — unchanged). Set each bullet URL using **Bullet links** (blog → PR → repo for docs).
 
 2. **Step 1 — Simplify EN** — review before translating:
 
@@ -193,7 +221,7 @@ Requires **Bun**. Loads `.env.local` automatically.
    pnpm cms:prepare:en -- --force v0.25.1
    ```
 
-   Inspect: `.github/scripts/cms/staging/en/changelog/index.mdx` → **stop until approved**
+   Inspect: `.github/scripts/cms/staging/en/changelog/index.mdx` (blog/PR/repo, fuller copy). Rewrite `.github/scripts/cms/staging/cloud/en/changelog/index.mdx`: user UTM or `?template=` from the index, and **shorter** bullets (model support, not every node). → **stop until approved**
 
 3. **Step 2 — Translate** — from approved staging EN only:
 
@@ -265,8 +293,10 @@ Re-run with `--force`. Staging without `--force` **skips** existing `<Update>` b
 When user asks to update CMS release notes:
 
 - [ ] Confirm `changelog/index.mdx` has the new `<Update>` block
+- [ ] Resolve bullet URLs: search template `index.json` and [blog.comfy.org/archive](https://blog.comfy.org/archive); Cloud = user UTM then `?template=` (video r2v → i2v → t2v); docs/local = blog then PR then repo
+- [ ] Shorten Cloud EN bullets (added model support, skip node lists). Keep local/docs more detailed
 - [ ] Omit ComfyUI-WIKI items (embedded docs, workflow templates, model blueprints) unless user explicitly asks
-- [ ] Run `pnpm cms:prepare:en`; show staging EN → **wait for user approval**
+- [ ] Run `pnpm cms:prepare:en`; rewrite Cloud EN links; show staging EN → **wait for user approval**
 - [ ] Run `pnpm cms:prepare:locales` (not `cms:prepare:en`) → **wait for user approval**
 - [ ] Run `pnpm cms:preview -- --project comfyui ...` then `pnpm cms:sync -- --project comfyui ...` **only after user confirms staging**
 - [ ] Run cloud `cms:sync` / `cms:publish` only after separate explicit cloud confirmation

--- a/.cursor/skills/docs-i18n-translate/SKILL.md
+++ b/.cursor/skills/docs-i18n-translate/SKILL.md
@@ -104,6 +104,8 @@ only re-translate changed `##` sections when `auto_chunk` applies).
 
 Do not add bullets for dependency-only version bumps. See also **`cms-changelog-sync`** for CMS popup rules.
 
+**Docs changelog bullet URLs** (same as local CMS): matching [blog.comfy.org](https://blog.comfy.org/) post first, then the GitHub PR, then the ComfyUI repo commit/tag/compare. Do not use Cloud `?template=` links on the docs changelog. Cloud popup URLs are a separate rule in **cms-changelog-sync**.
+
 ```bash
 pnpm translate -- changelog/index.mdx
 pnpm translate -- changelog/index.mdx --lang zh

--- a/.github/scripts/cms/README.md
+++ b/.github/scripts/cms/README.md
@@ -62,6 +62,8 @@ Each version is **saved immediately** after simplify/translate (safe to resume).
 
 After prepare:en, secondary projects (cloud) merge only the prepared `<Update>` blocks from comfyui. If cloud EN already has that version, incoming tracking shortlinks are rewritten to match cloud EN (local vs cloud campaign URLs). `prepare:locales` translates each project from its own staging EN and does not copy comfyui locale files onto cloud.
 
+**Bullet URLs** (agents rewrite after prepare:en; see skill `cms-changelog-sync`): Cloud prefers a user-supplied UTM/`links.comfy.org` URL, else `https://cloud.comfy.org/?template=<name>` from [workflow_templates `index.json`](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) (video: r2v → i2v → t2v). Docs and local CMS prefer a [blog.comfy.org](https://blog.comfy.org/) post, then the GitHub PR, then the repo commit/tag. **Cloud copy** is shorter than local (announce the model, do not enumerate every node).
+
 ## Projects & attention
 
 | Project | CLI | Default attention |

--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -776,7 +776,7 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-08-28T15:40:36.700Z"
+      "published_at": "2026-08-28T15:54:39.895Z"
     },
     {
       "project": "comfyui",
@@ -790,7 +790,35 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-08-28T15:39:47.293Z"
+      "published_at": "2026-08-28T15:54:14.650Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.34.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-03T10:13:11.924Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.34.3",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-03T10:12:48.455Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="September 2, 2026">
+
+**Partner Node Updates**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v): Added H3 Max model support
+
+</Update>
+
 <Update label="v0.34.2" description="August 27, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v): Se ha añadido compatibilidad con el modelo H3 Max
+
+</Update>
+
 <Update label="v0.34.2" description="27 de agosto de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 septembre 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v) : Ajout de la prise en charge du modèle H3 Max
+
+</Update>
+
 <Update label="v0.34.2" description="27 août 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026年9月2日">
+
+**パートナーノードの更新**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v)：H3 Max モデルのサポートが追加されました
+
+</Update>
+
 <Update label="v0.34.2" description="2026年8月27日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026년 9월 2일">
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v): H3 Max 모델 지원 추가
+
+</Update>
+
 <Update label="v0.34.2" description="2026년 8월 27일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 сентября 2026">
+
+**Обновления партнёрских узлов**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v): Добавлена поддержка модели H3 Max
+
+</Update>
+
 <Update label="v0.34.2" description="27 августа 2026 г.">
 
 **Обновления партнёрских нод**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026年9月2日">
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Max**](https://cloud.comfy.org/?template=api_minimax_h3_max_r2v)：添加了 H3 Max 模型支持
+
+</Update>
+
 <Update label="v0.34.2" description="2026年8月27日">
 
 **合作伙伴节点更新**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="September 2, 2026">
+
+**Partner Node Updates**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): Adds H3 Max option to text-to-video, first-last-frame, and reference nodes.
+
+</Update>
+
 <Update label="v0.34.2" description="August 27, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): Añade la opción H3 Max a los nodos de texto a video, de primer y último fotograma y de referencia.
+
+</Update>
+
 <Update label="v0.34.2" description="27 de agosto de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 septembre 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025) : ajoute l'option H3 Max aux nœuds texte-vers-vidéo, première/dernière image et référence.
+
+</Update>
+
 <Update label="v0.34.2" description="27 août 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026年9月2日">
+
+**パートナーノードの更新**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): テキストから動画、最初と最後のフレーム、および参照の各ノードに H3 Max オプションを追加します。
+
+</Update>
+
 <Update label="v0.34.2" description="2026年8月27日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026년 9월 2일">
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): 텍스트 기반 비디오 생성, 첫 번째/마지막 프레임, 참조 노드에 H3 Max 옵션을 추가합니다.
+
+</Update>
+
 <Update label="v0.34.2" description="2026년 8월 27일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2 сентября 2026">
+
+**Обновления партнёрских узлов**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): Добавлена опция H3 Max для узлов text-to-video, first-last-frame и reference.
+
+</Update>
+
 <Update label="v0.34.2" description="27 августа 2026 г.">
 
 **Обновления партнёрских нод**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,13 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.3" description="2026年9月2日">
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025)：为文生视频、首尾帧和参考节点添加 H3 Max 选项。
+
+</Update>
+
 <Update label="v0.34.2" description="2026年8月27日">
 
 **合作伙伴节点更新**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,19 @@ description: "ComfyUI changelog: the latest features, improvements, and bug fixe
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.34.3" description="September 2, 2026">
+
+**Partner Node Updates**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): Added the H3 Max model option to MiniMax H3 text-to-video, first-last-frame, and reference nodes
+
+**Performance & Stability**
+* [**TRELLIS remesh memory**](https://github.com/Comfy-Org/ComfyUI/pull/16034): Lowered remesh memory usage in TRELLIS workflows
+
+**Bug Fixes**
+* [**3D preview paths**](https://github.com/Comfy-Org/ComfyUI/pull/16038): Annotate temp paths on Preview3DAdvanced, PreviewGaussianSplat, and PreviewPointCloud so Cloud previews resolve
+
+</Update>
+
 <Update label="v0.34.2" description="August 27, 2026">
 
 **Partner Node Updates**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "変更履歴"
 description: "ComfyUI の変更ログ：各リリースの最新機能、改善点、バグ修正を、新バージョンのリリースに合わせて更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 13aa7c8c
+translationSourceHash: 2be39ac3
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
   "v0.34.0": ab0efbb1
@@ -123,6 +124,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.3" description="2026年9月2日">
+
+**パートナーノードの更新**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): MiniMax H3 のテキストから動画、最初と最後のフレーム、リファレンスの各ノードに H3 Max モデルオプションを追加しました
+
+**パフォーマンスと安定性**
+* [**TRELLIS リメッシュのメモリ**](https://github.com/Comfy-Org/ComfyUI/pull/16034): TRELLIS ワークフローでリメッシュ処理のメモリ使用量を削減しました
+
+**バグ修正**
+* [**3D プレビューのパス**](https://github.com/Comfy-Org/ComfyUI/pull/16038): Preview3DAdvanced、PreviewGaussianSplat、PreviewPointCloud の一時パスに注釈を付け、Cloud プレビューが解決されるようにしました
+
+</Update>
 
 <Update label="v0.34.2" description="2026年8月27日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "변경 로그"
 description: "ComfyUI 변경 로그: 각 릴리스의 최신 기능, 개선 사항, 버그 수정을 새 버전 출시에 맞춰 업데이트합니다."
 icon: "clock-rotate-left"
-translationSourceHash: 13aa7c8c
+translationSourceHash: 2be39ac3
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
   "v0.34.0": ab0efbb1
@@ -123,6 +124,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.3" description="2026년 9월 2일">
+
+**파트너 노드 업데이트**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025): MiniMax H3 텍스트 기반 비디오 생성, 첫 번째 및 마지막 프레임, 레퍼런스 노드에 H3 Max 모델 옵션을 추가했습니다.
+
+**성능 및 안정성**
+* [**TRELLIS remesh 메모리**](https://github.com/Comfy-Org/ComfyUI/pull/16034): TRELLIS 워크플로에서 remesh 메모리 사용량을 줄였습니다.
+
+**버그 수정**
+* [**3D 미리보기 경로**](https://github.com/Comfy-Org/ComfyUI/pull/16038): Preview3DAdvanced, PreviewGaussianSplat, PreviewPointCloud의 임시 경로에 주석을 추가하여 클라우드 미리보기가 정상적으로 표시되도록 했습니다.
+
+</Update>
 
 <Update label="v0.34.2" description="2026년 8월 27일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,10 @@
 title: "更新日志"
 description: "ComfyUI 变更日志：每个版本的最新功能、改进和错误修复，随新版本发布持续更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 13aa7c8c
+translationSourceHash: 2be39ac3
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
   "v0.34.0": ab0efbb1
@@ -123,6 +124,19 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.3" description="2026年9月2日">
+
+**合作伙伴节点更新**
+* [**MiniMax H3 Max**](https://github.com/Comfy-Org/ComfyUI/pull/16025)：为 MiniMax H3 文生视频、首尾帧和参考节点新增了 H3 Max 模型选项
+
+**性能与稳定性**
+* [**TRELLIS 重新网格化内存**](https://github.com/Comfy-Org/ComfyUI/pull/16034)：降低了 TRELLIS 工作流中重新网格化的内存占用
+
+**Bug 修复**
+* [**3D 预览路径**](https://github.com/Comfy-Org/ComfyUI/pull/16038)：为 Preview3DAdvanced、PreviewGaussianSplat 和 PreviewPointCloud 标注临时路径，以便云端预览能够正常解析
+
+</Update>
 
 <Update label="v0.34.2" description="2026年8月27日">
 


### PR DESCRIPTION
## Summary
- Add ComfyUI v0.34.3 changelog (en/zh/ja/ko): MiniMax H3 Max, TRELLIS remesh memory, 3D preview path fix
- Publish CMS popup notes for ComfyUI and Cloud (7 locales). Cloud uses the `api_minimax_h3_max_r2v` template URL and shorter copy; local/docs keep node-level detail
- Document changelog link rules (blog → PR → repo for docs/local; user UTM then Cloud template for Cloud) and Cloud-vs-local copy length in the CMS skill

## Test plan
- [ ] Confirm docs changelog block for v0.34.3 on the preview
- [ ] Confirm in-app ComfyUI popup shows the detailed MiniMax H3 Max bullet with the GitHub PR
- [ ] Confirm Cloud popup shows the short "Added H3 Max model support" bullet and opens `cloud.comfy.org/?template=api_minimax_h3_max_r2v`