### PR TITLE
Add Cloud Agent dev environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "ComfyUI Docs",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "mint-dev",
+      "command": "npm run dev"
+    }
+  ],
+  "ports": [{ "name": "docs dev server", "port": 3000 }]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cloud Agent install for the ComfyUI docs repo.
+# Idempotent: safe to run repeatedly against cached or partial state.
+
+cd "$(dirname "$0")/.."
+
+# Node dependencies for the Mintlify docs site (mint, sharp).
+npm ci
+
+# Bun toolchain for the i18n / CMS / analytics pipelines (translate, cms:*, analytics:*).
+# Skip the download when bun is already available.
+if ! command -v bun >/dev/null 2>&1; then
+  export BUN_INSTALL="$HOME/.bun"
+  curl -fsSL https://bun.sh/install | bash
+  # Expose bun on the default PATH for login and non-login shells.
+  sudo ln -sf "$HOME/.bun/bin/bun" /usr/local/bin/bun
+fi
+
+bun --version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment so this docs repo is usable out of the box.

- `.cursor/environment.json`: `install` runs the bootstrap script, a `mint-dev` terminal serves the docs on port 3000.
- `.cursor/install.sh`: idempotent bootstrap. `npm ci` for the Mintlify site (`mint`, `sharp`), plus the Bun toolchain required by the i18n / CMS / analytics pipelines (guarded so re-runs skip the download).

## Validation

- `npm ci` completes and is idempotent (second run reuses cache in ~8s).
- Mintlify dev server (`npm run dev`) serves docs on `localhost:3000` (home + several MDX pages return 200).
- Bun pipelines run end to end without secrets: `code-pages:check` (157 pages fresh) and `glossary:sync:dry-run` (~3000 terms/lang fetched from GitHub).
- The translate/cms/analytics API calls remain gated on secrets (`TRANSLATE_API_KEY`, `CMS_API_TOKEN`, `MINTLIFY_API_KEY`), documented in `.env.local.example`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e874e48-c404-4cce-8fed-57c5ea7dad4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e874e48-c404-4cce-8fed-57c5ea7dad4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

