### PR TITLE
docs(comfy-router): drop the wrong global fhd resolution default for FLUX 3 Video

### DIFF
--- a/development/comfy-router/models/black-forest-labs/flux-3-video/code.yaml
+++ b/development/comfy-router/models/black-forest-labs/flux-3-video/code.yaml
@@ -73,11 +73,12 @@ input:
       default: auto
     resolution:
       type: string
-      description: '`fhd` (default) is finished by the video upsampler; `hd` is faster.'
+      description: >-
+        Video resolution class. `hd` is the default for `t2v`, `i2v` and `v2v`; `fhd` finishes the
+        result with the video upsampler and is the default for `draft_enhance`.
       enum:
       - hd
       - fhd
-      default: fhd
     generate_audio:
       type: boolean
       description: Generate synchronized audio alongside the video.


### PR DESCRIPTION
## ELI-5

The FLUX 3 Video spec file said "`resolution` defaults to `fhd`". That is only true for one of the model's four modes. BFL actually defaults `resolution` to `hd` for `t2v`, `i2v` and `v2v`, and to `fhd` only for `draft_enhance`. This removes the single wrong global default and states both per-mode defaults in the field description instead.

## What changed

`development/comfy-router/models/black-forest-labs/flux-3-video/code.yaml` — the `input.properties.resolution` block loses its `default: fhd` key and gains a description naming both per-mode defaults. Three lines, one file. `pnpm code-pages:gen` was re-run; it produced no change to `code.mdx` (see Residual for why).

## Why the key is removed rather than set to `hd`

`.github/scripts/snippets/check-provider-schemas.ts` normalises the provider's `oneOf` by merging every alternative's properties with `Object.assign` (last wins). BFL's `Flux3VideoInputsBody` lists its four mode schemas with `Flux3VideoDraftEnhanceInputs` last, so the single collapsed `resolution.default` the checker compares against is `"fhd"`. Documenting `hd` would therefore trip the mismatch error and fail the `provider-schemas` CI job; documenting no default takes the warning branch instead, which does not fail CI. A per-mode default is not expressible in the flat shape this file uses at all, so the description is the only honest place for it.

## Verification

Evidence re-derived first-hand from BFL's live spec (`https://api.bfl.ai/openapi.json`) rather than taken on trust:

- `Flux3VideoT2VInputs`, `Flux3VideoI2VInputs`, `Flux3VideoV2VInputs` → `resolution.default: "hd"`; `Flux3VideoDraftEnhanceInputs` → `resolution.default: "fhd"`. Confirmed, all four.
- `Flux3VideoInputsBody.oneOf` order is `[T2V, I2V, V2V, DraftEnhance]`, so the checker's last-wins collapse does yield `"fhd"`. Confirmed — the reason the `hd` spelling would fail CI is real, not assumed.
- `bun run code-pages:check` → `157 code page(s) fresh (9 curated, 148 derived)`, exit 0.
- `bun run code-pages:check-providers --verbose` → `14 model(s) checked, 0 skipped, 0 error(s)`. Diffed the full warning list before vs. after: exactly one line added, `black-forest-labs/flux-3-video (bfl/flux-3-video) input: 'resolution' provider default "fhd" is not documented` (269 → 270 warnings). Nothing else in the report moved.

## Corpus sweep

Two sweeps, so the portion not being fixed is a number rather than a guess.

- Every `fhd` mention in the repo outside `router-schemas/`: three, all in this model's directory. The hand-authored `code.yaml` (fixed here), the generated `code.mdx`, and nothing else. The partner-node prose page and its `ja`/`ko`/`zh` mirrors do not mention `resolution` at all, so there is no stale prose to follow up.
- The bug class — a documented flat `default` sitting in front of a provider request body that is a discriminated union, where the checker's last-wins collapse can hide a per-variant disagreement: of the 14 provider-spec'd model variants, 7 name an OpenAPI operation and 7 are Google discovery documents naming a single flat `GenerateContentRequest` (no root union, so structurally immune). Of the 7 operation-based ones, **1** sits behind a union — this model. 1 of 1 fixed; 0 left in that class.

## Residual

**The rendered page still shows `default="hd"`, and this change does not move it.** The acceptance target was that the regenerated `code.mdx` `<ParamField body="resolution">` would lose its `default=` attribute and pick up the new per-mode wording. That is no longer reachable from this file. `gen-code-pages.ts` renders a curated page's Input section from `router-schemas/<provider>/<model>.json` whenever that document exists and is authored, falling back to `code.yaml`'s hand-written `input:` only otherwise — and `router-schemas/bfl/flux-3-video.json` now exists with `x-comfy-input-schema-authored: true`, carrying its own `resolution: {default: "hd", description: "Video resolution class: hd, or fhd for a higher-resolution result finished by the video upsampler..."}`. So `pnpm code-pages:gen` is a genuine no-op for `code.mdx` here, and `code.yaml`'s `input:` block is now the documented fallback and the artifact the `provider-schemas` job reads, not the page source. Fixing what the page actually shows means fixing the Router contract's own `resolution.default` upstream (the `services/comfy-api` OpenAPI document that the spec-sync bot mirrors into `router-schemas/`), where the same flat-`hd`-for-all-modes claim is wrong for `draft_enhance` in the mirror image of the way this file was wrong for the other three. That is a separate change in a separate repo and is not attempted here; `router-schemas/` is bot-synced and must not be hand-edited.

**Unexercised:** the upstream investigation notes this work was written from were not reachable from the environment that produced this PR. Rather than assume them, every factual claim they carried was re-derived independently against the live BFL spec and against the checker's own code — that re-derivation is the Verification section above, and it agreed with the notes on every point. No claim here rests on a document I could not read.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `bun run code-pages:check` → 157 pages fresh, exit 0; `bun run code-pages:check-providers --verbose` → 14 models checked, 0 errors, before/after warning diff = exactly the 1 expected added line; BFL live spec re-fetched and all four mode schemas plus the `oneOf` ordering confirmed by hand
- **Deviations:** the "regenerated `code.mdx` loses its `default=` attribute" criterion is not met and cannot be met from this file — see Residual
