### PR TITLE
fix(code-pages): report per-variant provider defaults instead of collapsing a oneOf last-wins

### DIFF
--- a/.github/scripts/snippets/README.md
+++ b/.github/scripts/snippets/README.md
@@ -100,6 +100,36 @@ we leave undocumented are warnings (`--strict` makes them errors, `omit:` lists
 the deliberate ones). It runs in CI as the `provider-schemas` job, so the
 fallback schemas are tested rather than trusted until Router publishes its own.
 
+### Per-variant defaults
+
+Some provider bodies are a `oneOf` of modes: BFL's FLUX 3 Video is `t2v`, `i2v`,
+`v2v` and `draft_enhance`, and the four modes disagree about `resolution` (`hd`
+in three of them, `fhd` in `draft_enhance`). Merging those alternatives into one
+shape used to take the last one's `default`, so the checker would have accepted a
+documented `default: fhd` and rejected a documented `default: hd`. Both are wrong:
+neither value is the default in every mode.
+
+The checker now records the disagreement as `defaultByVariant` instead of picking
+a winner, and reports it two ways:
+
+```text
+ERROR ... input: `resolution` documents a single default "fhd" but the provider default is per-variant
+      {"t2v":"hd","i2v":"hd","v2v":"hd","draft_enhance":"fhd"}; document the per-variant defaults in the
+      description and drop `default`
+warn  ... input: `resolution` provider default is per-variant
+      {"t2v":"hd","i2v":"hd","v2v":"hd","draft_enhance":"fhd"}; make sure the description says so
+```
+
+So a field like this carries no `default:` in the `code.yaml` and explains the
+per-mode values in its `description` instead, which is what the page renders. The
+variant keys come from the union's discriminator when the document declares one,
+and fall back to `#0`, `#1` when it does not. Everything else about the field
+(type, `enum`, bounds) is still checked as usual.
+
+`bun test ./.github/scripts/snippets/` covers this against a fixture, and runs in
+CI as the `snippet-script-tests` job. It needs no network, so it stays green when
+a provider's host is down.
+
 ## Adding a model
 
 1. Create `code.yaml` in the model's directory (copy the Kontext one).

--- a/.github/scripts/snippets/check-provider-schemas.test.ts
+++ b/.github/scripts/snippets/check-provider-schemas.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { normalizer, variantLabels, compare, type Report } from "./check-provider-schemas.ts";
+
+/**
+ * A miniature of BFL's `Flux3VideoInputsBody`: a discriminated `oneOf` whose four modes
+ * agree on `generate_audio` (true), disagree on `resolution` (`hd` in three, `fhd` in
+ * `draft_enhance`) and where only `draft_enhance` declares `draft_cache`.
+ */
+const BFL_DOC = {
+  openapi: "3.1.0",
+  components: {
+    schemas: {
+      Body: {
+        title: "Body",
+        discriminator: { propertyName: "mode" },
+        oneOf: [{ $ref: "#/components/schemas/T2V" }, { $ref: "#/components/schemas/I2V" }, { $ref: "#/components/schemas/V2V" }, { $ref: "#/components/schemas/DraftEnhance" }],
+      },
+      T2V: mode("t2v", { resolution: "hd" }, ["prompt", "mode"]),
+      I2V: mode("i2v", { resolution: "hd" }, ["prompt", "mode"]),
+      V2V: mode("v2v", { resolution: "hd" }, ["prompt", "mode"]),
+      DraftEnhance: { ...mode("draft_enhance", { resolution: "fhd" }, ["mode", "draft_cache"]), },
+    },
+  },
+} as any;
+
+function mode(name: string, overrides: Record<string, unknown>, required: string[]) {
+  const s: any = {
+    type: "object",
+    required,
+    properties: {
+      mode: { type: "string", const: name, title: "Mode" },
+      prompt: { type: "string" },
+      resolution: { type: "string", enum: ["hd", "fhd"], default: overrides.resolution },
+      generate_audio: { type: "boolean", default: true },
+      safety_tolerance: { type: "integer", minimum: 0, maximum: 4, default: 2 },
+    },
+  };
+  if (name === "draft_enhance") s.properties.draft_cache = { type: "string", default: "" };
+  return s;
+}
+
+const provider = () => normalizer(BFL_DOC).norm({ $ref: "#/components/schemas/Body" });
+const emptyReport = (): Report => ({ errors: [], warnings: [] });
+/**
+ * `compare` also warns about every provider field a fixture leaves undocumented, which is a
+ * different check; drop those so each assertion below reads only the messages it is about.
+ */
+const run = (ours: any, theirs: any = provider()) => {
+  const rep = emptyReport();
+  compare(ours, theirs, "model input", new Set<string>(), rep);
+  const undocumented = (m: string) => /provider field `/.test(m);
+  return { errors: rep.errors.filter((m) => !undocumented(m)), warnings: rep.warnings.filter((m) => !undocumented(m)) };
+};
+
+describe("normalizer: per-variant defaults across a union", () => {
+  test("a property the alternatives disagree about loses `default` and gains `defaultByVariant`", () => {
+    const res = provider().properties.resolution;
+    expect(res.default).toBeUndefined();
+    expect(res.defaultByVariant).toEqual({ t2v: "hd", i2v: "hd", v2v: "hd", draft_enhance: "fhd" });
+  });
+
+  test("the rest of the merged property survives, so enum and type are still checkable", () => {
+    const res = provider().properties.resolution;
+    expect(res.type).toBe("string");
+    expect(res.enum).toEqual(["hd", "fhd"]);
+  });
+
+  test("a property every alternative agrees about keeps its single default", () => {
+    const merged = provider().properties;
+    expect(merged.generate_audio.default).toBe(true);
+    expect(merged.generate_audio.defaultByVariant).toBeUndefined();
+    expect(merged.safety_tolerance.default).toBe(2);
+  });
+
+  test("a default only one alternative declares is not a disagreement", () => {
+    const merged = provider().properties;
+    expect(merged.draft_cache.default).toBe("");
+    expect(merged.draft_cache.defaultByVariant).toBeUndefined();
+  });
+
+  test("union merging is otherwise unchanged: required is the intersection", () => {
+    expect(provider().required).toEqual(["mode"]);
+    expect(provider().union).toBe(true);
+  });
+});
+
+describe("variantLabels", () => {
+  test("uses the declared discriminator's constants", () => {
+    const alts = [{ properties: { mode: { const: "t2v" } } }, { properties: { mode: { const: "i2v" } } }];
+    expect(variantLabels({ discriminator: { propertyName: "mode" } }, alts)).toEqual(["t2v", "i2v"]);
+  });
+
+  test("falls back to a single-valued enum, then to the alternative index", () => {
+    const enums = [{ properties: { kind: { enum: ["a"] } } }, { properties: { kind: { enum: ["b"] } } }];
+    expect(variantLabels({}, enums)).toEqual(["a", "b"]);
+    expect(variantLabels({}, [{ properties: { x: { type: "string" } } }, { properties: { x: { type: "string" } } }])).toEqual(["#0", "#1"]);
+  });
+
+  test("a property that is constant but not distinct is not the discriminator", () => {
+    const alts = [{ properties: { kind: { const: "same" } } }, { properties: { kind: { const: "same" } } }];
+    expect(variantLabels({}, alts)).toEqual(["#0", "#1"]);
+  });
+
+  test("labels a union whose alternatives are unlabelled by index", () => {
+    const doc = { openapi: "3.1.0", components: { schemas: {} } } as any;
+    const s = { oneOf: [{ type: "object", properties: { size: { type: "string", default: "small" } } }, { type: "object", properties: { size: { type: "string", default: "large" } } }] };
+    expect(normalizer(doc).norm(s).properties.size.defaultByVariant).toEqual({ "#0": "small", "#1": "large" });
+  });
+});
+
+describe("compare: reporting a per-variant provider default", () => {
+  const documented = (resolution: any) => ({ type: "object", properties: { resolution: { type: "string", enum: ["hd", "fhd"], ...resolution } } });
+
+  test("documenting a single default is an ERROR naming every variant", () => {
+    const rep = run(documented({ default: "fhd" }));
+    expect(rep.errors).toEqual([
+      'model input: `resolution` documents a single default "fhd" but the provider default is per-variant {"t2v":"hd","i2v":"hd","v2v":"hd","draft_enhance":"fhd"}; document the per-variant defaults in the description and drop `default`',
+    ]);
+  });
+
+  test("the default that is right for MOST modes is an error too: there is no single right one", () => {
+    expect(run(documented({ default: "hd" })).errors).toHaveLength(1);
+  });
+
+  test("documenting no default is a WARNING, not an error", () => {
+    const rep = run(documented({}));
+    expect(rep.errors).toEqual([]);
+    expect(rep.warnings).toEqual([
+      'model input: `resolution` provider default is per-variant {"t2v":"hd","i2v":"hd","v2v":"hd","draft_enhance":"fhd"}; make sure the description says so',
+    ]);
+  });
+
+  test("the collapsed last-wins default is never reported: `fhd` alone is not the provider's default", () => {
+    for (const rep of [run(documented({})), run(documented({ default: "fhd" }))]) {
+      expect([...rep.errors, ...rep.warnings].filter((m) => /provider default "fhd"|default "fhd" vs provider/.test(m))).toEqual([]);
+    }
+  });
+
+  test("the other checks still run on a per-variant property (only the default checks are skipped)", () => {
+    const rep = run({ type: "object", properties: { resolution: { type: "integer", enum: ["hd", "fhd", "uhd"] } } });
+    expect(rep.errors).toContain('model input: `resolution` type "integer" vs provider "string"');
+    expect(rep.errors).toContain('model input: `resolution` enum values ["uhd"] are not in the provider\'s ["hd","fhd"]');
+  });
+
+  test("inside an array's items a per-variant default warns nothing but still errors", () => {
+    const rep = emptyReport();
+    const items = { type: "object", properties: { resolution: { type: "string" } } };
+    compare(items, provider(), "model input", new Set<string>(), rep, "clips[]");
+    expect(rep.warnings.filter((m) => /per-variant/.test(m))).toEqual([]);
+    compare({ type: "object", properties: { resolution: { type: "string", default: "hd" } } }, provider(), "model input", new Set<string>(), rep, "clips[]");
+    expect(rep.errors.filter((m) => /per-variant/.test(m))).toHaveLength(1);
+  });
+
+  test("properties without a per-variant default keep the ordinary default checks", () => {
+    expect(run({ type: "object", properties: { generate_audio: { type: "boolean", default: false } } }).errors).toEqual([
+      "model input: `generate_audio` default false vs provider true",
+    ]);
+    expect(run({ type: "object", properties: { generate_audio: { type: "boolean" } } }).warnings).toEqual([
+      "model input: `generate_audio` provider default true is not documented",
+    ]);
+  });
+});

--- a/.github/scripts/snippets/check-provider-schemas.ts
+++ b/.github/scripts/snippets/check-provider-schemas.ts
@@ -18,9 +18,18 @@
  *     omit: [webhook_url, webhook_secret]            # provider fields we deliberately do not document
  *
  * Errors (exit 1): a documented field the provider does not have; a type, default,
- * enum, bound or required-ness that disagrees with the provider. Warnings: provider
- * fields we do not document (errors under --strict), and provider shapes that are
- * opaque (`{}`) where we document structure.
+ * enum, bound or required-ness that disagrees with the provider; a single documented
+ * `default` for a field whose provider default is PER-VARIANT. Warnings: provider
+ * fields we do not document (errors under --strict), provider shapes that are
+ * opaque (`{}`) where we document structure, and a per-variant provider default the
+ * page has to explain in prose.
+ *
+ * Per-variant defaults: when a provider body is a `oneOf`/`anyOf` of modes (BFL's
+ * FLUX 3 Video is t2v/i2v/v2v/draft_enhance) the alternatives can disagree about a
+ * field's `default` — `resolution` is `hd` in three modes and `fhd` in the fourth.
+ * Merging the alternatives last-wins would pick one arbitrarily and then "verify"
+ * the docs against it, so `norm` instead drops `default` from such a field and
+ * records `defaultByVariant: { <mode>: <default> }` for `compare` to report.
  */
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -46,8 +55,24 @@ function fetchDoc(url: string): Promise<any> {
   return cache.get(url)!;
 }
 
+/**
+ * Name each alternative of a union so a per-variant default reads as `{"t2v":"hd",…}` rather
+ * than `{"#0":"hd",…}`: the discriminator's value when the document declares a discriminator,
+ * else a property that is a distinct constant in every alternative, else the index.
+ */
+export function variantLabels(s: any, alts: any[]): string[] {
+  const constOf = (p: any) => (p?.const !== undefined ? p.const : Array.isArray(p?.enum) && p.enum.length === 1 ? p.enum[0] : undefined);
+  const names: string[] = s?.discriminator?.propertyName ? [s.discriminator.propertyName] : [...new Set(alts.flatMap((a) => Object.keys(a.properties ?? {})))];
+  for (const name of names) {
+    const vals = alts.map((a) => constOf(a.properties?.[name]));
+    // Every alternative must pin it, and to a value no other alternative uses — otherwise it is not the discriminator.
+    if (vals.every((v) => v !== undefined) && new Set(vals.map(String)).size === alts.length) return vals.map(String);
+  }
+  return alts.map((_, i) => `#${i}`);
+}
+
 // ---- normalise provider schemas (OpenAPI 3 or Google discovery) into plain JSON-schema-ish objects
-function normalizer(doc: any) {
+export function normalizer(doc: any) {
   const isDiscovery = !!doc.schemas && !doc.openapi;
   const comps: Record<string, any> = isDiscovery ? doc.schemas : doc.components?.schemas ?? {};
   const seen = new Set<string>();
@@ -64,9 +89,21 @@ function normalizer(doc: any) {
       if (alts.length === 1) return { ...alts[0], nullable: true, ...(s.default !== undefined ? { default: s.default } : {}) };
       // discriminated unions (FLUX 3 Video): union of properties, required = intersection
       const props: Record<string, any> = {}; let req: Set<string> | null = null;
-      for (const a of alts) {
+      // Merging last-wins would silently adopt the LAST alternative's default as if it were the
+      // provider's one default, so collect every alternative's default per property as we go.
+      const labels = variantLabels(s, alts);
+      const defaults = new Map<string, [string, unknown][]>();
+      alts.forEach((a: any, i: number) => {
+        for (const [name, p] of Object.entries<any>(a.properties ?? {})) {
+          if (p?.default !== undefined) defaults.set(name, [...(defaults.get(name) ?? []), [labels[i]!, p.default]]);
+        }
         Object.assign(props, a.properties ?? {});
         const r = new Set<string>(a.required ?? []); req = req ? new Set([...req].filter((x) => r.has(x))) : r;
+      });
+      for (const [name, entries] of defaults) {
+        if (new Set(entries.map(([, d]) => JSON.stringify(d))).size < 2) continue; // the alternatives agree — the merged default is theirs
+        const { default: _collapsed, ...rest } = props[name] ?? {};
+        props[name] = { ...rest, defaultByVariant: Object.fromEntries(entries) };
       }
       const types = [...new Set(alts.map((a: any) => a.type).filter(Boolean))];
       return { type: types.length === 1 ? types[0] : types, properties: props, required: [...(req ?? [])], union: true, ...(s.default !== undefined ? { default: s.default } : {}) };
@@ -74,7 +111,8 @@ function normalizer(doc: any) {
     if (s.allOf) return s.allOf.map((a: any) => norm(a, depth + 1)).reduce((acc: any, d: any) => ({ ...acc, ...d, properties: { ...(acc.properties ?? {}), ...(d.properties ?? {}) }, required: [...(acc.required ?? []), ...(d.required ?? [])] }), {});
     const out: any = { type: s.type };
     if ((s.type === "object" || s.type === undefined) && !s.properties && !s.items && !s.enum && !s.anyOf) out.opaque = true;
-    for (const k of ["default", "enum", "minimum", "maximum", "format", "description"]) if (s[k] !== undefined) out[k] = s[k];
+    // `const` is carried for `variantLabels` only — nothing compares it, so it adds no new drift.
+    for (const k of ["default", "enum", "minimum", "maximum", "format", "description", "const"]) if (s[k] !== undefined) out[k] = s[k];
     if (s.properties) { out.properties = {}; for (const [k, v] of Object.entries<any>(s.properties)) out.properties[k] = norm(v, depth + 1); }
     if (s.required) out.required = s.required;
     if (s.items) out.items = norm(s.items, depth + 1);
@@ -113,7 +151,7 @@ async function providerShapes(ps: ProviderSpec): Promise<{ input: any; output: a
 }
 
 // ---- comparison
-type Report = { errors: string[]; warnings: string[] };
+export type Report = { errors: string[]; warnings: string[] };
 const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
 const baseType = (t: unknown) => (Array.isArray(t) ? t : [t]).map(String);
 const compatible = (ours: unknown, theirs: unknown) => {
@@ -147,7 +185,7 @@ function flatten(s: any): any {
   };
 }
 
-function compare(ours: any, theirs: any, where: string, omit: Set<string>, rep: Report, prefix = "", noRequired = false) {
+export function compare(ours: any, theirs: any, where: string, omit: Set<string>, rep: Report, prefix = "", noRequired = false) {
   ours = flatten(ours);
   noRequired = noRequired || !!theirs?.noRequiredInfo;
   if (!theirs || theirs.opaque) { if (ours?.properties && Object.keys(ours.properties).length) rep.warnings.push(`${where}: provider declares \`${prefix || "body"}\` as an opaque object; cannot verify ${Object.keys(ours.properties).length} documented field(s) beneath it`); return; }
@@ -159,9 +197,18 @@ function compare(ours: any, theirs: any, where: string, omit: Set<string>, rep: 
     if (!t) { rep.errors.push(`${where}: \`${path}\` is documented but the provider spec has no such field`); continue; }
     if (!compatible(o.type, t.type)) rep.errors.push(`${where}: \`${path}\` type ${JSON.stringify(o.type)} vs provider ${JSON.stringify(t.type)}`);
     if (!noRequired && ourReq.has(name) !== theirReq.has(name) && !theirs.union) rep.errors.push(`${where}: \`${path}\` required=${ourReq.has(name)} vs provider required=${theirReq.has(name)}`);
-    if (t.default !== undefined && o.default !== undefined && !eq(o.default, t.default)) rep.errors.push(`${where}: \`${path}\` default ${JSON.stringify(o.default)} vs provider ${JSON.stringify(t.default)}`);
-    if (t.default !== undefined && o.default === undefined && !prefix.includes("[]")) rep.warnings.push(`${where}: \`${path}\` provider default ${JSON.stringify(t.default)} is not documented`);
-    if (o.default !== undefined && t.default === undefined) rep.warnings.push(`${where}: \`${path}\` documents default ${JSON.stringify(o.default)} but the provider spec declares none`);
+    if (t.defaultByVariant) {
+      // The provider's alternatives disagree: there is no single default to document, so a `default:`
+      // here is wrong for at least one mode however it is written. Only these two apply to the field.
+      if (o.default !== undefined) rep.errors.push(`${where}: \`${path}\` documents a single default ${JSON.stringify(o.default)} but the provider default is per-variant ${JSON.stringify(t.defaultByVariant)}; document the per-variant defaults in the description and drop \`default\``);
+      // `!prefix.includes("[]")` mirrors the undocumented-default warning below: inside an array's items
+      // an undocumented provider default is not something the page is expected to state. An ERROR still fires there.
+      else if (!prefix.includes("[]")) rep.warnings.push(`${where}: \`${path}\` provider default is per-variant ${JSON.stringify(t.defaultByVariant)}; make sure the description says so`);
+    } else {
+      if (t.default !== undefined && o.default !== undefined && !eq(o.default, t.default)) rep.errors.push(`${where}: \`${path}\` default ${JSON.stringify(o.default)} vs provider ${JSON.stringify(t.default)}`);
+      if (t.default !== undefined && o.default === undefined && !prefix.includes("[]")) rep.warnings.push(`${where}: \`${path}\` provider default ${JSON.stringify(t.default)} is not documented`);
+      if (o.default !== undefined && t.default === undefined) rep.warnings.push(`${where}: \`${path}\` documents default ${JSON.stringify(o.default)} but the provider spec declares none`);
+    }
     if (o.enum && t.enum) { const extra = o.enum.filter((v: unknown) => !t.enum.includes(v)); if (extra.length) rep.errors.push(`${where}: \`${path}\` enum values ${JSON.stringify(extra)} are not in the provider's ${JSON.stringify(t.enum)}`); const missing = t.enum.filter((v: unknown) => !o.enum.includes(v) && !String(v).endsWith("UNSPECIFIED")); if (missing.length) rep.warnings.push(`${where}: \`${path}\` provider also allows ${JSON.stringify(missing)}`); }
     if (t.enum && !o.enum && t.enum.length <= 12) rep.warnings.push(`${where}: \`${path}\` provider enumerates ${JSON.stringify(t.enum)} but we document a free ${o.type}`);
     for (const b of ["minimum", "maximum"] as const) if (o[b] !== undefined && t[b] !== undefined && Number(o[b]) !== Number(t[b])) rep.errors.push(`${where}: \`${path}\` ${b} ${o[b]} vs provider ${t[b]}`);
@@ -176,28 +223,30 @@ function compare(ours: any, theirs: any, where: string, omit: Set<string>, rep: 
   }
 }
 
-// ---- main
-const glob = new Bun.Glob("development/comfy-router/models/**/code.yaml");
-const rep: Report = { errors: [], warnings: [] };
-let checked = 0, skipped = 0;
-for (const specPath of glob.scanSync({ cwd: ROOT })) {
-  const spec = Bun.YAML.parse(readFileSync(join(ROOT, specPath), "utf8")) as any;
-  for (const v of spec.variants) {
-    const ps: ProviderSpec | undefined = v.provider_spec ?? spec.provider_spec;
-    const input = v.input ?? spec.input, output = v.output ?? spec.output;
-    if (!ps) { skipped++; rep.warnings.push(`${dirname(specPath)} (${v.model}): no provider_spec, cannot verify`); continue; }
-    const where = `${dirname(specPath).replace("development/comfy-router/models/", "")} (${v.model})`;
-    try {
-      const shapes = await providerShapes(ps);
-      const omit = new Set<string>(ps.omit ?? []);
-      if (input) compare(input, shapes.input, `${where} input`, omit, rep);
-      if (output) compare(output, shapes.output, `${where} output`, omit, rep);
-      checked++;
-    } catch (e) { rep.errors.push(`${where}: ${(e as Error).message}`); }
+// ---- main (only when run as a script; importing this file for tests must not fetch anything)
+if (import.meta.main) {
+  const glob = new Bun.Glob("development/comfy-router/models/**/code.yaml");
+  const rep: Report = { errors: [], warnings: [] };
+  let checked = 0, skipped = 0;
+  for (const specPath of glob.scanSync({ cwd: ROOT })) {
+    const spec = Bun.YAML.parse(readFileSync(join(ROOT, specPath), "utf8")) as any;
+    for (const v of spec.variants) {
+      const ps: ProviderSpec | undefined = v.provider_spec ?? spec.provider_spec;
+      const input = v.input ?? spec.input, output = v.output ?? spec.output;
+      if (!ps) { skipped++; rep.warnings.push(`${dirname(specPath)} (${v.model}): no provider_spec, cannot verify`); continue; }
+      const where = `${dirname(specPath).replace("development/comfy-router/models/", "")} (${v.model})`;
+      try {
+        const shapes = await providerShapes(ps);
+        const omit = new Set<string>(ps.omit ?? []);
+        if (input) compare(input, shapes.input, `${where} input`, omit, rep);
+        if (output) compare(output, shapes.output, `${where} output`, omit, rep);
+        checked++;
+      } catch (e) { rep.errors.push(`${where}: ${(e as Error).message}`); }
+    }
   }
+  if (verbose) for (const w of rep.warnings) console.log(`warn  ${w}`);
+  else if (rep.warnings.length) console.log(`(${rep.warnings.length} warning(s); run with --verbose to list them)`);
+  for (const e of rep.errors) console.log(`ERROR ${e}`);
+  console.log(`\n${checked} model(s) checked against provider specs, ${skipped} skipped, ${rep.errors.length} error(s), ${rep.warnings.length} warning(s)`);
+  process.exit(rep.errors.length ? 1 : 0);
 }
-if (verbose) for (const w of rep.warnings) console.log(`warn  ${w}`);
-else if (rep.warnings.length) console.log(`(${rep.warnings.length} warning(s); run with --verbose to list them)`);
-for (const e of rep.errors) console.log(`ERROR ${e}`);
-console.log(`\n${checked} model(s) checked against provider specs, ${skipped} skipped, ${rep.errors.length} error(s), ${rep.warnings.length} warning(s)`);
-process.exit(rep.errors.length ? 1 : 0);

--- a/.github/workflows/code-pages-check.yml
+++ b/.github/workflows/code-pages-check.yml
@@ -33,6 +33,24 @@ jobs:
       - name: Check generated code pages are fresh and their snippets parse
         run: bun run code-pages:check
 
+  snippet-script-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Fixture-driven, so unlike provider-schemas below it needs no network and cannot go red on a provider outage.
+      - name: Run the snippet script unit tests
+        run: bun test ./.github/scripts/snippets/
+
   provider-schemas:
     runs-on: ubuntu-latest
     # Fetches each provider's published spec, so a stalled provider host must not hold the runner.


### PR DESCRIPTION
## ELI-5

Some providers describe a request body as "one of these four modes." BFL's FLUX 3 Video is one of those: `t2v`, `i2v`, `v2v` and `draft_enhance`. The drift checker squashed those four alternatives into one shape by copying each alternative's fields over the last, so whichever mode came last won any field they disagreed about. `resolution` defaults to `hd` in three modes and `fhd` in `draft_enhance`, and `draft_enhance` is last, so the checker believed the provider's default was `fhd`. It would then have blessed a docs page that said `default: fhd` (wrong in three modes out of four) and gone red on one that said `default: hd` (wrong in one). Now the checker notices the disagreement instead of picking a winner, and says so.

## What changed

`normalizer()`'s union branch collects every alternative's `default` per property while it merges. When the collected values for a property are not all identical it drops `default` from the merged property and records `defaultByVariant` on it instead, keyed by the union discriminator's value when the document declares one (`t2v` / `i2v` / `v2v` / `draft_enhance` here) and by alternative index (`#0`, `#1`) when it does not.

`compare()` reads that key before the ordinary default checks:

* documented `default` present -> **ERROR**: "documents a single default `X` but the provider default is per-variant `{...}`; document the per-variant defaults in the description and drop `default`"
* documented `default` absent -> **WARNING**: "provider default is per-variant `{...}`; make sure the description says so"

Everything else about such a field (type, `enum`, bounds, nested properties) is still checked exactly as before. Properties whose alternatives agree, and every non-union schema, are untouched.

Also: the header comment now describes per-variant defaults, the snippets README grows a "Per-variant defaults" subsection showing both messages, and the script's main block moves behind `if (import.meta.main)` (the existing convention in `.github/scripts/i18n/`) so it can be imported by a test without fetching anything.

## Tests

New `.github/scripts/snippets/check-provider-schemas.test.ts`: 16 fixture-driven cases over a miniature of `Flux3VideoInputsBody`, covering the merge (disagreement detected, agreement left alone, a default only one alternative declares left alone, `required` still the intersection), `variantLabels` (discriminator, single-valued-enum fallback, index fallback, non-distinct constants rejected), and both new `compare` messages including a regression case asserting the collapsed `fhd` is never reported as "the" provider default. A new `snippet-script-tests` job in `code-pages-check.yml` runs them; it needs no network, so unlike `provider-schemas` it cannot go red on a provider outage.

I confirmed the tests bind rather than restate the implementation: neutralising the disagreement detection turns 5 of the 16 red, including the last-wins regression case.

## Verification

Run against the live BFL and Google specs from a clean worktree on the current default branch.

* `bun .github/scripts/snippets/check-provider-schemas.ts --verbose` reports for `black-forest-labs/flux-3-video (bfl/flux-3-video) input` exactly the new warning, `` `resolution` provider default is per-variant {"t2v":"hd","i2v":"hd","v2v":"hd","draft_enhance":"fhd"} ``, with **0 errors** over 14 models.
* Diffing the full sorted output before and after the change: **one line differs** across all 14 models. The old `` `resolution` provider default "fhd" is not documented `` becomes the new per-variant warning. No warning gained or lost anywhere else, no new errors for the other 13 models.
* Temporarily re-adding `default: fhd` to `flux-3-video/code.yaml` makes the job exit 1 with the new ERROR text. So does `default: hd`, which is the point: no single value is right for every mode. The yaml was reverted and is not part of this diff.
* `bun run code-pages:check`: 157 code pages fresh, 0 stale.
* `bun test ./.github/scripts/snippets/`: 16 pass, 0 fail.

I read BFL's published `openapi.json` directly to establish the premise the new ERROR asserts, rather than inferring it: `Flux3VideoT2VInputs`, `Flux3VideoI2VInputs` and `Flux3VideoV2VInputs` each declare `resolution.default = "hd"`, `Flux3VideoDraftEnhanceInputs` declares `"fhd"`, and all four pin `mode` with a `const`. There is genuinely no single correct value to document, which is why the error tells the author to move the information into the description (where `flux-3-video/code.yaml` already carries it) rather than dead-ending them.

## Judgment calls

Three deliberate departures from the plan as written, each because the literal instruction would have been wrong here:

1. **The default checks are skipped with an `if`/`else`, not a `continue`.** A `continue` at that point in the property loop would also have skipped the `enum`, `minimum`/`maximum` and nested-object checks for that property. For `resolution`, whose whole remaining contract is its `enum`, that would have quietly stopped validating the field in exchange for reporting it. There is a test asserting type and enum errors still fire on a per-variant property.
2. **The discriminator is read from the document, not hardcoded to `mode`, and `norm` now carries `const`.** Reading `a.properties.mode?.const` off a normalised alternative would always have been `undefined`, because `norm`'s copied-key list did not include `const`, so every label would silently have fallen back to `#0`..`#3`. `const` is now carried (nothing compares it, so it introduces no new drift, and the before/after output diff confirms that empirically), and the discriminator property comes from `discriminator.propertyName` when the document declares one, else from a property that is a distinct constant in every alternative, else the index.
3. **The new WARNING is suppressed inside array items** (`!prefix.includes("[]")`), matching the adjacent undocumented-default warning's existing contract. The ERROR is not suppressed there, which also matches the adjacent rule. No model in the repo exercises this today; it is about not introducing an inconsistency for the next one.

## Residual

* **Pre-existing non-determinism in the warning count, not addressed here.** Google's discovery document does not serve a stable shape between fetches: seven `contents[].parts[].inlineData` "opaque object" warnings appear or vanish as a group from run to run, moving the summary total between 263 and 270. I measured this on the **unmodified** script from the default branch (7, 0, 7 warnings across three consecutive runs), so it predates this change and this change does not affect it. It does mean the `provider-schemas` job's warning count is not a stable signal and a future "did the warning count change?" gate would be flaky. Worth its own investigation into whether the fetch should be pinned or the opaque-object warning made insensitive to it.
* **The historical CI run cited by the investigation behind this change was not re-opened.** Its finding (0 errors while the docs carried a wrong default) was reproduced locally instead, by running the unmodified checker from the default branch and confirming it accepts `default: fhd`. The run's own logs were not read.
* **Only the four BFL FLUX 3 Video alternatives were exercised against a real provider document.** `variantLabels`' index and single-valued-enum fallbacks, and the array-item suppression above, are covered by fixtures only, because no other model in the catalog currently presents a union with disagreeing defaults. The sweep supporting that: all 14 models with a `provider_spec` were checked, and `resolution` is the only property in any of them that this change reclassifies.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `bun test ./.github/scripts/snippets/`: 16 pass, 0 fail; `bun run code-pages:check`: 157 pages fresh, 0 stale; `bun .github/scripts/snippets/check-provider-schemas.ts --verbose`: 14 models, 0 errors, one changed warning line vs the default branch; error path re-checked by temporarily re-adding `default: fhd` and `default: hd` to the flux-3-video spec (exit 1 both times, reverted)
- **Deviations:** the three judgment calls above (`if`/`else` in place of `continue`, document-driven discriminator plus carrying `const`, array-item suppression on the new warning); no acceptance criterion was left unmet
