### PR TITLE
docs(comfy-router): link provider API references, retire the pre-GA banner

### DIFF
--- a/.github/scripts/snippets/gen-code-pages.ts
+++ b/.github/scripts/snippets/gen-code-pages.ts
@@ -84,6 +84,36 @@ const PROVIDER_LABEL: Record<string, string> = {
 const PROVIDER_DOC_BASE: Record<string, string> = { openai: "https://platform.openai.com" };
 
 /**
+ * Provider slug -> that provider's own API reference.
+ *
+ * A model with no authored input schema is documented by the provider and nobody
+ * else, so the Note that says so links there rather than leaving the reader to
+ * search. Every URL here was fetched and returned 200 on 2026-09-04; a provider
+ * with no entry keeps the unlinked wording, which is why `ltx` is absent (its
+ * docs answer 403 to a plain fetch, so the link could not be verified). Verify
+ * before adding a row: a docs link that rots is worse than no link.
+ */
+const PROVIDER_API_DOCS: Record<string, string> = {
+  anthropic: "https://docs.claude.com/en/api/messages",
+  bfl: "https://docs.bfl.ai/",
+  bria: "https://docs.bria.ai/",
+  byteplus: "https://docs.byteplus.com/",
+  "gemini-interactions": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference",
+  kling: "https://app.klingai.com/global/dev/document-api",
+  krea: "https://docs.krea.ai/",
+  luma: "https://docs.lumalabs.ai/docs/api",
+  luma_2: "https://docs.lumalabs.ai/docs/api",
+  meshy: "https://docs.meshy.ai/",
+  minimax: "https://platform.minimax.io/docs/api-reference",
+  openai: "https://platform.openai.com/docs/api-reference",
+  recraft: "https://www.recraft.ai/docs",
+  runway: "https://docs.dev.runwayml.com/",
+  veo: "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation",
+  vertexai: "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference",
+  xai: "https://docs.x.ai/docs/api-reference",
+};
+
+/**
  * Display titles for derived pages.
  *
  * Neither `GET /v2/models` nor the per-model schema publishes a human name — the
@@ -691,9 +721,10 @@ function renderDerivedPage(model: string, s: ModelSchema): string {
   const provider = providerLabel(providerOf(model));
   const setup = `Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as \`COMFY_API_KEY\`. The Python and TypeScript snippets use the Comfy SDKs (\`pip install comfy-sdk\`, \`npm install @comfyorg/sdk\`); the cURL snippet is the same call over raw HTTP.`;
   const docBase = PROVIDER_DOC_BASE[providerOf(model)];
+  const apiDocs = PROVIDER_API_DOCS[providerOf(model)];
   const input = s.authored && s.input
     ? `${schemaFields(s.input, s.components, "param", docBase)}\n\nGenerated from the schema Router serves at \`GET ${ROUTE}/${model}/openapi.json\`, the same document it validates a call against before the request reaches the provider.`
-    : `<Note>\nRouter has not published an authored input schema for this model yet: \`GET ${ROUTE}/${model}/openapi.json\` returns an open object with \`x-comfy-input-schema-authored: false\`. Router forwards the body to ${provider} unchanged, so ${provider}'s own API documentation is authoritative for the request fields, and nothing is validated server side.\n</Note>`;
+    : `<Note>\nRouter has not published an authored input schema for this model yet: \`GET ${ROUTE}/${model}/openapi.json\` returns an open object with \`x-comfy-input-schema-authored: false\`. Router forwards the body to ${provider} unchanged, so ${apiDocs ? `[${provider}'s own API reference](${apiDocs})` : `${provider}'s own API documentation`} is authoritative for the request fields, and nothing is validated server side.\n</Note>`;
   const output = s.output
     ? schemaFields(s.output, s.components, "response", docBase)
     : `Router does not publish an output schema for this model.`;

--- a/development/comfy-router/headers.mdx
+++ b/development/comfy-router/headers.mdx
@@ -4,10 +4,6 @@ sidebarTitle: "Headers"
 description: "The request headers you can send to Comfy Router and the response headers it returns, for every model: authentication, idempotency, request IDs, error buckets, retry pacing and spend limits."
 ---
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
-
-<RouterPreviewNotice />
-
 Every model behind Comfy Router is called the same way: `POST /v2/models/{provider}/{model}` with the model's own JSON body. What is common to all of them lives in the headers, and this page is the one place they are described. The per-model Code pages link here instead of repeating it; the [API reference](/development/comfy-router/reference) carries the same definitions in generated form.
 
 The Comfy SDKs (`comfy-sdk` for Python, `@comfyorg/sdk` for TypeScript) send the request headers for you and surface the response headers as fields on results and errors. If you call Router over raw HTTP, you send and read them yourself.

--- a/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-fable-5-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-fable-5-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-fable-5-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Fable 5.1"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-fable-5-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-fable-5-1`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Fable 5"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-fable-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-fable-5`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-fable-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-fable-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-fable-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Haiku 4.5 20251001"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-haiku-4-5-20251001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-haiku-4-5-20251001`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-haiku-4-5-20251001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-haiku-4-5-20251001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-haiku-4-5-20251001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-6 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Opus 4.6"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-opus-4-6.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-opus-4-6`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-7 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-7/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-7/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Opus 4.7"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-opus-4-7.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-opus-4-7`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Opus 4.8"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-opus-4-8.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-opus-4-8`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-8 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-8/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-4-8/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Opus 5"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-opus-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-opus-5`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-opus-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-opus-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Sonnet 4.5 20250929"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-sonnet-4-5-20250929.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-sonnet-4-5-20250929`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-4-5-20250929 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-4-5-20250929/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-4-5-20250929/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-4-6 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-4-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-4-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Sonnet 4.6"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-sonnet-4-6.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-sonnet-4-6`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Claude Sonnet 5"
 
 {/* GENERATED FILE. Generated from router-schemas/anthropic/claude-sonnet-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `anthropic/claude-sonnet-5`, served by Comfy Router from Anthropic.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so Anthropic's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/anthropic/claude-sonnet-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/beeble/switchx/code.mdx
+++ b/development/comfy-router/models/beeble/switchx/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "SwitchX"
 
 {/* GENERATED FILE. Generated from router-schemas/beeble/switchx.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `beeble/switchx`, served by Comfy Router from Beeble.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/erase-v1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/erase-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/erase-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Erase V1"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/erase-v1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/erase-v1`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Flux 1.1 Pro Ultra Image"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Flux 1.1 Pro Ultra Image. FLUX 1.1 [pro] is a text-to-image model from Black Forest Labs. Ultra mode generates images at up to 4MP resolution.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Flux.1 Kontext"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Flux.1 Kontext. Flux.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX 2 Max"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-2-max.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-2-max`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-2-max \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-2-max/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-2-max/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX 2 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-2-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-2-pro`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-2-pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-2-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-2-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX 3 Video"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for FLUX 3 Video. FLUX 3 Video is Black Forest Labs' video generation model, turning a text prompt into a short clip with synchronized audio.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX Pro 1.0 Canny"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-pro-1.0-canny.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-pro-1.0-canny`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-canny \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-canny/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-canny/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-depth \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-depth/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-depth/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX Pro 1.0 Depth"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-pro-1.0-depth.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-pro-1.0-depth`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-expand \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-expand/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-expand/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX Pro 1.0 Expand"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-pro-1.0-expand.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-pro-1.0-expand`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX Pro 1.0 Fill"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/flux-pro-1.0-fill.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/flux-pro-1.0-fill`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-fill \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-fill/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/flux-pro-1.0-fill/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "FLUX Video Upscale"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for FLUX Video Upscale. FLUX Video Upscale is Black Forest Labs' video upscaler: send a video, get a higher-resolution version back.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bfl/vto-v1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/vto-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so Black Forest Labs's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bfl/vto-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Black Forest Labs unchanged, so [Black Forest Labs's own API reference](https://docs.bfl.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "VTO V1"
 
 {/* GENERATED FILE. Generated from router-schemas/bfl/vto-v1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bfl/vto-v1`, served by Comfy Router from Black Forest Labs.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/fibo/code.mdx
+++ b/development/comfy-router/models/bria/fibo/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bria/fibo \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/fibo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so Bria's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bria/fibo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/bria/fibo/code.mdx
+++ b/development/comfy-router/models/bria/fibo/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Fibo"
 
 {/* GENERATED FILE. Generated from router-schemas/bria/fibo.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bria/fibo`, served by Comfy Router from Bria.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-erase/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-erase/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Image Edit Erase"
 
 {/* GENERATED FILE. Generated from router-schemas/bria/image-edit-erase.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bria/image-edit-erase`, served by Comfy Router from Bria.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-erase/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-erase/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bria/image-edit-erase \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-erase/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so Bria's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-erase/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/bria/image-edit-expand/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-expand/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Image Edit Expand"
 
 {/* GENERATED FILE. Generated from router-schemas/bria/image-edit-expand.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bria/image-edit-expand`, served by Comfy Router from Bria.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-expand/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-expand/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bria/image-edit-expand \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-expand/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so Bria's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-expand/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Image Edit Gen Fill"
 
 {/* GENERATED FILE. Generated from router-schemas/bria/image-edit-gen-fill.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bria/image-edit-gen-fill`, served by Comfy Router from Bria.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bria/image-edit-gen-fill \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-gen-fill/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so Bria's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-gen-fill/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Image Edit Remove Background"
 
 {/* GENERATED FILE. Generated from router-schemas/bria/image-edit-remove-background.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `bria/image-edit-remove-background`, served by Comfy Router from Bria.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/bria/image-edit-remove-background \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-remove-background/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so Bria's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-remove-background/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-260128 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Dreamina Seedance 2.0 260128"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/dreamina-seedance-2-0-260128.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/dreamina-seedance-2-0-260128`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-fast-260128 
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-fast-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-fast-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Dreamina Seedance 2.0 Fast 260128"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/dreamina-seedance-2-0-fast-260128.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/dreamina-seedance-2-0-fast-260128`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Dreamina Seedance 2.0 Mini"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/dreamina-seedance-2-0-mini.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/dreamina-seedance-2-0-mini`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-mini \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-0-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Dreamina Seedance 2.5 260628"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/dreamina-seedance-2-5-260628.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/dreamina-seedance-2-5-260628`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-5-260628 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-5-260628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/dreamina-seedance-2-5-260628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seed-audio-1.0-multilingual \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seed-audio-1.0-multilingual/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seed-audio-1.0-multilingual/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seed Audio 1.0 Multilingual"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seed-audio-1.0-multilingual.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seed-audio-1.0-multilingual`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seed-audio-1.0 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seed-audio-1.0/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seed-audio-1.0/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seed Audio 1.0"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seed-audio-1.0.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seed-audio-1.0`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-lite-i2v-250428 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-lite-i2v-250428/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-lite-i2v-250428/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedance 1.0 Lite I2V 250428"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedance-1-0-lite-i2v-250428.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedance-1-0-lite-i2v-250428`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-lite-t2v-250428 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-lite-t2v-250428/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-lite-t2v-250428/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedance 1.0 Lite T2V 250428"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedance-1-0-lite-t2v-250428.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedance-1-0-lite-t2v-250428`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedance 1.0 Pro 250528"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedance-1-0-pro-250528.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedance-1-0-pro-250528`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-pro-250528 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-pro-250528/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-pro-250528/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-pro-fast-251015 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-pro-fast-251015/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-0-pro-fast-251015/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedance 1.0 Pro Fast 251015"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedance-1-0-pro-fast-251015.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedance-1-0-pro-fast-251015`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedance 1.5 Pro 251215"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedance-1-5-pro-251215.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedance-1-5-pro-251215`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedance-1-5-pro-251215 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-5-pro-251215/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedance-1-5-pro-251215/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
+++ b/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seededit 3.0 I2I 250628"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seededit-3-0-i2i-250628.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seededit-3-0-i2i-250628`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
+++ b/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seededit-3-0-i2i-250628 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seededit-3-0-i2i-250628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seededit-3-0-i2i-250628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedream 3.0 T2I 250415"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedream-3-0-t2i-250415.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedream-3-0-t2i-250415`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedream-3-0-t2i-250415 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-3-0-t2i-250415/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-3-0-t2i-250415/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedream 4.0 250828"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedream-4-0-250828.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedream-4-0-250828`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedream-4-0-250828 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-4-0-250828/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-4-0-250828/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedream 4.5 251128"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedream-4-5-251128.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedream-4-5-251128`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedream-4-5-251128 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-4-5-251128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-4-5-251128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedream-5-0-260128 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-5-0-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-5-0-260128/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedream 5.0 260128"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedream-5-0-260128.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedream-5-0-260128`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Seedream 5.0 Pro 260628"
 
 {/* GENERATED FILE. Generated from router-schemas/byteplus/seedream-5-0-pro-260628.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `byteplus/seedream-5-0-pro-260628`, served by Comfy Router from BytePlus.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/byteplus/seedream-5-0-pro-260628 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-5-0-pro-260628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so BytePlus's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/byteplus/seedream-5-0-pro-260628/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to BytePlus unchanged, so [BytePlus's own API reference](https://docs.byteplus.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gemini Omni 1.1 Flash"
 
 {/* GENERATED FILE. Generated from router-schemas/gemini-interactions/gemini-omni-1.1-flash.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `gemini-interactions/gemini-omni-1.1-flash`, served by Comfy Router from Gemini Interactions.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-1.1-flash \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-1.1-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so Gemini Interactions's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-1.1-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-flash-previ
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-flash-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so Gemini Interactions's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-flash-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gemini Omni Flash Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/gemini-interactions/gemini-omni-flash-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `gemini-interactions/gemini-omni-flash-preview`, served by Comfy Router from Gemini Interactions.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
+++ b/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gemini 2.5 Flash Image"
 
 {/* GENERATED FILE. Generated from router-schemas/vertexai/gemini-2.5-flash-image.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `vertexai/gemini-2.5-flash-image`, served by Comfy Router from Google.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
+++ b/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-2.5-flash-image \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-2.5-flash-image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so Google's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-2.5-flash-image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so [Google's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gemini 3.1 Flash Lite"
 
 {/* GENERATED FILE. Generated from router-schemas/vertexai/gemini-3.1-flash-lite.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `vertexai/gemini-3.1-flash-lite`, served by Comfy Router from Google.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-flash-lite \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-3.1-flash-lite/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so Google's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-3.1-flash-lite/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so [Google's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-3.7-flash \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-3.7-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so Google's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/vertexai/gemini-3.7-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Google unchanged, so [Google's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gemini 3.7 Flash"
 
 {/* GENERATED FILE. Generated from router-schemas/vertexai/gemini-3.7-flash.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `vertexai/gemini-3.7-flash`, served by Comfy Router from Google.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini/code.mdx
+++ b/development/comfy-router/models/google/gemini/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Google Gemini"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Google Gemini. Google Gemini is Google's family of multimodal text models, covering fast drafting through deep reasoning across the Flash and Pro tiers.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Nano Banana 2 Lite"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Nano Banana 2 Lite. Nano Banana 2 Lite (Gemini 3.1 Flash-Lite Image) is the Flash-Lite tier of Google's Nano Banana image generation family, tuned for lower latency and cost.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-2/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Nano Banana 2"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Nano Banana 2. Nano Banana 2 (Gemini 3.1 Flash Image) is Google's image generation and editing model, balancing quality and speed.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-pro/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Nano Banana Pro"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Nano Banana Pro. Nano Banana Pro (Gemini 3 Pro Image) is the Pro tier of Google's Nano Banana image generation family, aimed at complex scenes and legible text.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
+++ b/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Ideogram 4.0"
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for Ideogram 4.0. Ideogram 4.0 is Ideogram's text-to-image model, which renders legible text inside generated images.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling 3.0 Turbo"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-3.0-turbo.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-3.0-turbo`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-3.0-turbo \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-3.0-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-3.0-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-image-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-image-o1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling Image O1"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-image-o1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-image-o1`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-image-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-image-o1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-image-o1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-image-o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-image-o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v1-5/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v1-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v1-5/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V1.5"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v1-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v1-5`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v1-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-6/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v1-6 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v1-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-6/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V1.6"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v1-6.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v1-6`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V1"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v1`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V2.1 Master"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v2-1-master.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v2-1-master`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v2-1-master \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-1-master/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-1-master/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v2-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V2.1"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v2-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v2-1`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V2.5 Turbo"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v2-5-turbo.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v2-5-turbo`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v2-5-turbo \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-5-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-5-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-6/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v2-6 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-6/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V2.6"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v2-6.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v2-6`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-master/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v2-master \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-master/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v2-master/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v2-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-master/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V2 Master"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v2-master.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v2-master`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v3-omni/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3-omni/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V3 Omni"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v3-omni.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v3-omni`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v3-omni/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3-omni/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v3-omni \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v3-omni/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v3-omni/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-v3/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling V3"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-v3.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-v3`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v3/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-v3 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-v3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/kling/kling-video-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-video-o1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Kling Video O1"
 
 {/* GENERATED FILE. Generated from router-schemas/kling/kling-video-o1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `kling/kling-video-o1`, served by Comfy Router from Kling.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-video-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-video-o1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/kling/kling-video-o1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-video-o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so Kling's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/kling/kling-video-o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Kling unchanged, so [Kling's own API reference](https://app.klingai.com/global/dev/document-api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/krea/krea-2-large/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-large/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Krea 2 Large"
 
 {/* GENERATED FILE. Generated from router-schemas/krea/krea-2-large.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `krea/krea-2-large`, served by Comfy Router from Krea.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-large/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-large/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/krea/krea-2-large \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-large/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so Krea's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-large/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so [Krea's own API reference](https://docs.krea.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Krea 2 Medium Turbo"
 
 {/* GENERATED FILE. Generated from router-schemas/krea/krea-2-medium-turbo.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `krea/krea-2-medium-turbo`, served by Comfy Router from Krea.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/krea/krea-2-medium-turbo \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-medium-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so Krea's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-medium-turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so [Krea's own API reference](https://docs.krea.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/krea/krea-2-medium/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/krea/krea-2-medium \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-medium/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so Krea's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2-medium/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so [Krea's own API reference](https://docs.krea.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/krea/krea-2-medium/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Krea 2 Medium"
 
 {/* GENERATED FILE. Generated from router-schemas/krea/krea-2-medium.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `krea/krea-2-medium`, served by Comfy Router from Krea.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2/code.mdx
+++ b/development/comfy-router/models/krea/krea-2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/krea/krea-2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so Krea's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/krea/krea-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Krea unchanged, so [Krea's own API reference](https://docs.krea.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/krea/krea-2/code.mdx
+++ b/development/comfy-router/models/krea/krea-2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Krea 2"
 
 {/* GENERATED FILE. Generated from router-schemas/krea/krea-2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `krea/krea-2`, served by Comfy Router from Krea.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "LTX 2.5 Fast"
 
 {/* GENERATED FILE. Generated from router-schemas/ltx/ltx-2-5-fast.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `ltx/ltx-2-5-fast`, served by Comfy Router from LTX.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "LTX 2.5 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/ltx/ltx-2-5-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `ltx/ltx-2-5-pro`, served by Comfy Router from LTX.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma/photon-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma/photon-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so Luma's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma/photon-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so [Luma's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma/photon-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Photon 1"
 
 {/* GENERATED FILE. Generated from router-schemas/luma/photon-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma/photon-1`, served by Comfy Router from Luma.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-flash-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-flash-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Photon Flash 1"
 
 {/* GENERATED FILE. Generated from router-schemas/luma/photon-flash-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma/photon-flash-1`, served by Comfy Router from Luma.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-flash-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-flash-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma/photon-flash-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma/photon-flash-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so Luma's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma/photon-flash-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so [Luma's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma/ray-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma/ray-2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma/ray-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so Luma's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma/ray-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so [Luma's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma/ray-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Ray 2"
 
 {/* GENERATED FILE. Generated from router-schemas/luma/ray-2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma/ray-2`, served by Comfy Router from Luma.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/ray-flash-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-flash-2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Ray Flash 2"
 
 {/* GENERATED FILE. Generated from router-schemas/luma/ray-flash-2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma/ray-flash-2`, served by Comfy Router from Luma.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/ray-flash-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-flash-2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma/ray-flash-2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma/ray-flash-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so Luma's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma/ray-flash-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma unchanged, so [Luma's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma_2/uni-1-max/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1-max/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma_2/uni-1-max \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma_2/uni-1-max/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma 2 unchanged, so Luma 2's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma_2/uni-1-max/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma 2 unchanged, so [Luma 2's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma_2/uni-1-max/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1-max/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Uni 1 Max"
 
 {/* GENERATED FILE. Generated from router-schemas/luma_2/uni-1-max.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma_2/uni-1-max`, served by Comfy Router from Luma 2.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/luma_2/uni-1/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/luma_2/uni-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/luma_2/uni-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma 2 unchanged, so Luma 2's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/luma_2/uni-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Luma 2 unchanged, so [Luma 2's own API reference](https://docs.lumalabs.ai/docs/api) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/luma_2/uni-1/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Uni 1"
 
 {/* GENERATED FILE. Generated from router-schemas/luma_2/uni-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `luma_2/uni-1`, served by Comfy Router from Luma 2.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-5/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/meshy/meshy-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so Meshy's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so [Meshy's own API reference](https://docs.meshy.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/meshy/meshy-5/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Meshy 5"
 
 {/* GENERATED FILE. Generated from router-schemas/meshy/meshy-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `meshy/meshy-5`, served by Comfy Router from Meshy.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-6/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-6/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/meshy/meshy-6 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so Meshy's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-6/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so [Meshy's own API reference](https://docs.meshy.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/meshy/meshy-6/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-6/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Meshy 6"
 
 {/* GENERATED FILE. Generated from router-schemas/meshy/meshy-6.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `meshy/meshy-6`, served by Comfy Router from Meshy.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-7/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-7/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Meshy 7"
 
 {/* GENERATED FILE. Generated from router-schemas/meshy/meshy-7.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `meshy/meshy-7`, served by Comfy Router from Meshy.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-7/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-7/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/meshy/meshy-7 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-7/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so Meshy's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/meshy/meshy-7/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Meshy unchanged, so [Meshy's own API reference](https://docs.meshy.ai/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/minimax/minimax-h3/code.mdx
+++ b/development/comfy-router/models/minimax/minimax-h3/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/minimax/minimax-h3 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/minimax/minimax-h3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to MiniMax unchanged, so MiniMax's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/minimax/minimax-h3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to MiniMax unchanged, so [MiniMax's own API reference](https://platform.minimax.io/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/minimax/minimax-h3/code.mdx
+++ b/development/comfy-router/models/minimax/minimax-h3/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "MiniMax H3"
 
 {/* GENERATED FILE. Generated from router-schemas/minimax/minimax-h3.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `minimax/minimax-h3`, served by Comfy Router from MiniMax.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-4.1-mini \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 4.1 Mini"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-4.1-mini.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-4.1-mini`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-4.1-nano \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1-nano/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1-nano/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 4.1 Nano"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-4.1-nano.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-4.1-nano`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-4.1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4.1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-4-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 4.1"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-4.1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-4.1`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4o/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4o/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 4o"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-4o.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-4o`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4o/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4o/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-4o \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4o/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-4o/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5.5-pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.5-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.5-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5.5 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.5-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5.5-pro`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5.5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5.5"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5.5`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5.6 Luna"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.6-luna.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5.6-luna`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5.6-luna \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-luna/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-luna/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5.6-sol \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-sol/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-sol/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5.6 Sol"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.6-sol.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5.6-sol`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5.6-terra \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-terra/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5.6-terra/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5.6 Terra"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.6-terra.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5.6-terra`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-mini/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5 Mini"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5-mini.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5-mini`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-mini/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5-mini \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-nano/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5-nano \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5-nano/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5-nano/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-5-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-nano/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5 Nano"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5-nano.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5-nano`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT 5"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-5`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-image-1.5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-1.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-1.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT Image 1.5"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-image-1.5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-image-1.5`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-image-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-image-1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-image-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT Image 1"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-image-1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-image-1`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-image-2/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/gpt-image-2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-image-2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/gpt-image-2/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "GPT Image 2"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/gpt-image-2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/gpt-image-2`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o1-pro/code.mdx
+++ b/development/comfy-router/models/openai/o1-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "o1-pro"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/o1-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/o1-pro`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o1-pro/code.mdx
+++ b/development/comfy-router/models/openai/o1-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/o1-pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o1-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o1-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/o1/code.mdx
+++ b/development/comfy-router/models/openai/o1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "o1"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/o1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/o1`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o1/code.mdx
+++ b/development/comfy-router/models/openai/o1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/o1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/o3/code.mdx
+++ b/development/comfy-router/models/openai/o3/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/o3 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/o3/code.mdx
+++ b/development/comfy-router/models/openai/o3/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "o3"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/o3.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/o3`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o4-mini/code.mdx
+++ b/development/comfy-router/models/openai/o4-mini/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/openai/o4-mini \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o4-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so OpenAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/o4-mini/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/openai/o4-mini/code.mdx
+++ b/development/comfy-router/models/openai/o4-mini/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "o4-mini"
 
 {/* GENERATED FILE. Generated from router-schemas/openai/o4-mini.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `openai/o4-mini`, served by Comfy Router from OpenAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Qwen Image 3.0 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/qwen/qwen-image-3.0-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `qwen/qwen-image-3.0-pro`, served by Comfy Router from Qwen.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Qwen Image 3.0"
 
 {/* GENERATED FILE. Generated from router-schemas/qwen/qwen-image-3.0.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `qwen/qwen-image-3.0`, served by Comfy Router from Qwen.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv2/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv2/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V2"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv2`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv3/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv3/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv3 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv3/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv3/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V3"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv3.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv3`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Pro Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_pro_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_pro_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_pro`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Utility Pro Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_utility_pro_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_utility_pro_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Utility Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_utility_pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_utility_pro`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Utility Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_utility_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_utility_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Utility"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_utility.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_utility`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1 Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-1/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4.1"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_1.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_1`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4 Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_pro`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4 Styles Pro Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_styles_pro_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_styles_pro_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4 Styles Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_styles_pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_styles_pro`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_vector \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4 Styles Vector"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_styles_vector.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_styles_vector`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4 Styles"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4_styles.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4_styles`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so Recraft's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/recraft/recraftv4/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Recraft V4"
 
 {/* GENERATED FILE. Generated from router-schemas/recraft/recraftv4.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `recraft/recraftv4`, served by Comfy Router from Recraft.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/aleph2/code.mdx
+++ b/development/comfy-router/models/runway/aleph2/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/runway/aleph2 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/runway/aleph2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so Runway's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/runway/aleph2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so [Runway's own API reference](https://docs.dev.runwayml.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/runway/aleph2/code.mdx
+++ b/development/comfy-router/models/runway/aleph2/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Aleph 2"
 
 {/* GENERATED FILE. Generated from router-schemas/runway/aleph2.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `runway/aleph2`, served by Comfy Router from Runway.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/gen4-image/code.mdx
+++ b/development/comfy-router/models/runway/gen4-image/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gen 4 Image"
 
 {/* GENERATED FILE. Generated from router-schemas/runway/gen4_image.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `runway/gen4_image`, served by Comfy Router from Runway.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/gen4-image/code.mdx
+++ b/development/comfy-router/models/runway/gen4-image/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/runway/gen4_image \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/runway/gen4_image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so Runway's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/runway/gen4_image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so [Runway's own API reference](https://docs.dev.runwayml.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/runway/gen4-turbo/code.mdx
+++ b/development/comfy-router/models/runway/gen4-turbo/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/runway/gen4_turbo \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/runway/gen4_turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so Runway's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/runway/gen4_turbo/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Runway unchanged, so [Runway's own API reference](https://docs.dev.runwayml.com/) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/runway/gen4-turbo/code.mdx
+++ b/development/comfy-router/models/runway/gen4-turbo/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Gen 4 Turbo"
 
 {/* GENERATED FILE. Generated from router-schemas/runway/gen4_turbo.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `runway/gen4_turbo`, served by Comfy Router from Runway.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 2.0 Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-2.0-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-2.0-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-2.0-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-2.0-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-2.0-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 3.0 Fast Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-3.0-fast-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-3.0-fast-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-3.0-fast-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.0-fast-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.0-fast-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 3.0 Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-3.0-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-3.0-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-3.0-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.0-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.0-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-3.1-fast-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-fast-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-fast-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 3.1 Fast Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-3.1-fast-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-3.1-fast-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 3.1 Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-3.1-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-3.1-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-3.1-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/veo/veo-3.1-lite-generate-001 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-lite-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so Veo's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/veo/veo-3.1-lite-generate-001/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Veo unchanged, so [Veo's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo-video-generation) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Veo 3.1 Lite Generate 001"
 
 {/* GENERATED FILE. Generated from router-schemas/veo/veo-3.1-lite-generate-001.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `veo/veo-3.1-lite-generate-001`, served by Comfy Router from Veo.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.0 I2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-i2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.0-i2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.0 R2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-r2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.0-r2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.0 T2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-t2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.0-t2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.0 Video Edit"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-video-edit.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.0-video-edit`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.1 I2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-i2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.1-i2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.1 R2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-r2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.1-r2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Happyhorse 1.1 T2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-t2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/happyhorse-1.1-t2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.5 I2I Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-i2i-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.5-i2i-preview`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.5 I2V Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-i2v-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.5-i2v-preview`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.5 T2I Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-t2i-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.5-t2i-preview`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.5 T2V Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-t2v-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.5-t2v-preview`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.6 I2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-i2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.6-i2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.6 R2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-r2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.6-r2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.6 T2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-t2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.6-t2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.7 I2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-i2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.7-i2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.7 R2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-r2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.7-r2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.7 T2V"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-t2v.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.7-t2v`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 2.7 Video Edit"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-videoedit.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan2.7-videoedit`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 3.0 Video Prime"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan3.0-video-prime.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan3.0-video-prime`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan3-0-video/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Wan 3.0 Video"
 
 {/* GENERATED FILE. Generated from router-schemas/wan/wan3.0-video.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `wan/wan3.0-video`, served by Comfy Router from Wan.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Image 2.0"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-image-2.0.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-image-2.0`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-image-2.0 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-2.0/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-2.0/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-image-pro \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Image Pro"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-image-pro.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-image-pro`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Image Quality"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-image-quality.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-image-quality`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-image-quality \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-quality/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image-quality/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-image/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-image \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-image/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-image/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Image"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-image.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-image`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Video 1.5 Preview"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-video-1.5-preview.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-video-1.5-preview`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-video-1.5-preview \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video-1.5-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video-1.5-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Video 1.5"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-video-1.5.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-video-1.5`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-video-1.5 \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video-1.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video-1.5/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/xai/grok-imagine-video/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video/code.mdx
@@ -6,12 +6,9 @@ sidebarTitle: "Grok Imagine Video"
 
 {/* GENERATED FILE. Generated from router-schemas/xai/grok-imagine-video.json by `pnpm code-pages:gen`. */}
 
-import RouterPreviewNotice from "/snippets/comfy-router/preview-notice.mdx";
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
 API Reference for `xai/grok-imagine-video`, served by Comfy Router from xAI.
-
-<RouterPreviewNotice />
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video/code.mdx
@@ -65,7 +65,7 @@ curl https://api.comfy.org/v2/models/xai/grok-imagine-video \
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so xAI's own API documentation is authoritative for the request fields, and nothing is validated server side.
+Router has not published an authored input schema for this model yet: `GET /v2/models/xai/grok-imagine-video/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to xAI unchanged, so [xAI's own API reference](https://docs.x.ai/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
 </Note>
 
 ### Output

--- a/snippets/comfy-router/preview-notice.mdx
+++ b/snippets/comfy-router/preview-notice.mdx
@@ -1,3 +1,0 @@
-<Note>
-**Comfy Router is not generally available yet.** `POST /v2/models/{provider}/{model}` and its catalog and schema siblings are not serving requests yet: an authenticated call answers `404` today. The snippets on this page document the contract those routes will serve, published ahead of the rollout so your integration is ready to write against.
-</Note>


### PR DESCRIPTION
Follow-up to #1594. Two small changes on top of the generated Code pages.

## 1. The unauthored-input note now links to the provider

148 of the 157 pages carry a note saying Router has not narrowed that model's input and the provider's own documentation is authoritative — without saying where that is. It now links:

> Router forwards the body to Anthropic unchanged, so [Anthropic's own API reference](https://docs.claude.com/en/api/messages) is authoritative for the request fields, and nothing is validated server side.

Every URL in `PROVIDER_API_DOCS` was fetched and returned **200** on 2026-09-04. A provider with no row keeps the previous unlinked wording — that is the point of the map being explicit rather than derived:

- `ltx` — docs.ltx.video answers **403** to a plain fetch, so the link could not be verified.
- `wan`, `qwen` — which Alibaba surface actually serves them is still an open question (see below).

25 of 148 pages stay unlinked, all four cases deliberate. A docs link that rots is worse than no link, so verify before adding a row.

## 2. The pre-GA banner is retired

`snippets/comfy-router/preview-notice.mdx` told every Router page that `POST /v2/models/{provider}/{model}` "is not serving requests yet: an authenticated call answers `404` today". That has been false since the flag flip — I get 200s from the catalog, the per-model schema route and model runs.

Deleting the snippet is the entire change for the 157 generated pages: #1594 made the banner conditional on that file existing, so a regen drops the import and the element from all of them. `development/comfy-router/headers.mdx` is hand-written and imported it directly, so its two lines are removed here.

The parallel notices on the three cloud-owned pages (reference, quickstart, limitations) are removed upstream and arrive via the spec-sync PR #1595 — this is the docs-owned half of the same retirement.

## Related work in flight

Six agents are crawling provider documentation to author the **input schemas** for the 148 models Router does not narrow. That work lands upstream as components in `services/comfy-api/openapi.yml` (`x-comfy-router-model-id`), not here — once it does, these pages render real fields automatically and the note disappears for those models with no docs change at all. The `wan`/`qwen` question above is one of the things that crawl should settle.

## Verification

- `pnpm code-pages:check` — `157 code page(s) fresh (9 curated, 148 derived)`, all snippets syntax-checked.
- Zero `RouterPreviewNotice` references remain in `development/` or `snippets/`.
- The nine curated pages are byte-identical: they never render the note, and their banner import is dropped by the same regen.

## Provenance

Drafted with Claude Code. Provider URLs verified by fetch on 2026-09-04.
