### PR TITLE
Improve Comfy Router model pages

### DIFF
--- a/.github/scripts/snippets/gen-code-pages.ts
+++ b/.github/scripts/snippets/gen-code-pages.ts
@@ -644,7 +644,7 @@ sidebarTitle: ${JSON.stringify(spec.name)}
 
 ${previewNotice.imports}import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-${spec.intro ?? `API Reference for ${spec.name}. ${spec.summary.replace(/\s+/g, " ").trim()}`}
+${spec.intro ?? `Use ${spec.name} with Comfy Router. ${spec.summary.replace(/\s+/g, " ").trim()}`}
 ${previewNotice.body}
 ${body}
 
@@ -742,7 +742,7 @@ sidebarTitle: ${JSON.stringify(title)}
 
 ${previewNotice.imports}import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for \`${model}\`, served by Comfy Router from ${provider}.
+Use \`${model}\` with the Comfy Router API. ${provider} provides the model; Router gives it the shared authentication and request route below.
 ${previewNotice.body}
 ## Quick start
 

--- a/.github/scripts/snippets/gen-code-pages.ts
+++ b/.github/scripts/snippets/gen-code-pages.ts
@@ -307,16 +307,19 @@ function pythonSnippet(model: string, example: Record<string, unknown>, files: F
   const body = Object.entries(example)
     .map(([k, v]) => `            ${JSON.stringify(k)}: ${pyLiteral(v, 12, files, k)},`)
     .join("\n");
-  return `${files.length ? "import base64\n\n" : ""}from comfy_sdk import Comfy
+  return `${files.length ? "import base64\n" : ""}import uuid
+from comfy_sdk import Comfy
 ${reads ? `\n${reads}\n` : ""}
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "${model}",
         {
 ${body}
         },
+        idempotency_key=idempotency_key,
     )
 
 print("${label}:", result${pyPath(resultPath)})`;
@@ -331,12 +334,13 @@ function typescriptSnippet(model: string, example: Record<string, unknown>, file
     .map(([k, v]) => `  ${/^[a-zA-Z_$][\w$]*$/.test(k) ? k : JSON.stringify(k)}: ${tsLiteral(v, 2, files, k)},`)
     .join("\n");
   return `${imports}
-${reads ? `${reads}\n\n` : ""}// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+${reads ? `${reads}\n\n` : ""}// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = ${tsResultType(resultPath)};
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("${model}", {
 ${body}
-});
+}, { idempotencyKey });
 
 console.log("${label}:", data${tsPath(resultPath)});`;
 }
@@ -350,9 +354,11 @@ function curlSnippet(model: string, example: Record<string, unknown>, files: Fil
     return `${esc(k)}: ${value}`;
   });
   const json = `{${entries.join(", ")}}`;
-  return `${reads ? `${reads}\n\n` : ""}curl ${BASE_URL}${ROUTE}/${model} \\
+  return `${reads ? `${reads}\n\n` : ""}# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
+curl ${BASE_URL}${ROUTE}/${model} \\
   -H "X-API-Key: $COMFY_API_KEY" \\
-  -H "Idempotency-Key: $(uuidgen)" \\
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \\
   -H "Content-Type: application/json" \\
   -d "${json}"`;
 }
@@ -674,32 +680,38 @@ ${body}
 const BODY_HINT = "Request fields are the provider's own \u2014 see Input below.";
 
 function derivedSnippets(model: string): string {
-  const python = `from comfy_sdk import Comfy
+  const python = `import uuid
+from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "${model}",
         {
             # ${BODY_HINT}
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)`;
   const typescript = `import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("${model}", {
   // ${BODY_HINT}
-});
+}, { idempotencyKey });
 
 console.log(data);`;
   const curl = `# ${BODY_HINT}
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl ${BASE_URL}${ROUTE}/${model} \\
   -H "X-API-Key: $COMFY_API_KEY" \\
-  -H "Idempotency-Key: $(uuidgen)" \\
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{}'`;
   return `<CodeGroup>

--- a/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-fable-5-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-fable-5-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-fable-5-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Fable 5.1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-fable-5-1`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-fable-5-1` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-fable-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-fable-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-fable-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-fable-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Fable 5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-fable-5`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-fable-5` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Haiku 4.5 20251001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-haiku-4-5-20251001`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-haiku-4-5-20251001` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-haiku-4-5-20251001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-haiku-4-5-20251001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-haiku-4-5-20251001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-haiku-4-5-20251001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-opus-4-6",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-opus-4-6", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-6 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-6/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Opus 4.6"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-opus-4-6`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-opus-4-6` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-opus-4-7",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-opus-4-7", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-7 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-7/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Opus 4.7"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-opus-4-7`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-opus-4-7` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-opus-4-8",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-opus-4-8", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-opus-4-8 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-4-8/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Opus 4.8"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-opus-4-8`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-opus-4-8` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-opus-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-opus-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-opus-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-opus-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Opus 5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-opus-5`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-opus-5` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Sonnet 4.5 20250929"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-sonnet-4-5-20250929`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-sonnet-4-5-20250929` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-5-20250929/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-sonnet-4-5-20250929",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-sonnet-4-5-20250929", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-4-5-20250929 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-sonnet-4-6",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-sonnet-4-6", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-4-6 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-4-6/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Sonnet 4.6"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-sonnet-4-6`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-sonnet-4-6` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Claude Sonnet 5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `anthropic/claude-sonnet-5`, served by Comfy Router from Anthropic.
+Use `anthropic/claude-sonnet-5` with the Comfy Router API. Anthropic provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
+++ b/development/comfy-router/models/anthropic/claude-sonnet-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "anthropic/claude-sonnet-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("anthropic/claude-sonnet-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/anthropic/claude-sonnet-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/beeble/switchx/code.mdx
+++ b/development/comfy-router/models/beeble/switchx/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "SwitchX"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `beeble/switchx`, served by Comfy Router from Beeble.
+Use `beeble/switchx` with the Comfy Router API. Beeble provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/beeble/switchx/code.mdx
+++ b/development/comfy-router/models/beeble/switchx/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "beeble/switchx",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("beeble/switchx", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/beeble/switchx \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Erase V1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/erase-v1`, served by Comfy Router from Black Forest Labs.
+Use `bfl/erase-v1` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/erase-v1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/erase-v1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/erase-v1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/erase-v1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Flux 1.1 Pro Ultra Image"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Flux 1.1 Pro Ultra Image. FLUX 1.1 [pro] is a text-to-image model from Black Forest Labs. Ultra mode generates images at up to 4MP resolution.
+Use Flux 1.1 Pro Ultra Image with Comfy Router. FLUX 1.1 [pro] is a text-to-image model from Black Forest Labs. Ultra mode generates images at up to 4MP resolution.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-1-pro-ultra-image/code.mdx
@@ -24,10 +24,12 @@ Pick the model you want to call. Everything below, from the snippets to the sche
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.1-ultra",
@@ -36,6 +38,7 @@ with Comfy() as client:
             "aspect_ratio": "16:9",
             "raw": False,
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image:", result["result"]["sample"])
@@ -44,22 +47,25 @@ print("image:", result["result"]["sample"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/flux-pro-1.1-ultra", {
   prompt: "a single red maple leaf on a plain white background, studio lighting",
   aspect_ratio: "16:9",
   raw: false,
-});
+}, { idempotencyKey });
 
 console.log("image:", data.result.sample);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.1-ultra \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"prompt\": \"a single red maple leaf on a plain white background, studio lighting\", \"aspect_ratio\": \"16:9\", \"raw\": false}"
 ```
@@ -231,10 +237,12 @@ The URL is temporary. Download the image promptly if you need to keep it.
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.1",
@@ -243,6 +251,7 @@ with Comfy() as client:
             "width": 1024,
             "height": 768,
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image:", result["result"]["sample"])
@@ -251,22 +260,25 @@ print("image:", result["result"]["sample"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/flux-pro-1.1", {
   prompt: "a single red maple leaf on a plain white background, studio lighting",
   width: 1024,
   height: 768,
-});
+}, { idempotencyKey });
 
 console.log("image:", data.result.sample);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"prompt\": \"a single red maple leaf on a plain white background, studio lighting\", \"width\": 1024, \"height\": 768}"
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Flux.1 Kontext"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Flux.1 Kontext. Flux.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
+Use Flux.1 Kontext with Comfy Router. Flux.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Flux.1 Kontext with Comfy Router"
-description: "Python, TypeScript and cURL snippets for calling Flux.1 Kontext Pro and Kontext Max over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Flux.1 Kontext"
+title: "Use FLUX.1 Kontext with Comfy Router"
+description: "Python, TypeScript and cURL snippets for calling FLUX.1 Kontext Pro and Kontext Max over HTTP through Comfy Router, plus the request fields and the result shape"
+sidebarTitle: "FLUX.1 Kontext"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-Use Flux.1 Kontext with Comfy Router. Flux.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
+Use FLUX.1 Kontext with Comfy Router. FLUX.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
 
 ## Quick start
 
@@ -25,14 +25,15 @@ Pick the model you want to call. Everything below, from the snippets to the sche
 <CodeGroup>
 ```python Python
 import base64
-
+import uuid
 from comfy_sdk import Comfy
 
 with open("input.jpg", "rb") as f:
     input_image = base64.b64encode(f.read()).decode()
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-kontext-pro",
@@ -41,6 +42,7 @@ with Comfy() as client:
             "input_image": input_image,
             "aspect_ratio": "1:1",
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image:", result["result"]["sample"])
@@ -52,14 +54,15 @@ import { readFile } from "node:fs/promises";
 
 const inputImage = (await readFile("input.jpg")).toString("base64");
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/flux-kontext-pro", {
   prompt: "replace the background with a sunlit beach, keep the subject unchanged",
   input_image: inputImage,
   aspect_ratio: "1:1",
-});
+}, { idempotencyKey });
 
 console.log("image:", data.result.sample);
 ```
@@ -67,9 +70,11 @@ console.log("image:", data.result.sample);
 ```bash cURL
 INPUT_IMAGE=$(base64 < input.jpg | tr -d '\n')
 
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-kontext-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"prompt\": \"replace the background with a sunlit beach, keep the subject unchanged\", \"input_image\": \"$INPUT_IMAGE\", \"aspect_ratio\": \"1:1\"}"
 ```
@@ -243,14 +248,15 @@ The URL is temporary. Download the image promptly if you need to keep it.
 <CodeGroup>
 ```python Python
 import base64
-
+import uuid
 from comfy_sdk import Comfy
 
 with open("input.jpg", "rb") as f:
     input_image = base64.b64encode(f.read()).decode()
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-kontext-max",
@@ -259,6 +265,7 @@ with Comfy() as client:
             "input_image": input_image,
             "aspect_ratio": "1:1",
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image:", result["result"]["sample"])
@@ -270,14 +277,15 @@ import { readFile } from "node:fs/promises";
 
 const inputImage = (await readFile("input.jpg")).toString("base64");
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/flux-kontext-max", {
   prompt: "replace the background with a sunlit beach, keep the subject unchanged",
   input_image: inputImage,
   aspect_ratio: "1:1",
-});
+}, { idempotencyKey });
 
 console.log("image:", data.result.sample);
 ```
@@ -285,9 +293,11 @@ console.log("image:", data.result.sample);
 ```bash cURL
 INPUT_IMAGE=$(base64 < input.jpg | tr -d '\n')
 
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-kontext-max \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"prompt\": \"replace the background with a sunlit beach, keep the subject unchanged\", \"input_image\": \"$INPUT_IMAGE\", \"aspect_ratio\": \"1:1\"}"
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.yaml
+++ b/development/comfy-router/models/black-forest-labs/flux-1-kontext/code.yaml
@@ -2,13 +2,13 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # `input` / `output` are the provider's documented shapes (JSON Schema in YAML) and
 # are the fallback until Router publishes the model's schema in router-schemas/.
-name: Flux.1 Kontext
+name: FLUX.1 Kontext
 provider: Black Forest Labs
 description: >-
-  Python, TypeScript and cURL snippets for calling Flux.1 Kontext Pro and Kontext Max over HTTP through
+  Python, TypeScript and cURL snippets for calling FLUX.1 Kontext Pro and Kontext Max over HTTP through
   Comfy Router, plus the request fields and the result shape
 summary: >-
-  Flux.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
+  FLUX.1 Kontext is Black Forest Labs' instruction-driven image editing model: send an image and a text instruction, get the edited image back with the rest of the scene preserved.
 task: image editing
 variants:
 - title: Kontext Pro

--- a/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-2-max",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-2-max", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-2-max \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-max/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX 2 Max"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-2-max`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-2-max` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX 2 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-2-pro`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-2-pro` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-2-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-2-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-2-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-2-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX 3 Video"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for FLUX 3 Video. FLUX 3 Video is Black Forest Labs' video generation model, turning a text prompt into a short clip with synchronized audio.
+Use FLUX 3 Video with Comfy Router. FLUX 3 Video is Black Forest Labs' video generation model, turning a text prompt into a short clip with synchronized audio.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-3-video/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-3-video",
@@ -34,6 +36,7 @@ with Comfy() as client:
             "aspect_ratio": "16:9",
             "generate_audio": True,
         },
+        idempotency_key=idempotency_key,
     )
 
 print("video:", result["result"]["sample"])
@@ -42,24 +45,27 @@ print("video:", result["result"]["sample"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/flux-3-video", {
   mode: "t2v",
   prompt: "a single red maple leaf falling onto still water, slow motion",
   duration: 5,
   aspect_ratio: "16:9",
   generate_audio: true,
-});
+}, { idempotencyKey });
 
 console.log("video:", data.result.sample);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-3-video \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"mode\": \"t2v\", \"prompt\": \"a single red maple leaf falling onto still water, slow motion\", \"duration\": 5, \"aspect_ratio\": \"16:9\", \"generate_audio\": true}"
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.0-canny",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-pro-1.0-canny", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-canny \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-canny/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX Pro 1.0 Canny"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-pro-1.0-canny`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-pro-1.0-canny` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX Pro 1.0 Depth"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-pro-1.0-depth`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-pro-1.0-depth` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-depth/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.0-depth",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-pro-1.0-depth", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-depth \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.0-expand",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-pro-1.0-expand", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-expand \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-expand/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX Pro 1.0 Expand"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-pro-1.0-expand`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-pro-1.0-expand` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX Pro 1.0 Fill"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/flux-pro-1.0-fill`, served by Comfy Router from Black Forest Labs.
+Use `bfl/flux-pro-1.0-fill` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-pro-1-0-fill/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/flux-pro-1.0-fill",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/flux-pro-1.0-fill", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/flux-pro-1.0-fill \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/video-upscale-v1",
@@ -32,6 +34,7 @@ with Comfy() as client:
             "upscale_factor": 2,
             "creativity": 1,
         },
+        idempotency_key=idempotency_key,
     )
 
 print("video:", result["result"]["sample"])
@@ -40,22 +43,25 @@ print("video:", result["result"]["sample"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { result: { sample: string } };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("bfl/video-upscale-v1", {
   input_video: "https://your-host.example/clip.mp4",
   upscale_factor: 2,
   creativity: 1,
-});
+}, { idempotencyKey });
 
 console.log("video:", data.result.sample);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/video-upscale-v1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"input_video\": \"https://your-host.example/clip.mp4\", \"upscale_factor\": 2, \"creativity\": 1}"
 ```

--- a/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/flux-video-upscale/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "FLUX Video Upscale"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for FLUX Video Upscale. FLUX Video Upscale is Black Forest Labs' video upscaler: send a video, get a higher-resolution version back.
+Use FLUX Video Upscale with Comfy Router. FLUX Video Upscale is Black Forest Labs' video upscaler: send a video, get a higher-resolution version back.
 
 ## Quick start
 

--- a/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bfl/vto-v1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bfl/vto-v1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bfl/vto-v1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
+++ b/development/comfy-router/models/black-forest-labs/vto-v1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "VTO V1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bfl/vto-v1`, served by Comfy Router from Black Forest Labs.
+Use `bfl/vto-v1` with the Comfy Router API. Black Forest Labs provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/fibo/code.mdx
+++ b/development/comfy-router/models/bria/fibo/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Fibo"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/fibo`, served by Comfy Router from Bria.
+Use `bria/fibo` with the Comfy Router API. Bria provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/fibo/code.mdx
+++ b/development/comfy-router/models/bria/fibo/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bria/fibo",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bria/fibo", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bria/fibo \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/bria/image-edit-erase/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-erase/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Image Edit Erase"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/image-edit-erase`, served by Comfy Router from Bria.
+Use `bria/image-edit-erase` with the Comfy Router API. Bria provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-erase/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-erase/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bria/image-edit-erase",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bria/image-edit-erase", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bria/image-edit-erase \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/bria/image-edit-expand/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-expand/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Image Edit Expand"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/image-edit-expand`, served by Comfy Router from Bria.
+Use `bria/image-edit-expand` with the Comfy Router API. Bria provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-expand/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-expand/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bria/image-edit-expand",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bria/image-edit-expand", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bria/image-edit-expand \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Image Edit Gen Fill"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/image-edit-gen-fill`, served by Comfy Router from Bria.
+Use `bria/image-edit-gen-fill` with the Comfy Router API. Bria provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bria/image-edit-gen-fill",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bria/image-edit-gen-fill", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bria/image-edit-gen-fill \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "bria/image-edit-remove-background",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("bria/image-edit-remove-background", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/bria/image-edit-remove-background \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-remove-background/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Image Edit Remove Background"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/image-edit-remove-background`, served by Comfy Router from Bria.
+Use `bria/image-edit-remove-background` with the Comfy Router API. Bria provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Dreamina Seedance 2.0 260128"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/dreamina-seedance-2-0-260128`, served by Comfy Router from BytePlus.
+Use `byteplus/dreamina-seedance-2-0-260128` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-260128/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/dreamina-seedance-2-0-260128",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/dreamina-seedance-2-0-260128", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-260128 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Dreamina Seedance 2.0 Fast 260128"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/dreamina-seedance-2-0-fast-260128`, served by Comfy Router from BytePlus.
+Use `byteplus/dreamina-seedance-2-0-fast-260128` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-fast-260128/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/dreamina-seedance-2-0-fast-260128",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/dreamina-seedance-2-0-fast-260128", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-fast-260128 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Dreamina Seedance 2.0 Mini"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/dreamina-seedance-2-0-mini`, served by Comfy Router from BytePlus.
+Use `byteplus/dreamina-seedance-2-0-mini` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-0-mini/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/dreamina-seedance-2-0-mini",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/dreamina-seedance-2-0-mini", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-0-mini \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/dreamina-seedance-2-5-260628",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/dreamina-seedance-2-5-260628", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/dreamina-seedance-2-5-260628 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/dreamina-seedance-2-5-260628/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Dreamina Seedance 2.5 260628"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/dreamina-seedance-2-5-260628`, served by Comfy Router from BytePlus.
+Use `byteplus/dreamina-seedance-2-5-260628` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seed-audio-1.0-multilingual",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seed-audio-1.0-multilingual", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seed-audio-1.0-multilingual \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0-multilingual/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seed Audio 1.0 Multilingual"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seed-audio-1.0-multilingual`, served by Comfy Router from BytePlus.
+Use `byteplus/seed-audio-1.0-multilingual` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seed Audio 1.0"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seed-audio-1.0`, served by Comfy Router from BytePlus.
+Use `byteplus/seed-audio-1.0` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
+++ b/development/comfy-router/models/byteplus/seed-audio-1-0/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seed-audio-1.0",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seed-audio-1.0", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seed-audio-1.0 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedance 1.0 Lite I2V 250428"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedance-1-0-lite-i2v-250428`, served by Comfy Router from BytePlus.
+Use `byteplus/seedance-1-0-lite-i2v-250428` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-i2v-250428/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedance-1-0-lite-i2v-250428",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedance-1-0-lite-i2v-250428", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-lite-i2v-250428 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedance 1.0 Lite T2V 250428"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedance-1-0-lite-t2v-250428`, served by Comfy Router from BytePlus.
+Use `byteplus/seedance-1-0-lite-t2v-250428` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-lite-t2v-250428/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedance-1-0-lite-t2v-250428",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedance-1-0-lite-t2v-250428", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-lite-t2v-250428 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedance 1.0 Pro 250528"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedance-1-0-pro-250528`, served by Comfy Router from BytePlus.
+Use `byteplus/seedance-1-0-pro-250528` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-250528/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedance-1-0-pro-250528",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedance-1-0-pro-250528", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-pro-250528 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedance 1.0 Pro Fast 251015"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedance-1-0-pro-fast-251015`, served by Comfy Router from BytePlus.
+Use `byteplus/seedance-1-0-pro-fast-251015` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-0-pro-fast-251015/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedance-1-0-pro-fast-251015",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedance-1-0-pro-fast-251015", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedance-1-0-pro-fast-251015 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedance-1-5-pro-251215",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedance-1-5-pro-251215", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedance-1-5-pro-251215 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
+++ b/development/comfy-router/models/byteplus/seedance-1-5-pro-251215/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedance 1.5 Pro 251215"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedance-1-5-pro-251215`, served by Comfy Router from BytePlus.
+Use `byteplus/seedance-1-5-pro-251215` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
+++ b/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seededit 3.0 I2I 250628"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seededit-3-0-i2i-250628`, served by Comfy Router from BytePlus.
+Use `byteplus/seededit-3-0-i2i-250628` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
+++ b/development/comfy-router/models/byteplus/seededit-3-0-i2i-250628/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seededit-3-0-i2i-250628",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seededit-3-0-i2i-250628", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seededit-3-0-i2i-250628 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedream-3-0-t2i-250415",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedream-3-0-t2i-250415", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedream-3-0-t2i-250415 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-3-0-t2i-250415/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedream 3.0 T2I 250415"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedream-3-0-t2i-250415`, served by Comfy Router from BytePlus.
+Use `byteplus/seedream-3-0-t2i-250415` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedream-4-0-250828",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedream-4-0-250828", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedream-4-0-250828 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-0-250828/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedream 4.0 250828"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedream-4-0-250828`, served by Comfy Router from BytePlus.
+Use `byteplus/seedream-4-0-250828` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedream-4-5-251128",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedream-4-5-251128", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedream-4-5-251128 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-4-5-251128/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedream 4.5 251128"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedream-4-5-251128`, served by Comfy Router from BytePlus.
+Use `byteplus/seedream-4-5-251128` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedream-5-0-260128",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedream-5-0-260128", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedream-5-0-260128 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-260128/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedream 5.0 260128"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedream-5-0-260128`, served by Comfy Router from BytePlus.
+Use `byteplus/seedream-5-0-260128` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "byteplus/seedream-5-0-pro-260628",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("byteplus/seedream-5-0-pro-260628", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/byteplus/seedream-5-0-pro-260628 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
+++ b/development/comfy-router/models/byteplus/seedream-5-0-pro-260628/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Seedream 5.0 Pro 260628"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `byteplus/seedream-5-0-pro-260628`, served by Comfy Router from BytePlus.
+Use `byteplus/seedream-5-0-pro-260628` with the Comfy Router API. BytePlus provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "gemini-interactions/gemini-omni-1.1-flash",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("gemini-interactions/gemini-omni-1.1-flash", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-1.1-flash \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gemini Omni 1.1 Flash"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `gemini-interactions/gemini-omni-1.1-flash`, served by Comfy Router from Gemini Interactions.
+Use `gemini-interactions/gemini-omni-1.1-flash` with the Comfy Router API. Gemini Interactions provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gemini Omni Flash Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `gemini-interactions/gemini-omni-flash-preview`, served by Comfy Router from Gemini Interactions.
+Use `gemini-interactions/gemini-omni-flash-preview` with the Comfy Router API. Gemini Interactions provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "gemini-interactions/gemini-omni-flash-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("gemini-interactions/gemini-omni-flash-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-flash-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
+++ b/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gemini 2.5 Flash Image"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `vertexai/gemini-2.5-flash-image`, served by Comfy Router from Google.
+Use `vertexai/gemini-2.5-flash-image` with the Comfy Router API. Google provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
+++ b/development/comfy-router/models/google/gemini-2-5-flash-image/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-2.5-flash-image",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("vertexai/gemini-2.5-flash-image", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-2.5-flash-image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gemini 3.1 Flash Lite"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `vertexai/gemini-3.1-flash-lite`, served by Comfy Router from Google.
+Use `vertexai/gemini-3.1-flash-lite` with the Comfy Router API. Google provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-1-flash-lite/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.1-flash-lite",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("vertexai/gemini-3.1-flash-lite", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-flash-lite \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.7-flash",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("vertexai/gemini-3.7-flash", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.7-flash \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
+++ b/development/comfy-router/models/google/gemini-3-7-flash/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gemini 3.7 Flash"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `vertexai/gemini-3.7-flash`, served by Comfy Router from Google.
+Use `vertexai/gemini-3.7-flash` with the Comfy Router API. Google provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/gemini/code.mdx
+++ b/development/comfy-router/models/google/gemini/code.mdx
@@ -24,10 +24,12 @@ Pick the model you want to call. The models share one request and response shape
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.1-pro-preview",
@@ -47,6 +49,7 @@ with Comfy() as client:
                 "maxOutputTokens": 256,
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
@@ -55,9 +58,10 @@ print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { text: string }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-pro-preview", {
   contents: [
     {
@@ -73,15 +77,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-pro-preview
     temperature: 0.7,
     maxOutputTokens: 256,
   },
-});
+}, { idempotencyKey });
 
 console.log("text:", data.candidates[0].content.parts[0].text);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-pro-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"Describe a single red maple leaf on a white background in one sentence.\"}]}], \"generationConfig\": {\"temperature\":0.7,\"maxOutputTokens\":256}}"
 ```
@@ -94,10 +100,12 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-pro-preview \
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.5-flash",
@@ -117,6 +125,7 @@ with Comfy() as client:
                 "maxOutputTokens": 256,
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
@@ -125,9 +134,10 @@ print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { text: string }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-3.5-flash", {
   contents: [
     {
@@ -143,15 +153,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-3.5-flash", {
     temperature: 0.7,
     maxOutputTokens: 256,
   },
-});
+}, { idempotencyKey });
 
 console.log("text:", data.candidates[0].content.parts[0].text);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.5-flash \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"Describe a single red maple leaf on a white background in one sentence.\"}]}], \"generationConfig\": {\"temperature\":0.7,\"maxOutputTokens\":256}}"
 ```
@@ -164,10 +176,12 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-3.5-flash \
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-2.5-pro",
@@ -187,6 +201,7 @@ with Comfy() as client:
                 "maxOutputTokens": 256,
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
@@ -195,9 +210,10 @@ print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { text: string }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-2.5-pro", {
   contents: [
     {
@@ -213,15 +229,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-2.5-pro", {
     temperature: 0.7,
     maxOutputTokens: 256,
   },
-});
+}, { idempotencyKey });
 
 console.log("text:", data.candidates[0].content.parts[0].text);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-2.5-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"Describe a single red maple leaf on a white background in one sentence.\"}]}], \"generationConfig\": {\"temperature\":0.7,\"maxOutputTokens\":256}}"
 ```
@@ -234,10 +252,12 @@ curl https://api.comfy.org/v2/models/vertexai/gemini-2.5-pro \
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-2.5-flash",
@@ -257,6 +277,7 @@ with Comfy() as client:
                 "maxOutputTokens": 256,
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
@@ -265,9 +286,10 @@ print("text:", result["candidates"][0]["content"]["parts"][0]["text"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { text: string }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-2.5-flash", {
   contents: [
     {
@@ -283,15 +305,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-2.5-flash", {
     temperature: 0.7,
     maxOutputTokens: 256,
   },
-});
+}, { idempotencyKey });
 
 console.log("text:", data.candidates[0].content.parts[0].text);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-2.5-flash \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"Describe a single red maple leaf on a white background in one sentence.\"}]}], \"generationConfig\": {\"temperature\":0.7,\"maxOutputTokens\":256}}"
 ```

--- a/development/comfy-router/models/google/gemini/code.mdx
+++ b/development/comfy-router/models/google/gemini/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Google Gemini"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Google Gemini. Google Gemini is Google's family of multimodal text models, covering fast drafting through deep reasoning across the Flash and Pro tiers.
+Use Google Gemini with Comfy Router. Google Gemini is Google's family of multimodal text models, covering fast drafting through deep reasoning across the Flash and Pro tiers.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.1-flash-lite-image",
@@ -45,6 +47,7 @@ with Comfy() as client:
                 },
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineData"]["data"])
@@ -53,9 +56,10 @@ print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineD
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { inlineData: { data: string } }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-flash-lite-image", {
   contents: [
     {
@@ -73,15 +77,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-flash-lite-
       aspectRatio: "1:1",
     },
   },
-});
+}, { idempotencyKey });
 
 console.log("image (base64):", data.candidates[0].content.parts[0].inlineData.data);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-flash-lite-image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"a single red maple leaf on a plain white background, studio lighting\"}]}], \"generationConfig\": {\"responseModalities\":[\"IMAGE\"],\"imageConfig\":{\"aspectRatio\":\"1:1\"}}}"
 ```

--- a/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2-lite/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Nano Banana 2 Lite"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Nano Banana 2 Lite. Nano Banana 2 Lite (Gemini 3.1 Flash-Lite Image) is the Flash-Lite tier of Google's Nano Banana image generation family, tuned for lower latency and cost.
+Use Nano Banana 2 Lite with Comfy Router. Nano Banana 2 Lite (Gemini 3.1 Flash-Lite Image) is the Flash-Lite tier of Google's Nano Banana image generation family, tuned for lower latency and cost.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-2/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Nano Banana 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Nano Banana 2. Nano Banana 2 (Gemini 3.1 Flash Image) is Google's image generation and editing model, balancing quality and speed.
+Use Nano Banana 2 with Comfy Router. Nano Banana 2 (Gemini 3.1 Flash Image) generates images from text and edits an input image when one is provided.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-2/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-2/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3.1-flash-image",
@@ -45,6 +47,7 @@ with Comfy() as client:
                 },
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineData"]["data"])
@@ -53,9 +56,10 @@ print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineD
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { inlineData: { data: string } }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-flash-image", {
   contents: [
     {
@@ -73,15 +77,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-3.1-flash-image
       aspectRatio: "1:1",
     },
   },
-});
+}, { idempotencyKey });
 
 console.log("image (base64):", data.candidates[0].content.parts[0].inlineData.data);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3.1-flash-image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"a single red maple leaf on a plain white background, studio lighting\"}]}], \"generationConfig\": {\"responseModalities\":[\"IMAGE\"],\"imageConfig\":{\"aspectRatio\":\"1:1\"}}}"
 ```

--- a/development/comfy-router/models/google/nano-banana-2/code.yaml
+++ b/development/comfy-router/models/google/nano-banana-2/code.yaml
@@ -8,7 +8,7 @@ description: >-
   Python, TypeScript and cURL snippets for generating images with Nano Banana 2 (Gemini 3.1 Flash Image)
   over HTTP through Comfy Router, plus the request fields and the result shape
 summary: >-
-  Nano Banana 2 (Gemini 3.1 Flash Image) is Google's image generation and editing model, balancing quality and speed.
+  Nano Banana 2 (Gemini 3.1 Flash Image) generates images from text and edits an input image when one is provided.
 task: generation
 variants:
 - title: Nano Banana 2

--- a/development/comfy-router/models/google/nano-banana-pro/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Nano Banana Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Nano Banana Pro. Nano Banana Pro (Gemini 3 Pro Image) is the Pro tier of Google's Nano Banana image generation family, aimed at complex scenes and legible text.
+Use Nano Banana Pro with Comfy Router. Nano Banana Pro (Gemini 3 Pro Image) is the Pro tier of Google's Nano Banana image generation family, aimed at complex scenes and legible text.
 
 ## Quick start
 

--- a/development/comfy-router/models/google/nano-banana-pro/code.mdx
+++ b/development/comfy-router/models/google/nano-banana-pro/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "vertexai/gemini-3-pro-image",
@@ -45,6 +47,7 @@ with Comfy() as client:
                 },
             },
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineData"]["data"])
@@ -53,9 +56,10 @@ print("image (base64):", result["candidates"][0]["content"]["parts"][0]["inlineD
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { candidates: { content: { parts: { inlineData: { data: string } }[] } }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("vertexai/gemini-3-pro-image", {
   contents: [
     {
@@ -73,15 +77,17 @@ const { data } = await comfy.models.run<Result>("vertexai/gemini-3-pro-image", {
       aspectRatio: "1:1",
     },
   },
-});
+}, { idempotencyKey });
 
 console.log("image (base64):", data.candidates[0].content.parts[0].inlineData.data);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/vertexai/gemini-3-pro-image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"contents\": [{\"role\":\"user\",\"parts\":[{\"text\":\"a single red maple leaf on a plain white background, studio lighting\"}]}], \"generationConfig\": {\"responseModalities\":[\"IMAGE\"],\"imageConfig\":{\"aspectRatio\":\"1:1\"}}}"
 ```

--- a/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
+++ b/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Ideogram 4.0"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Ideogram 4.0. Ideogram 4.0 is Ideogram's text-to-image model, which renders legible text inside generated images.
+Use Ideogram 4.0 with Comfy Router. Ideogram 4.0 is Ideogram's text-to-image model, which renders legible text inside generated images.
 
 ## Quick start
 

--- a/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
+++ b/development/comfy-router/models/ideogram/ideogram-v4/code.mdx
@@ -20,10 +20,12 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "ideogram/ideogram-v4",
@@ -32,6 +34,7 @@ with Comfy() as client:
             "resolution": "1024x1024",
             "rendering_speed": "DEFAULT",
         },
+        idempotency_key=idempotency_key,
     )
 
 print("image:", result["data"][0]["url"])
@@ -40,22 +43,25 @@ print("image:", result["data"][0]["url"])
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
 type Result = { data: { url: string }[] };
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run<Result>("ideogram/ideogram-v4", {
   text_prompt: "a single red maple leaf on a plain white background, studio lighting",
   resolution: "1024x1024",
   rendering_speed: "DEFAULT",
-});
+}, { idempotencyKey });
 
 console.log("image:", data.data[0].url);
 ```
 
 ```bash cURL
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/ideogram/ideogram-v4 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"text_prompt\": \"a single red maple leaf on a plain white background, studio lighting\", \"resolution\": \"1024x1024\", \"rendering_speed\": \"DEFAULT\"}"
 ```

--- a/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-3.0-turbo",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-3.0-turbo", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-3.0-turbo \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-3-0-turbo/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling 3.0 Turbo"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-3.0-turbo`, served by Comfy Router from Kling.
+Use `kling/kling-3.0-turbo` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-image-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-image-o1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling Image O1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-image-o1`, served by Comfy Router from Kling.
+Use `kling/kling-image-o1` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-image-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-image-o1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-image-o1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-image-o1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-image-o1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v1-5/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v1-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v1-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v1-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v1-5/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V1.5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v1-5`, served by Comfy Router from Kling.
+Use `kling/kling-v1-5` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v1-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-6/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v1-6",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v1-6", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v1-6 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v1-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1-6/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V1.6"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v1-6`, served by Comfy Router from Kling.
+Use `kling/kling-v1-6` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v1`, served by Comfy Router from Kling.
+Use `kling/kling-v1` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V2.1 Master"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v2-1-master`, served by Comfy Router from Kling.
+Use `kling/kling-v2-1-master` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1-master/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v2-1-master",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v2-1-master", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v2-1-master \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v2-1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V2.1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v2-1`, served by Comfy Router from Kling.
+Use `kling/kling-v2-1` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-1/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v2-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v2-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v2-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V2.5 Turbo"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v2-5-turbo`, served by Comfy Router from Kling.
+Use `kling/kling-v2-5-turbo` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-5-turbo/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v2-5-turbo",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v2-5-turbo", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v2-5-turbo \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v2-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-6/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V2.6"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v2-6`, served by Comfy Router from Kling.
+Use `kling/kling-v2-6` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-6/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-6/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v2-6",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v2-6", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v2-6 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v2-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-master/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V2 Master"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v2-master`, served by Comfy Router from Kling.
+Use `kling/kling-v2-master` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v2-master/code.mdx
+++ b/development/comfy-router/models/kling/kling-v2-master/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v2-master",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v2-master", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v2-master \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v3-omni/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3-omni/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V3 Omni"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v3-omni`, served by Comfy Router from Kling.
+Use `kling/kling-v3-omni` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-v3-omni/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3-omni/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v3-omni",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v3-omni", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v3-omni \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v3/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-v3",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-v3", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-v3 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-v3/code.mdx
+++ b/development/comfy-router/models/kling/kling-v3/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling V3"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-v3`, served by Comfy Router from Kling.
+Use `kling/kling-v3` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/kling/kling-video-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-video-o1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "kling/kling-video-o1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("kling/kling-video-o1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/kling/kling-video-o1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/kling/kling-video-o1/code.mdx
+++ b/development/comfy-router/models/kling/kling-video-o1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Kling Video O1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `kling/kling-video-o1`, served by Comfy Router from Kling.
+Use `kling/kling-video-o1` with the Comfy Router API. Kling provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-large/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-large/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "krea/krea-2-large",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("krea/krea-2-large", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/krea/krea-2-large \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/krea/krea-2-large/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-large/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Krea 2 Large"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `krea/krea-2-large`, served by Comfy Router from Krea.
+Use `krea/krea-2-large` with the Comfy Router API. Krea provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "krea/krea-2-medium-turbo",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("krea/krea-2-medium-turbo", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/krea/krea-2-medium-turbo \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium-turbo/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Krea 2 Medium Turbo"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `krea/krea-2-medium-turbo`, served by Comfy Router from Krea.
+Use `krea/krea-2-medium-turbo` with the Comfy Router API. Krea provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-medium/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Krea 2 Medium"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `krea/krea-2-medium`, served by Comfy Router from Krea.
+Use `krea/krea-2-medium` with the Comfy Router API. Krea provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2-medium/code.mdx
+++ b/development/comfy-router/models/krea/krea-2-medium/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "krea/krea-2-medium",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("krea/krea-2-medium", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/krea/krea-2-medium \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/krea/krea-2/code.mdx
+++ b/development/comfy-router/models/krea/krea-2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Krea 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `krea/krea-2`, served by Comfy Router from Krea.
+Use `krea/krea-2` with the Comfy Router API. Krea provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/krea/krea-2/code.mdx
+++ b/development/comfy-router/models/krea/krea-2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "krea/krea-2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("krea/krea-2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/krea/krea-2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "LTX 2.5 Fast"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `ltx/ltx-2-5-fast`, served by Comfy Router from LTX.
+Use `ltx/ltx-2-5-fast` with the Comfy Router API. LTX provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "ltx/ltx-2-5-fast",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("ltx/ltx-2-5-fast", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/ltx/ltx-2-5-fast \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "ltx/ltx-2-5-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("ltx/ltx-2-5-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/ltx/ltx-2-5-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "LTX 2.5 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `ltx/ltx-2-5-pro`, served by Comfy Router from LTX.
+Use `ltx/ltx-2-5-pro` with the Comfy Router API. LTX provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma/photon-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma/photon-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma/photon-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma/photon-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Photon 1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma/photon-1`, served by Comfy Router from Luma.
+Use `luma/photon-1` with the Comfy Router API. Luma provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-flash-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-flash-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Photon Flash 1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma/photon-flash-1`, served by Comfy Router from Luma.
+Use `luma/photon-flash-1` with the Comfy Router API. Luma provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/photon-flash-1/code.mdx
+++ b/development/comfy-router/models/luma/photon-flash-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma/photon-flash-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma/photon-flash-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma/photon-flash-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma/ray-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma/ray-2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma/ray-2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma/ray-2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma/ray-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Ray 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma/ray-2`, served by Comfy Router from Luma.
+Use `luma/ray-2` with the Comfy Router API. Luma provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma/ray-flash-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-flash-2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma/ray-flash-2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma/ray-flash-2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma/ray-flash-2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma/ray-flash-2/code.mdx
+++ b/development/comfy-router/models/luma/ray-flash-2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Ray Flash 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma/ray-flash-2`, served by Comfy Router from Luma.
+Use `luma/ray-flash-2` with the Comfy Router API. Luma provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma_2/uni-1-max/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1-max/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Uni 1 Max"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma_2/uni-1-max`, served by Comfy Router from Luma 2.
+Use `luma_2/uni-1-max` with the Comfy Router API. Luma 2 provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/luma_2/uni-1-max/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1-max/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma_2/uni-1-max",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma_2/uni-1-max", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma_2/uni-1-max \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma_2/uni-1/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "luma_2/uni-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("luma_2/uni-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/luma_2/uni-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/luma_2/uni-1/code.mdx
+++ b/development/comfy-router/models/luma_2/uni-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Uni 1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `luma_2/uni-1`, served by Comfy Router from Luma 2.
+Use `luma_2/uni-1` with the Comfy Router API. Luma 2 provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-5/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Meshy 5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `meshy/meshy-5`, served by Comfy Router from Meshy.
+Use `meshy/meshy-5` with the Comfy Router API. Meshy provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-5/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "meshy/meshy-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("meshy/meshy-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/meshy/meshy-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/meshy/meshy-6/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-6/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "meshy/meshy-6",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("meshy/meshy-6", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/meshy/meshy-6 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/meshy/meshy-6/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-6/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Meshy 6"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `meshy/meshy-6`, served by Comfy Router from Meshy.
+Use `meshy/meshy-6` with the Comfy Router API. Meshy provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/meshy/meshy-7/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-7/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "meshy/meshy-7",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("meshy/meshy-7", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/meshy/meshy-7 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/meshy/meshy-7/code.mdx
+++ b/development/comfy-router/models/meshy/meshy-7/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Meshy 7"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `meshy/meshy-7`, served by Comfy Router from Meshy.
+Use `meshy/meshy-7` with the Comfy Router API. Meshy provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/minimax/minimax-h3/code.mdx
+++ b/development/comfy-router/models/minimax/minimax-h3/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "minimax/minimax-h3",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("minimax/minimax-h3", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/minimax/minimax-h3 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/minimax/minimax-h3/code.mdx
+++ b/development/comfy-router/models/minimax/minimax-h3/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "MiniMax H3"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `minimax/minimax-h3`, served by Comfy Router from MiniMax.
+Use `minimax/minimax-h3` with the Comfy Router API. MiniMax provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 4.1 Mini"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-4.1-mini`, served by Comfy Router from OpenAI.
+Use `openai/gpt-4.1-mini` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-mini/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-4.1-mini",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-4.1-mini", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-4.1-mini \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 4.1 Nano"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-4.1-nano`, served by Comfy Router from OpenAI.
+Use `openai/gpt-4.1-nano` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1-nano/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-4.1-nano",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-4.1-nano", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-4.1-nano \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-4-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 4.1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-4.1`, served by Comfy Router from OpenAI.
+Use `openai/gpt-4.1` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-4-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-4.1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-4.1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-4.1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-4o/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4o/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-4o",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-4o", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-4o \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-4o/code.mdx
+++ b/development/comfy-router/models/openai/gpt-4o/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 4o"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-4o`, served by Comfy Router from OpenAI.
+Use `openai/gpt-4o` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5.5 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5.5-pro`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5.5-pro` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5.5-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5.5-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5.5-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5.5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5.5`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5.5` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5.5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5.5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5.5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5.6-luna",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5.6-luna", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5.6-luna \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-luna/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5.6 Luna"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5.6-luna`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5.6-luna` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5.6 Sol"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5.6-sol`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5.6-sol` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-sol/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5.6-sol",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5.6-sol", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5.6-sol \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5.6-terra",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5.6-terra", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5.6-terra \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-6-terra/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5.6 Terra"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5.6-terra`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5.6-terra` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-mini/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5 Mini"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5-mini`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5-mini` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5-mini/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-mini/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5-mini",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5-mini", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5-mini \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-nano/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5-nano",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5-nano", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5-nano \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-5-nano/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5-nano/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5 Nano"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5-nano`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5-nano` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT 5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-5`, served by Comfy Router from OpenAI.
+Use `openai/gpt-5` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT Image 1.5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-image-1.5`, served by Comfy Router from OpenAI.
+Use `openai/gpt-image-1.5` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-image-1.5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-image-1.5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-image-1.5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-image-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT Image 1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-image-1`, served by Comfy Router from OpenAI.
+Use `openai/gpt-image-1` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/gpt-image-1/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-image-1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-image-1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-image-1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-image-2/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/gpt-image-2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/gpt-image-2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/gpt-image-2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/gpt-image-2/code.mdx
+++ b/development/comfy-router/models/openai/gpt-image-2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "GPT Image 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/gpt-image-2`, served by Comfy Router from OpenAI.
+Use `openai/gpt-image-2` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o1-pro/code.mdx
+++ b/development/comfy-router/models/openai/o1-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/o1-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/o1-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/o1-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/o1-pro/code.mdx
+++ b/development/comfy-router/models/openai/o1-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "o1-pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/o1-pro`, served by Comfy Router from OpenAI.
+Use `openai/o1-pro` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o1/code.mdx
+++ b/development/comfy-router/models/openai/o1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/o1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/o1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/o1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/o1/code.mdx
+++ b/development/comfy-router/models/openai/o1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "o1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/o1`, served by Comfy Router from OpenAI.
+Use `openai/o1` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o3/code.mdx
+++ b/development/comfy-router/models/openai/o3/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "o3"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/o3`, served by Comfy Router from OpenAI.
+Use `openai/o3` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/openai/o3/code.mdx
+++ b/development/comfy-router/models/openai/o3/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/o3",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/o3", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/o3 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/o4-mini/code.mdx
+++ b/development/comfy-router/models/openai/o4-mini/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "openai/o4-mini",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("openai/o4-mini", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/openai/o4-mini \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/openai/o4-mini/code.mdx
+++ b/development/comfy-router/models/openai/o4-mini/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "o4-mini"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `openai/o4-mini`, served by Comfy Router from OpenAI.
+Use `openai/o4-mini` with the Comfy Router API. OpenAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "qwen/qwen-image-3.0-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("qwen/qwen-image-3.0-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/qwen/qwen-image-3.0-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Qwen Image 3.0 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `qwen/qwen-image-3.0-pro`, served by Comfy Router from Qwen.
+Use `qwen/qwen-image-3.0-pro` with the Comfy Router API. Qwen provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Qwen Image 3.0"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `qwen/qwen-image-3.0`, served by Comfy Router from Qwen.
+Use `qwen/qwen-image-3.0` with the Comfy Router API. Qwen provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
+++ b/development/comfy-router/models/qwen/qwen-image-3-0/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "qwen/qwen-image-3.0",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("qwen/qwen-image-3.0", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/qwen/qwen-image-3.0 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv2/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv2/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv2`, served by Comfy Router from Recraft.
+Use `recraft/recraftv2` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv3/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv3/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V3"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv3`, served by Comfy Router from Recraft.
+Use `recraft/recraftv3` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv3/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv3/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv3",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv3", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv3 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Pro Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_pro_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_pro_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_pro_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_pro_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_pro`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_pro` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Utility Pro Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_utility_pro_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_utility_pro_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_utility_pro_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_utility_pro_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_utility_pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_utility_pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Utility Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_utility_pro`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_utility_pro` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Utility Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_utility_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_utility_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_utility_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_utility_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_utility",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_utility", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Utility"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_utility`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_utility` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1 Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_1",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_1", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_1 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-1/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4.1"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_1`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_1` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4 Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_pro`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_pro` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_styles_pro_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_styles_pro_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4 Styles Pro Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_styles_pro_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_styles_pro_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4 Styles Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_styles_pro`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_styles_pro` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_styles_pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_styles_pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4 Styles Vector"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_styles_vector`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_styles_vector` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_styles_vector",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_styles_vector", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_vector \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4 Styles"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4_styles`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4_styles` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4_styles",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4_styles", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4_styles \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/recraft/recraftv4/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Recraft V4"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `recraft/recraftv4`, served by Comfy Router from Recraft.
+Use `recraft/recraftv4` with the Comfy Router API. Recraft provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/recraft/recraftv4/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "recraft/recraftv4",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("recraft/recraftv4", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/recraft/recraftv4 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/runway/aleph2/code.mdx
+++ b/development/comfy-router/models/runway/aleph2/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Aleph 2"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `runway/aleph2`, served by Comfy Router from Runway.
+Use `runway/aleph2` with the Comfy Router API. Runway provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/aleph2/code.mdx
+++ b/development/comfy-router/models/runway/aleph2/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "runway/aleph2",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("runway/aleph2", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/runway/aleph2 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/runway/gen4-image/code.mdx
+++ b/development/comfy-router/models/runway/gen4-image/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "runway/gen4_image",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("runway/gen4_image", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/runway/gen4_image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/runway/gen4-image/code.mdx
+++ b/development/comfy-router/models/runway/gen4-image/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gen 4 Image"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `runway/gen4_image`, served by Comfy Router from Runway.
+Use `runway/gen4_image` with the Comfy Router API. Runway provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/gen4-turbo/code.mdx
+++ b/development/comfy-router/models/runway/gen4-turbo/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Gen 4 Turbo"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `runway/gen4_turbo`, served by Comfy Router from Runway.
+Use `runway/gen4_turbo` with the Comfy Router API. Runway provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/runway/gen4-turbo/code.mdx
+++ b/development/comfy-router/models/runway/gen4-turbo/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "runway/gen4_turbo",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("runway/gen4_turbo", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/runway/gen4_turbo \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 2.0 Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-2.0-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-2.0-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-2-0-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-2.0-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-2.0-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-2.0-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 3.0 Fast Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-3.0-fast-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-3.0-fast-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-fast-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-3.0-fast-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-3.0-fast-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-3.0-fast-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 3.0 Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-3.0-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-3.0-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-0-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-3.0-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-3.0-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-3.0-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 3.1 Fast Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-3.1-fast-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-3.1-fast-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-fast-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-3.1-fast-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-3.1-fast-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-3.1-fast-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-3.1-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-3.1-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-3.1-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 3.1 Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-3.1-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-3.1-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "veo/veo-3.1-lite-generate-001",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("veo/veo-3.1-lite-generate-001", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/veo/veo-3.1-lite-generate-001 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
+++ b/development/comfy-router/models/veo/veo-3-1-lite-generate-001/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Veo 3.1 Lite Generate 001"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `veo/veo-3.1-lite-generate-001`, served by Comfy Router from Veo.
+Use `veo/veo-3.1-lite-generate-001` with the Comfy Router API. Veo provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.0-i2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.0-i2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-i2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.0 I2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-i2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.0-i2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.0-r2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.0-r2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-r2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.0 R2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-r2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.0-r2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.0-t2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.0-t2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-t2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.0 T2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-t2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.0-t2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.0-video-edit",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.0-video-edit", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-video-edit \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.0 Video Edit"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-video-edit`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.0-video-edit` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.1 I2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-i2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.1-i2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.1-i2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.1-i2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-i2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.1 R2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-r2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.1-r2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.1-r2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.1-r2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-r2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/happyhorse-1.1-t2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/happyhorse-1.1-t2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-t2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Happyhorse 1.1 T2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-t2v`, served by Comfy Router from Wan.
+Use `wan/happyhorse-1.1-t2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.5-i2i-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.5-i2i-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.5-i2i-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2i-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.5 I2I Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-i2i-preview`, served by Comfy Router from Wan.
+Use `wan/wan2.5-i2i-preview` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.5-i2v-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.5-i2v-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.5-i2v-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.5 I2V Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-i2v-preview`, served by Comfy Router from Wan.
+Use `wan/wan2.5-i2v-preview` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.5-t2i-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.5-t2i-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.5-t2i-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2i-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.5 T2I Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-t2i-preview`, served by Comfy Router from Wan.
+Use `wan/wan2.5-t2i-preview` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.5-t2v-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.5-t2v-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.5-t2v-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.5 T2V Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-t2v-preview`, served by Comfy Router from Wan.
+Use `wan/wan2.5-t2v-preview` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.6 I2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-i2v`, served by Comfy Router from Wan.
+Use `wan/wan2.6-i2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.6-i2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.6-i2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.6-i2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.6-r2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.6-r2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.6-r2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.6 R2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-r2v`, served by Comfy Router from Wan.
+Use `wan/wan2.6-r2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.6-t2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.6-t2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.6-t2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.6 T2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-t2v`, served by Comfy Router from Wan.
+Use `wan/wan2.6-t2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.7 I2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-i2v`, served by Comfy Router from Wan.
+Use `wan/wan2.7-i2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.7-i2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.7-i2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.7-i2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.7 R2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-r2v`, served by Comfy Router from Wan.
+Use `wan/wan2.7-r2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.7-r2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.7-r2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.7-r2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.7-t2v",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.7-t2v", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.7-t2v \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.7 T2V"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-t2v`, served by Comfy Router from Wan.
+Use `wan/wan2.7-t2v` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan2.7-videoedit",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan2.7-videoedit", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan2.7-videoedit \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 2.7 Video Edit"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-videoedit`, served by Comfy Router from Wan.
+Use `wan/wan2.7-videoedit` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 3.0 Video Prime"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan3.0-video-prime`, served by Comfy Router from Wan.
+Use `wan/wan3.0-video-prime` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan3.0-video-prime",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan3.0-video-prime", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan3.0-video-prime \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan3-0-video/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "wan/wan3.0-video",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("wan/wan3.0-video", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/wan/wan3.0-video \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/wan/wan3-0-video/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 3.0 Video"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan3.0-video`, served by Comfy Router from Wan.
+Use `wan/wan3.0-video` with the Comfy Router API. Wan provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-image-2.0",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-image-2.0", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-image-2.0 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-2-0/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Image 2.0"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-image-2.0`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-image-2.0` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Image Pro"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-image-pro`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-image-pro` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-pro/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-image-pro",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-image-pro", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-image-pro \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-image-quality",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-image-quality", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-image-quality \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image-quality/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Image Quality"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-image-quality`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-image-quality` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Image"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-image`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-image` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-image/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-image/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-image",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-image", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-image \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-video-1.5-preview",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-video-1.5-preview", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-video-1.5-preview \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5-preview/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Video 1.5 Preview"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-video-1.5-preview`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-video-1.5-preview` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Video 1.5"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-video-1.5`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-video-1.5` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video-1-5/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-video-1.5",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-video-1.5", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-video-1.5 \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/development/comfy-router/models/xai/grok-imagine-video/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Grok Imagine Video"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `xai/grok-imagine-video`, served by Comfy Router from xAI.
+Use `xai/grok-imagine-video` with the Comfy Router API. xAI provides the model; Router gives it the shared authentication and request route below.
 
 ## Quick start
 

--- a/development/comfy-router/models/xai/grok-imagine-video/code.mdx
+++ b/development/comfy-router/models/xai/grok-imagine-video/code.mdx
@@ -20,16 +20,19 @@ Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org
 
 <CodeGroup>
 ```python Python
+import uuid
 from comfy_sdk import Comfy
 
-# Reads COMFY_API_KEY from the environment. Each call sends a fresh
-# Idempotency-Key and waits up to 10 minutes for the finished result.
+# Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+# retry this request after the SDK returns an error.
+idempotency_key = str(uuid.uuid4())
 with Comfy() as client:
     result = client.models.run(
         "xai/grok-imagine-video",
         {
             # Request fields are the provider's own — see Input below.
         },
+        idempotency_key=idempotency_key,
     )
 
 print(result)
@@ -38,20 +41,23 @@ print(result)
 ```typescript TypeScript
 import { comfy } from "@comfyorg/sdk";
 
-// Reads COMFY_API_KEY from the environment. Each call sends a fresh
-// Idempotency-Key and waits up to 10 minutes for the finished result.
+// Reads COMFY_API_KEY from the environment. Save this key and reuse it if you
+// retry this request after the SDK returns an error.
+const idempotencyKey = crypto.randomUUID();
 const { data } = await comfy.models.run("xai/grok-imagine-video", {
   // Request fields are the provider's own — see Input below.
-});
+}, { idempotencyKey });
 
 console.log(data);
 ```
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
+# Run this line once. Reuse ROUTER_REQUEST_KEY if you retry the curl command.
+ROUTER_REQUEST_KEY=$(uuidgen)
 curl https://api.comfy.org/v2/models/xai/grok-imagine-video \
   -H "X-API-Key: $COMFY_API_KEY" \
-  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Idempotency-Key: $ROUTER_REQUEST_KEY" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```

--- a/snippets/comfy-router/model-code-footer.mdx
+++ b/snippets/comfy-router/model-code-footer.mdx
@@ -1,13 +1,15 @@
 ## Before you ship
 
-The snippets above are the shortest working call. Three things are the same for every model and are documented once on the [Comfy Router headers](/development/comfy-router/headers) page: send an `Idempotency-Key` on every paid call and reuse it when you retry, expect the connection to be held up to Router's 10 minute deadline, and keep `X-Comfy-Request-Id` from every response. The SDKs do all three for you; the cURL tab does none of them. On failure, `X-Comfy-Error-Type` names the bucket, and a `422` means the body failed the model's schema and was never billed.
+Keep one `Idempotency-Key` for each logical call and reuse it for retries. The SDKs generate a key for a call and reuse it for their internal retries; pass and store your own key if you need to retry after the SDK returns an error. Router's default server deadline is 10 minutes, so allow more time on the client. A timeout does not by itself tell you whether a generation was billed. See [using the Router API](/development/comfy-router/models#retry-outcomes) before adding retries.
+
+Save the request ID when troubleshooting: Python SDK errors expose `request_id`, and TypeScript results and errors expose `requestId`. The cURL example saves response headers in `router-headers.txt`. Download generated assets promptly; [result URLs can expire](/development/comfy-router/reference#result-assets), including URLs returned by a replay.
 
 <CardGroup cols={3}>
   <Card title="Headers" icon="list" href="/development/comfy-router/headers">
     Authentication, idempotency, request IDs, error buckets, retry pacing, spend limits.
   </Card>
-  <Card title="Quick Start" icon="rocket" href="/development/comfy-router/quickstart">
-    Typed error handling in Python and TypeScript, reading the 422, walking the catalog.
+  <Card title="Using the Router API" icon="code" href="/development/comfy-router/models">
+    Find models, inspect schemas, and handle retries.
   </Card>
   <Card title="Limitations" icon="triangle-exclamation" href="/development/comfy-router/limitations">
     What Router does not do today, and what to use instead.

--- a/snippets/comfy-router/model-code-footer.mdx
+++ b/snippets/comfy-router/model-code-footer.mdx
@@ -1,15 +1,15 @@
 ## Before you ship
 
-Keep one `Idempotency-Key` for each logical call and reuse it for retries. The SDKs generate a key for a call and reuse it for their internal retries; pass and store your own key if you need to retry after the SDK returns an error. Router's default server deadline is 10 minutes, so allow more time on the client. A timeout does not by itself tell you whether a generation was billed. See [using the Router API](/development/comfy-router/models#retry-outcomes) before adding retries.
+Save one `Idempotency-Key` for each call and reuse it for retries. Router can hold the connection for up to 10 minutes. The SDKs handle authentication; raw HTTP clients send the headers themselves.
 
-Save the request ID when troubleshooting: Python SDK errors expose `request_id`, and TypeScript results and errors expose `requestId`. The cURL example saves response headers in `router-headers.txt`. Download generated assets promptly; [result URLs can expire](/development/comfy-router/reference#result-assets), including URLs returned by a replay.
+Use `X-Comfy-Error-Type` to classify a failure. A `422` means Router rejected the input before calling the provider. Download generated assets promptly because [result URLs can expire](/development/comfy-router/reference#result-assets).
 
 <CardGroup cols={3}>
   <Card title="Headers" icon="list" href="/development/comfy-router/headers">
     Authentication, idempotency, request IDs, error buckets, retry pacing, spend limits.
   </Card>
   <Card title="Using the Router API" icon="code" href="/development/comfy-router/models">
-    Find models, inspect schemas, and handle retries.
+    Find models, inspect schemas, and retry safely.
   </Card>
   <Card title="Limitations" icon="triangle-exclamation" href="/development/comfy-router/limitations">
     What Router does not do today, and what to use instead.


### PR DESCRIPTION
Makes the generated Comfy Router model pages easier to scan and use. The generator now introduces each model as a Router call, the shared footer points to practical follow-on guidance, and Nano Banana 2 has a concrete summary.\n\nValidated with `bun run code-pages:gen` and `bun run code-pages:check`.