### PR TITLE
docs: add v0.34.4 and v0.34.5 changelog

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -819,6 +819,48 @@
         "zh"
       ],
       "published_at": "2026-09-03T10:12:48.455Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.34.4",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-05T03:58:58.825Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.34.4",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-05T03:57:56.662Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.34.5",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-05T03:58:03.365Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Partner Node Updates**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Added Muse Image 1.0 support
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Added Recraft V4 Styles Pro
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): Added H3 Max Turbo model support
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Added Claude Fable 5.1
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Fixed Tripo output formats, pricing, and parameters
+
+</Update>
+
 <Update label="v0.34.3" description="September 2, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="4 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Se añadió soporte para Muse Image 1.0
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Se añadió Recraft V4 Styles Pro
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): Se añadió soporte para el modelo H3 Max Turbo
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Se añadió Claude Fable 5.1
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Se corrigieron formatos de salida, precios y parámetros de Tripo
+
+</Update>
+
 <Update label="v0.34.3" description="2 de septiembre de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Ajout de la prise en charge de Muse Image 1.0
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Ajout de Recraft V4 Styles Pro
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): Ajout de la prise en charge du modèle H3 Max Turbo
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Ajout de Claude Fable 5.1
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Correction des formats de sortie, des tarifs et des paramètres Tripo
+
+</Update>
+
 <Update label="v0.34.3" description="2 septembre 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="2026年9月4日">
+
+**パートナーノードの更新**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Muse Image 1.0 のサポートを追加
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Recraft V4 Styles Pro を追加
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): H3 Max Turbo モデルのサポートを追加
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Claude Fable 5.1 を追加
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripo の出力形式、料金、パラメーターを修正
+
+</Update>
+
 <Update label="v0.34.3" description="2026年9月2日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="2026년 9월 4일">
+
+**파트너 노드 업데이트**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Muse Image 1.0 지원 추가
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Recraft V4 Styles Pro 추가
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): H3 Max Turbo 모델 지원 추가
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Claude Fable 5.1 추가
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripo 출력 형식, 가격, 매개변수를 수정했습니다
+
+</Update>
+
 <Update label="v0.34.3" description="2026년 9월 2일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Обновления партнёрских узлов**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i): Добавлена поддержка Muse Image 1.0
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style): Добавлен Recraft V4 Styles Pro
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v): Добавлена поддержка модели H3 Max Turbo
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1): Добавлен Claude Fable 5.1
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Исправлены форматы вывода, цены и параметры Tripo
+
+</Update>
+
 <Update label="v0.34.3" description="2 сентября 2026">
 
 **Обновления партнёрских узлов**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,17 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.4" description="2026年9月4日">
+
+**合作伙伴节点更新**
+* [**Meta Muse Image**](https://cloud.comfy.org/?template=api_meta_muse_image_t2i)：新增 Muse Image 1.0 支持
+* [**Recraft V4 Styles Pro**](https://cloud.comfy.org/?template=template-recraft_create_style)：新增 Recraft V4 Styles Pro
+* [**MiniMax H3 Max Turbo**](https://cloud.comfy.org/?template=api_minimax_h3_max_turbo_i2v)：新增 H3 Max Turbo 模型支持
+* [**Claude Fable 5.1**](https://cloud.comfy.org/?template=api_anthropic_claude_fable5_1)：新增 Claude Fable 5.1
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060)：修复了 Tripo 的输出格式、定价和参数
+
+</Update>
+
 <Update label="v0.34.3" description="2026年9月2日">
 
 **合作伙伴节点更新**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="September 5, 2026">
+
+**Partner Node Updates**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Beta nodes run curated Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3, and Music 3 workflows on Cloud GPUs.
+
+</Update>
+
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Partner Node Updates**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Adds Muse Image 1.0 text-to-image and edit nodes with up to 10 reference images.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Adds Recraft V4 Styles Pro and Pro vector models to the Create Style node.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): Adds H3 Max Turbo to MiniMax H3 text-to-video and first-last-frame nodes.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): Adds Claude Fable 5.1 and xhigh/max reasoning on supported Claude models.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Fixes real FBX/GLB outputs, exact pricing, and missing parameters on Tripo nodes.
+
+</Update>
+
 <Update label="v0.34.3" description="September 2, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="5 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Los nodos beta ejecutan flujos de trabajo seleccionados de Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3 y Music 3 en GPU de la nube.
+
+</Update>
+
+<Update label="v0.34.4" description="4 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Añade nodos de texto a imagen y edición de Muse Image 1.0 con hasta 10 imágenes de referencia.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Añade Recraft V4 Styles Pro y los modelos vectoriales Pro al nodo Create Style.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): Añade H3 Max Turbo a los nodos de texto a video y de primer y último fotograma de MiniMax H3.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): Añade Claude Fable 5.1 y el razonamiento xhigh/max en los modelos Claude compatibles.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Corrige las salidas reales FBX/GLB, los precios exactos y los parámetros faltantes de los nodos Tripo.
+
+</Update>
+
 <Update label="v0.34.3" description="2 de septiembre de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="5 septembre 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935) : les nœuds bêta exécutent des workflows sélectionnés de Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3 et Music 3 sur des GPU cloud.
+
+</Update>
+
+<Update label="v0.34.4" description="4 septembre 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078) : ajoute les nœuds texte-vers-image et d'édition Muse Image 1.0 avec jusqu'à 10 images de référence.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043) : ajoute Recraft V4 Styles Pro et les modèles vectoriels Pro au nœud Create Style.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094) : ajoute H3 Max Turbo aux nœuds texte-vers-vidéo et de première/dernière image de MiniMax H3.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085) : ajoute Claude Fable 5.1 et le raisonnement xhigh/max sur les modèles Claude pris en charge.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060) : corrige les sorties FBX/GLB, la tarification exacte et les paramètres manquants des nœuds Tripo.
+
+</Update>
+
 <Update label="v0.34.3" description="2 septembre 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="2026年9月5日">
+
+**パートナーノードの更新**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): ベータノードは、クラウドGPU上でFlux 2、Z-Image Turbo、Mage Flow、MiniMax H3、およびMusic 3の厳選されたワークフローを実行します。
+
+</Update>
+
+<Update label="v0.34.4" description="2026年9月4日">
+
+**パートナーノードの更新**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Muse Image 1.0 のテキストから画像への生成ノードと、最大10枚の参照画像を使用できる編集ノードを追加。
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Create Style ノードに Recraft V4 Styles Pro と Pro ベクターモデルを追加。
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): MiniMax H3 のテキストから動画への生成ノードと最初／最後のフレームノードに H3 Max Turbo を追加。
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): Claude Fable 5.1 と、対応する Claude モデルでの xhigh/max 推論を追加。
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripoノードの実際のFBX/GLB出力、正確な料金、不足していたパラメーターを修正。
+
+</Update>
+
 <Update label="v0.34.3" description="2026年9月2日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="2026년 9월 5일">
+
+**파트너 노드 업데이트**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): 베타 노드는 선별된 Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3 및 Music 3 워크플로를 클라우드 GPU에서 실행합니다.
+
+</Update>
+
+<Update label="v0.34.4" description="2026년 9월 4일">
+
+**파트너 노드 업데이트**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Muse Image 1.0 텍스트 기반 이미지 생성 및 편집 노드를 추가하며, 참조 이미지를 최대 10개까지 지원합니다.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Create Style 노드에 Recraft V4 Styles Pro 및 Pro 벡터 모델을 추가합니다.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): MiniMax H3 텍스트 기반 비디오 생성 및 첫 번째/마지막 프레임 노드에 H3 Max Turbo를 추가합니다.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): 지원되는 Claude 모델에 Claude Fable 5.1 및 xhigh/max 추론을 추가합니다.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripo 노드의 실제 FBX/GLB 출력, 정확한 가격, 누락된 매개변수를 수정합니다.
+
+</Update>
+
 <Update label="v0.34.3" description="2026년 9월 2일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="September 5, 2026">
+
+**Обновления партнерских узлов**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Бета-узлы запускают курируемые воркфлоу Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3 и Music 3 на облачных GPU.
+
+</Update>
+
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Обновления партнёрских узлов**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Добавляет узлы генерации изображений по тексту и редактирования Muse Image 1.0 с поддержкой до 10 референсных изображений.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Добавляет модели Recraft V4 Styles Pro и Pro vector в узел Create Style.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): Добавляет H3 Max Turbo в узлы MiniMax H3 для генерации видео по тексту и по первому и последнему кадру.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): Добавляет Claude Fable 5.1 и поддержку рассуждений xhigh/max на поддерживаемых моделях Claude.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Исправляет реальные выходы FBX/GLB, точные цены и недостающие параметры узлов Tripo.
+
+</Update>
+
 <Update label="v0.34.3" description="2 сентября 2026">
 
 **Обновления партнёрских узлов**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,24 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.34.5" description="2026年9月5日">
+
+**合作伙伴节点更新**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935)：测试版节点可在云端 GPU 上运行精选的 Flux 2、Z-Image Turbo、Mage Flow、MiniMax H3 和 Music 3 工作流。
+
+</Update>
+
+<Update label="v0.34.4" description="2026年9月4日">
+
+**合作伙伴节点更新**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078)：新增 Muse Image 1.0 文生图和编辑节点，最多支持 10 张参考图像。
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043)：为“创建样式”节点新增 Recraft V4 Styles Pro 和 Pro 矢量模型。
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094)：为 MiniMax H3 文生视频及首尾帧节点新增 H3 Max Turbo 支持。
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085)：新增 Claude Fable 5.1，并为受支持的 Claude 模型提供 xhigh/max 推理能力。
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060)：修复了 Tripo 节点的真实 FBX/GLB 输出、精确定价和缺失参数。
+
+</Update>
+
 <Update label="v0.34.3" description="2026年9月2日">
 
 **合作伙伴节点更新**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,24 @@ description: "ComfyUI changelog: the latest features, improvements, and bug fixe
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.34.5" description="September 5, 2026">
+
+**Partner Node Updates**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Added beta nodes that run curated Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3, and Music 3 workflows on Comfy Cloud GPUs
+
+</Update>
+
+<Update label="v0.34.4" description="September 4, 2026">
+
+**Partner Node Updates**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Added Muse Image 1.0 text-to-image and edit nodes with up to 10 reference images
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Added `recraftv4_styles_pro` and `recraftv4_styles_pro_vector` to the Create Style node
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): Added the H3 Max Turbo model option to MiniMax H3 text-to-video and first-last-frame nodes
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): Added Claude Fable 5.1 and xhigh/max reasoning levels on supported Claude models
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Fixed real FBX/GLB outputs, exact pricing, and missing parameters on Tripo nodes
+
+</Update>
+
 <Update label="v0.34.3" description="September 2, 2026">
 
 **Partner Node Updates**

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "変更履歴"
 description: "ComfyUI の変更ログ：各リリースの最新機能、改善点、バグ修正を、新バージョンのリリースに合わせて更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 2be39ac3
+translationSourceHash: 451e9d44
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.5": 599d1216
+  "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
@@ -124,6 +126,24 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.5" description="2026年9月5日">
+
+**パートナーノードの更新**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Comfy Cloud の GPU 上で、精選された Flux 2、Z-Image Turbo、Mage Flow、MiniMax H3、Music 3 のワークフローを実行するベータノードを追加しました。
+
+</Update>
+
+<Update label="v0.34.4" description="2026年9月4日">
+
+**パートナーノードの更新**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): Muse Image 1.0 のテキストから画像への変換ノードと編集ノードを追加しました(参照画像は最大10枚まで)
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Create Style ノードに `recraftv4_styles_pro` と `recraftv4_styles_pro_vector` を追加しました
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): MiniMax H3 のテキストから動画への変換ノードと最初・最後のフレームノードに H3 Max Turbo モデルオプションを追加しました
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): サポート対象の Claude モデルに Claude Fable 5.1 と xhigh/max の推論レベルを追加しました
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripo ノードの実際の FBX/GLB 出力、正確な料金、不足していたパラメーターを修正しました
+
+</Update>
 
 <Update label="v0.34.3" description="2026年9月2日">
 

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "변경 로그"
 description: "ComfyUI 변경 로그: 각 릴리스의 최신 기능, 개선 사항, 버그 수정을 새 버전 출시에 맞춰 업데이트합니다."
 icon: "clock-rotate-left"
-translationSourceHash: 2be39ac3
+translationSourceHash: 451e9d44
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.5": 599d1216
+  "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
@@ -124,6 +126,24 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.5" description="2026년 9월 5일">
+
+**파트너 노드 업데이트**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Comfy Cloud GPU에서 선별된 FLUX 2, Z-Image Turbo, Mage Flow, MiniMax H3, Music 3 워크플로를 실행하는 베타 노드를 추가했습니다
+
+</Update>
+
+<Update label="v0.34.4" description="2026년 9월 4일">
+
+**파트너 노드 업데이트**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078): 최대 10개의 참조 이미지를 지원하는 Muse Image 1.0 텍스트 기반 이미지 생성 및 편집 노드를 추가했습니다.
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043): Create Style 노드에 `recraftv4_styles_pro` 및 `recraftv4_styles_pro_vector`를 추가했습니다.
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094): MiniMax H3 텍스트 기반 비디오 생성 노드와 first-last-frame 노드에 H3 Max Turbo 모델 옵션을 추가했습니다.
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085): 지원되는 Claude 모델에 Claude Fable 5.1과 xhigh/max 추론 수준을 추가했습니다.
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060): Tripo 노드의 실제 FBX/GLB 출력, 정확한 가격, 누락된 매개변수를 수정했습니다.
+
+</Update>
 
 <Update label="v0.34.3" description="2026년 9월 2일">
 

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,9 +2,11 @@
 title: "更新日志"
 description: "ComfyUI 变更日志：每个版本的最新功能、改进和错误修复，随新版本发布持续更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 2be39ac3
+translationSourceHash: 451e9d44
 translationFrom: changelog/index.mdx
 translationBlockHashes:
+  "v0.34.5": 599d1216
+  "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
   "v0.34.1": f6bfdd8e
@@ -124,6 +126,24 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.34.5" description="2026年9月5日">
+
+**合作伙伴节点更新**
+* [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935)：新增了测试版节点，可在 Comfy Cloud GPU 上运行精选的 Flux 2、Z-Image Turbo、Mage Flow、MiniMax H3 和 Music 3 工作流
+
+</Update>
+
+<Update label="v0.34.4" description="2026年9月4日">
+
+**合作伙伴节点更新**
+* [**Meta Muse Image**](https://github.com/Comfy-Org/ComfyUI/pull/16078)：添加了 Muse Image 1.0 文生图和编辑节点，最多支持 10 张参考图像
+* [**Recraft V4 Styles Pro**](https://github.com/Comfy-Org/ComfyUI/pull/16043)：在创建样式节点中添加了 `recraftv4_styles_pro` 和 `recraftv4_styles_pro_vector`
+* [**MiniMax H3 Max Turbo**](https://github.com/Comfy-Org/ComfyUI/pull/16094)：为 MiniMax H3 文生视频和首尾帧节点添加了 H3 Max Turbo 模型选项
+* [**Claude Fable 5.1**](https://github.com/Comfy-Org/ComfyUI/pull/16085)：添加了 Claude Fable 5.1，并为支持的 Claude 模型添加了 xhigh/max 推理等级
+* [**Tripo**](https://github.com/Comfy-Org/ComfyUI/pull/16060)：修复了 Tripo 节点的真实 FBX/GLB 输出、精确定价和缺失参数
+
+</Update>
 
 <Update label="v0.34.3" description="2026年9月2日">
 


### PR DESCRIPTION
## Summary
- Add docs changelog for ComfyUI v0.34.4 (Muse Image, Recraft Styles Pro, H3 Max Turbo, Claude Fable 5.1, Tripo fixes) and v0.34.5 (Comfy Cloud partner nodes), with zh/ja/ko.
- Publish CMS popup notes: ComfyUI v0.34.4 and v0.34.5, Cloud v0.34.4 only. Refresh `published-versions.json`.

## Test plan
- [ ] Docs changelog renders v0.34.5 then v0.34.4 on en/zh/ja/ko
- [ ] In-app ComfyUI popup shows both versions
- [ ] Cloud popup shows v0.34.4 only (no v0.34.5)