### PR TITLE
chore(code-pages): regenerate Router code pages to restore freshness

### DIFF
--- a/development/comfy-router/models/bria/image-edit-erase/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-erase/code.mdx
@@ -61,9 +61,35 @@ curl https://api.comfy.org/v2/models/bria/image-edit-erase \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-erase/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="image" type="string" required>
+  The image to edit. Supported input types are Base64-encoded string or URL pointing to a publicly accessible image file. Accepted formats JPEG, JPG, PNG, WEBP.
+</ParamField>
+
+<ParamField body="mask" type="string" required>
+  The mask defining the area to erase. Base64-encoded string or URL pointing to a publicly accessible image file. White pixels (255) mark the region to remove, black pixels (0) are preserved.
+</ParamField>
+
+<ParamField body="mask_type" type="string">
+  The type of mask provided, either "manual" (default) or "automatic".
+</ParamField>
+
+<ParamField body="preserve_alpha" type="boolean">
+  Controls whether partially transparent areas from the input image are retained in the output.
+</ParamField>
+
+<ParamField body="sync" type="boolean">
+  When false (default), the request is processed asynchronously. When true, the API holds the connection open until complete.
+</ParamField>
+
+<ParamField body="visual_input_content_moderation" type="boolean">
+  When enabled, applies content moderation to input visual. Returns 422 if the image fails moderation.
+</ParamField>
+
+<ParamField body="visual_output_content_moderation" type="boolean">
+  When enabled, applies content moderation to result visual. Returns 422 if the output fails moderation.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/image-edit-erase/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -122,6 +148,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "image": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAC2klEQVR42u3TQQ0AQAgEMeTgX8W5gi8OjoROVgGhUdLhwgkEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAAkACQAJAAkACQAJAAkACQAJAAkACQAFjSy7SPAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8IIAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASABIAEgASABIAEgASABIAEgASABIAEgASABIAAgACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAadSRm+WukYdfewAAAABJRU5ErkJggg==",
+  "mask": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAB+UlEQVR42u3TMQ0AAAzDsPIn3d7DMBtCpKTwWCTAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAbAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGgGvctyzUB/Dz3wAAAABJRU5ErkJggg=="
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/bria/image-edit-expand/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-expand/code.mdx
@@ -61,9 +61,59 @@ curl https://api.comfy.org/v2/models/bria/image-edit-expand \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-expand/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="aspect_ratio" type="object">
+  Aspect ratio of the expanded canvas, either a predefined ratio string ("1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9") or a float between 0.5 and 3.0. When provided, canvas_size, original_image_size, and original_image_location are ignored.
+</ParamField>
+
+<ParamField body="canvas_size" type="integer[]">
+  Width and height of the expanded canvas in pixels. Defaults to [1000, 1000]. Maximum canvas area is 5000x5000 pixels.
+</ParamField>
+
+<ParamField body="image" type="string" required>
+  The image to expand. Supported input types are Base64-encoded string or URL pointing to a publicly accessible image file. Accepted formats JPEG, JPG, PNG, WEBP.
+</ParamField>
+
+<ParamField body="negative_prompt" type="string">
+  A text prompt specifying concepts, styles, or objects to exclude from the expanded area.
+</ParamField>
+
+<ParamField body="original_image_location" type="integer[]">
+  Position [x, y] of the original image's top-left corner on the canvas. Required together with original_image_size when aspect_ratio is not provided.
+</ParamField>
+
+<ParamField body="original_image_size" type="integer[]">
+  Width and height of the original image placed on the canvas. Required together with original_image_location when aspect_ratio is not provided.
+</ParamField>
+
+<ParamField body="preserve_alpha" type="boolean">
+  Controls whether partially transparent areas from the input image are retained in the output.
+</ParamField>
+
+<ParamField body="prompt" type="string">
+  Text prompt guiding the content generated in the expanded area. Auto-generated when omitted.
+</ParamField>
+
+<ParamField body="prompt_content_moderation" type="boolean">
+  When enabled, applies content moderation to the prompt. Returns 422 if the prompt fails moderation.
+</ParamField>
+
+<ParamField body="seed" type="integer">
+  Seed for deterministic generation. If omitted, a random seed is used.
+</ParamField>
+
+<ParamField body="sync" type="boolean">
+  When false (default), the request is processed asynchronously. When true, the API holds the connection open until complete.
+</ParamField>
+
+<ParamField body="visual_input_content_moderation" type="boolean">
+  When enabled, applies content moderation to input visual. Returns 422 if the image fails moderation.
+</ParamField>
+
+<ParamField body="visual_output_content_moderation" type="boolean">
+  When enabled, applies content moderation to result visual. Returns 422 if the output fails moderation.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/image-edit-expand/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -122,6 +172,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "aspect_ratio": "3:2",
+  "image": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAC2klEQVR42u3TQQ0AQAgEMeTgX8W5gi8OjoROVgGhUdLhwgkEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAAkACQAJAAkACQAJAAkACQAJAAkACQAFjSy7SPAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8IIAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASABIAEgASABIAEgASABIAEgASABIAEgASABIAAgACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAadSRm+WukYdfewAAAABJRU5ErkJggg=="
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-gen-fill/code.mdx
@@ -61,9 +61,51 @@ curl https://api.comfy.org/v2/models/bria/image-edit-gen-fill \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/bria/image-edit-gen-fill/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Bria unchanged, so [Bria's own API reference](https://docs.bria.ai/) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="image" type="string" required>
+  The image to edit. Supported input types are Base64-encoded string or URL pointing to a publicly accessible image file. Accepted formats JPEG, JPG, PNG, WEBP.
+</ParamField>
+
+<ParamField body="mask" type="string" required>
+  The mask defining the area to fill. Base64-encoded string or URL pointing to a publicly accessible image file. White pixels (255) mark the region to generate into, black pixels (0) are preserved.
+</ParamField>
+
+<ParamField body="negative_prompt" type="string">
+  A text prompt specifying concepts, styles, or objects to exclude from the generated area.
+</ParamField>
+
+<ParamField body="preserve_alpha" type="boolean">
+  Controls whether partially transparent areas from the input image are retained in the output.
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  Text description of what to generate inside the masked area.
+</ParamField>
+
+<ParamField body="prompt_content_moderation" type="boolean">
+  When enabled, applies content moderation to the prompt. Returns 422 if the prompt fails moderation.
+</ParamField>
+
+<ParamField body="refine_prompt" type="boolean">
+  When true (default), the prompt is automatically adjusted for optimal generation results.
+</ParamField>
+
+<ParamField body="seed" type="integer">
+  Seed for deterministic generation. If omitted, a random seed is used.
+</ParamField>
+
+<ParamField body="sync" type="boolean">
+  When false (default), the request is processed asynchronously. When true, the API holds the connection open until complete.
+</ParamField>
+
+<ParamField body="visual_input_content_moderation" type="boolean">
+  When enabled, applies content moderation to input visual. Returns 422 if the image fails moderation.
+</ParamField>
+
+<ParamField body="visual_output_content_moderation" type="boolean">
+  When enabled, applies content moderation to result visual. Returns 422 if the output fails moderation.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/image-edit-gen-fill/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -122,6 +164,16 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "image": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAC2klEQVR42u3TQQ0AQAgEMeTgX8W5gi8OjoROVgGhUdLhwgkEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAAkACQAJAAkACQAJAAkACQAJAAkACQAFjSy7SPAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8IIAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASABIAEgASABIAEgASABIAEgASABIAEgASABIAAgACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAadSRm+WukYdfewAAAABJRU5ErkJggg==",
+  "mask": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAB+UlEQVR42u3TMQ0AAAzDsPIn3d7DMBtCpKTwWCTAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAYAA4ABwABgADAAGAAMAAbAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAwABgADgAHAAGAAMAAYAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGAAOAAcAAYAAwABgADAAGgGvctyzUB/Dz3wAAAABJRU5ErkJggg==",
+  "prompt": "a small green leaf"
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/bria/image-edit-increase-resolution/code.mdx
+++ b/development/comfy-router/models/bria/image-edit-increase-resolution/code.mdx
@@ -1,22 +1,22 @@
 ---
-title: "Use Image Edit Remove Background with Comfy Router"
-description: "Call bria/image-edit-remove-background through Comfy Router: endpoint, request shape and the response Router returns."
-sidebarTitle: "Image Edit Remove Background"
+title: "Use Image Edit Increase Resolution with Comfy Router"
+description: "Call bria/image-edit-increase-resolution through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "Image Edit Increase Resolution"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/bria/image-edit-remove-background.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Generated from router-schemas/bria/image-edit-increase-resolution.json by `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `bria/image-edit-remove-background`, served by Comfy Router from Bria.
+API Reference for `bria/image-edit-increase-resolution`, served by Comfy Router from Bria.
 
 ## Quick start
 
 Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
-**Model ID:** `bria/image-edit-remove-background`
+**Model ID:** `bria/image-edit-increase-resolution`
 
-**Endpoint:** `POST https://api.comfy.org/v2/models/bria/image-edit-remove-background`
+**Endpoint:** `POST https://api.comfy.org/v2/models/bria/image-edit-increase-resolution`
 
 <CodeGroup>
 ```python Python
@@ -26,7 +26,7 @@ from comfy_sdk import Comfy
 # Idempotency-Key and waits up to 10 minutes for the finished result.
 with Comfy() as client:
     result = client.models.run(
-        "bria/image-edit-remove-background",
+        "bria/image-edit-increase-resolution",
         {
             # Request fields are the provider's own — see Input below.
         },
@@ -40,7 +40,7 @@ import { comfy } from "@comfyorg/sdk";
 
 // Reads COMFY_API_KEY from the environment. Each call sends a fresh
 // Idempotency-Key and waits up to 10 minutes for the finished result.
-const { data } = await comfy.models.run("bria/image-edit-remove-background", {
+const { data } = await comfy.models.run("bria/image-edit-increase-resolution", {
   // Request fields are the provider's own — see Input below.
 });
 
@@ -49,7 +49,7 @@ console.log(data);
 
 ```bash cURL
 # Request fields are the provider's own — see Input below.
-curl https://api.comfy.org/v2/models/bria/image-edit-remove-background \
+curl https://api.comfy.org/v2/models/bria/image-edit-increase-resolution \
   -H "X-API-Key: $COMFY_API_KEY" \
   -H "Idempotency-Key: $(uuidgen)" \
   -H "Content-Type: application/json" \
@@ -61,12 +61,16 @@ curl https://api.comfy.org/v2/models/bria/image-edit-remove-background \
 
 ### Input
 
+<ParamField body="desired_increase" type="integer">
+  Resolution multiplier to apply. Supported values are 2 and 4. Maximum output resolution is 8192x8192.
+</ParamField>
+
 <ParamField body="image" type="string" required>
-  The image to remove background from. Supported input types are Base64-encoded string or URL pointing to a publicly accessible image file. Accepted formats JPEG, JPG, PNG, WEBP.
+  The image to upscale. Supported input types are Base64-encoded string or URL pointing to a publicly accessible image file. Accepted formats JPEG, JPG, PNG, WEBP.
 </ParamField>
 
 <ParamField body="preserve_alpha" type="boolean">
-  Controls whether partially transparent areas from the input image are retained in the output after background removal.
+  Controls whether partially transparent areas from the input image are retained in the output.
 </ParamField>
 
 <ParamField body="sync" type="boolean">
@@ -81,63 +85,11 @@ curl https://api.comfy.org/v2/models/bria/image-edit-remove-background \
   When enabled, applies content moderation to result visual. Returns 422 if the output fails moderation.
 </ParamField>
 
-Generated from the schema Router serves at `GET /v2/models/bria/image-edit-remove-background/openapi.json`, the same document it validates a call against before the request reaches the provider.
+Generated from the schema Router serves at `GET /v2/models/bria/image-edit-increase-resolution/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
-<ResponseField name="error" type="object">
-  Error object (only present when status is ERROR)
-</ResponseField>
-
-<ResponseField name="error.code" type="integer">
-  Error code.
-</ResponseField>
-
-<ResponseField name="error.details" type="string">
-  Additional error details.
-</ResponseField>
-
-<ResponseField name="error.message" type="string">
-  Error message.
-</ResponseField>
-
-<ResponseField name="request_id" type="string">
-  Unique identifier for the request.
-</ResponseField>
-
-<ResponseField name="result" type="object">
-  Result object (only present when status is COMPLETED)
-</ResponseField>
-
-<ResponseField name="result.image_url" type="string">
-  URL of the generated/edited image.
-</ResponseField>
-
-<ResponseField name="result.prompt" type="string">
-  Original prompt.
-</ResponseField>
-
-<ResponseField name="result.refined_prompt" type="string">
-  Refined version of the prompt.
-</ResponseField>
-
-<ResponseField name="result.seed" type="integer">
-  Seed used for generation.
-</ResponseField>
-
-<ResponseField name="result.structured_prompt" type="string">
-  The detailed JSON structured prompt.
-</ResponseField>
-
-<ResponseField name="result.video_url" type="string">
-  URL of the generated video.
-</ResponseField>
-
-<ResponseField name="status" type="string">
-  Current status of the request.
-
-  Possible values: `IN_PROGRESS`, `COMPLETED`, `ERROR`, `UNKNOWN`
-</ResponseField>
+Router does not publish an output schema for this model.
 
 ## Examples
 
@@ -145,20 +97,8 @@ Generated from the schema Router serves at `GET /v2/models/bria/image-edit-remov
 
 ```json
 {
+  "desired_increase": 2,
   "image": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAC2klEQVR42u3TQQ0AQAgEMeTgX8W5gi8OjoROVgGhUdLhwgkEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAAkACQAJAAkACQAJAAkACQAJAAkACQAFjSy7SPAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8IIAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASABIAEgASABIAEgASABIAEgASABIAEgASABIAAgACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAadSRm+WukYdfewAAAABJRU5ErkJggg=="
-}
-```
-
-### Output
-
-```json
-{
-  "request_id": "0b3f9d7e-2c41-4a8b-9f10-6d5c8e2a4b71",
-  "result": {
-    "image_url": "https://example.invalid/bria/image-edit-remove-background/generated.png",
-    "seed": 42
-  },
-  "status": "COMPLETED"
 }
 ```
 

--- a/development/comfy-router/models/bria/structured-instruction/code.mdx
+++ b/development/comfy-router/models/bria/structured-instruction/code.mdx
@@ -1,0 +1,112 @@
+---
+title: "Use Structured Instruction with Comfy Router"
+description: "Call bria/structured-instruction through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "Structured Instruction"
+---
+
+{/* GENERATED FILE. Generated from router-schemas/bria/structured-instruction.json by `pnpm code-pages:gen`. */}
+
+import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
+
+API Reference for `bria/structured-instruction`, served by Comfy Router from Bria.
+
+## Quick start
+
+Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
+
+**Model ID:** `bria/structured-instruction`
+
+**Endpoint:** `POST https://api.comfy.org/v2/models/bria/structured-instruction`
+
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment. Each call sends a fresh
+# Idempotency-Key and waits up to 10 minutes for the finished result.
+with Comfy() as client:
+    result = client.models.run(
+        "bria/structured-instruction",
+        {
+            # Request fields are the provider's own — see Input below.
+        },
+    )
+
+print(result)
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment. Each call sends a fresh
+// Idempotency-Key and waits up to 10 minutes for the finished result.
+const { data } = await comfy.models.run("bria/structured-instruction", {
+  // Request fields are the provider's own — see Input below.
+});
+
+console.log(data);
+```
+
+```bash cURL
+# Request fields are the provider's own — see Input below.
+curl https://api.comfy.org/v2/models/bria/structured-instruction \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+</CodeGroup>
+
+## Schema
+
+### Input
+
+<ParamField body="images" type="string[]" required>
+  The source image to be edited. Publicly available URL or Base64-encoded. Must contain exactly one item.
+</ParamField>
+
+<ParamField body="instruction" type="string" required>
+  Required. Text-based edit instruction (e.g., "make the sky blue", "add a cat").
+</ParamField>
+
+<ParamField body="ip_signal" type="boolean" default="false">
+  If true, returns a warning for potential IP content in the instruction.
+</ParamField>
+
+<ParamField body="mask" type="string">
+  Optional mask image URL or Base64-encoded. Black areas will be preserved, white areas will be edited.
+</ParamField>
+
+<ParamField body="prompt_content_moderation" type="boolean" default="true">
+  If true, returns 422 on instruction moderation failure.
+</ParamField>
+
+<ParamField body="seed" type="integer">
+  Seed for deterministic generation. If omitted, a random seed is used.
+</ParamField>
+
+<ParamField body="visual_input_content_moderation" type="boolean" default="true">
+  If true, returns 422 on images or mask moderation failure.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/structured-instruction/openapi.json`, the same document it validates a call against before the request reaches the provider.
+
+### Output
+
+Router does not publish an output schema for this model.
+
+## Examples
+
+### Input
+
+```json
+{
+  "images": [
+    "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAC2klEQVR42u3TQQ0AQAgEMeTgX8W5gi8OjoROVgGhUdLhwgkEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAEgASABIAAkACQAJAAkACQAJAAkACQAJAAkACQAFjSy7SPAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8IIAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASABIAEgASABIAEgASABIAEgASABIAEgASABIAAgACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkACQAJAAkAadSRm+WukYdfewAAAABJRU5ErkJggg=="
+  ],
+  "instruction": "make the background light blue"
+}
+```
+
+
+<RouterCodeFooter />

--- a/development/comfy-router/models/bria/video-edit-green-screen/code.mdx
+++ b/development/comfy-router/models/bria/video-edit-green-screen/code.mdx
@@ -1,0 +1,102 @@
+---
+title: "Use Video Edit Green Screen with Comfy Router"
+description: "Call bria/video-edit-green-screen through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "Video Edit Green Screen"
+---
+
+{/* GENERATED FILE. Generated from router-schemas/bria/video-edit-green-screen.json by `pnpm code-pages:gen`. */}
+
+import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
+
+API Reference for `bria/video-edit-green-screen`, served by Comfy Router from Bria.
+
+## Quick start
+
+Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
+
+**Model ID:** `bria/video-edit-green-screen`
+
+**Endpoint:** `POST https://api.comfy.org/v2/models/bria/video-edit-green-screen`
+
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment. Each call sends a fresh
+# Idempotency-Key and waits up to 10 minutes for the finished result.
+with Comfy() as client:
+    result = client.models.run(
+        "bria/video-edit-green-screen",
+        {
+            # Request fields are the provider's own — see Input below.
+        },
+    )
+
+print(result)
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment. Each call sends a fresh
+// Idempotency-Key and waits up to 10 minutes for the finished result.
+const { data } = await comfy.models.run("bria/video-edit-green-screen", {
+  // Request fields are the provider's own — see Input below.
+});
+
+console.log(data);
+```
+
+```bash cURL
+# Request fields are the provider's own — see Input below.
+curl https://api.comfy.org/v2/models/bria/video-edit-green-screen \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+</CodeGroup>
+
+## Schema
+
+### Input
+
+<ParamField body="green_shade" type="string">
+  The solid background shade applied behind the foreground for chroma keying. Defaults to broadcast_green.
+
+  Possible values: `broadcast_green`, `chroma_green`, `blue_screen`
+</ParamField>
+
+<ParamField body="output_container_and_codec" type="string">
+  Output container and codec preset.
+
+  Possible values: `mp4_h264`, `mp4_h265`, `webm_vp9`, `mov_h265`, `mov_proresks`, `mkv_h264`, `mkv_h265`, `mkv_vp9`, `gif`
+</ParamField>
+
+<ParamField body="preserve_audio" type="boolean">
+  Whether to preserve audio from the input video.
+</ParamField>
+
+<ParamField body="video" type="string" required>
+  Publicly accessible URL of the input video. Input resolution supported up to 16000x16000 (16K). Max duration 60 seconds.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/video-edit-green-screen/openapi.json`, the same document it validates a call against before the request reaches the provider.
+
+### Output
+
+Router does not publish an output schema for this model.
+
+## Examples
+
+### Input
+
+```json
+{
+  "green_shade": "broadcast_green",
+  "video": "https://example.com/input.mp4"
+}
+```
+
+
+<RouterCodeFooter />

--- a/development/comfy-router/models/bria/video-edit-remove-background/code.mdx
+++ b/development/comfy-router/models/bria/video-edit-remove-background/code.mdx
@@ -1,0 +1,103 @@
+---
+title: "Use Video Edit Remove Background with Comfy Router"
+description: "Call bria/video-edit-remove-background through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "Video Edit Remove Background"
+---
+
+{/* GENERATED FILE. Generated from router-schemas/bria/video-edit-remove-background.json by `pnpm code-pages:gen`. */}
+
+import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
+
+API Reference for `bria/video-edit-remove-background`, served by Comfy Router from Bria.
+
+## Quick start
+
+Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
+
+**Model ID:** `bria/video-edit-remove-background`
+
+**Endpoint:** `POST https://api.comfy.org/v2/models/bria/video-edit-remove-background`
+
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment. Each call sends a fresh
+# Idempotency-Key and waits up to 10 minutes for the finished result.
+with Comfy() as client:
+    result = client.models.run(
+        "bria/video-edit-remove-background",
+        {
+            # Request fields are the provider's own — see Input below.
+        },
+    )
+
+print(result)
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment. Each call sends a fresh
+// Idempotency-Key and waits up to 10 minutes for the finished result.
+const { data } = await comfy.models.run("bria/video-edit-remove-background", {
+  // Request fields are the provider's own — see Input below.
+});
+
+console.log(data);
+```
+
+```bash cURL
+# Request fields are the provider's own — see Input below.
+curl https://api.comfy.org/v2/models/bria/video-edit-remove-background \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+</CodeGroup>
+
+## Schema
+
+### Input
+
+<ParamField body="background_color" type="string">
+  Background color for the output video. If Transparent, the output codec must support alpha.
+
+  Possible values: `Transparent`, `Black`, `White`, `Gray`, `Red`, `Green`, `Blue`, `Yellow`, `Cyan`, `Magenta`, `Orange`
+</ParamField>
+
+<ParamField body="output_container_and_codec" type="string">
+  Output container and codec preset.
+
+  Possible values: `mp4_h264`, `mp4_h265`, `webm_vp9`, `mov_h265`, `mov_proresks`, `mkv_h264`, `mkv_h265`, `mkv_vp9`, `gif`
+</ParamField>
+
+<ParamField body="preserve_audio" type="boolean">
+  Whether to preserve audio from the input video.
+</ParamField>
+
+<ParamField body="video" type="string" required>
+  Publicly accessible URL of the input video. Input resolution supported up to 16000x16000 (16K). Max duration 60 seconds.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/video-edit-remove-background/openapi.json`, the same document it validates a call against before the request reaches the provider.
+
+### Output
+
+Router does not publish an output schema for this model.
+
+## Examples
+
+### Input
+
+```json
+{
+  "background_color": "Transparent",
+  "output_container_and_codec": "webm_vp9",
+  "video": "https://example.com/input.mp4"
+}
+```
+
+
+<RouterCodeFooter />

--- a/development/comfy-router/models/bria/video-edit-replace-background/code.mdx
+++ b/development/comfy-router/models/bria/video-edit-replace-background/code.mdx
@@ -1,0 +1,100 @@
+---
+title: "Use Video Edit Replace Background with Comfy Router"
+description: "Call bria/video-edit-replace-background through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "Video Edit Replace Background"
+---
+
+{/* GENERATED FILE. Generated from router-schemas/bria/video-edit-replace-background.json by `pnpm code-pages:gen`. */}
+
+import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
+
+API Reference for `bria/video-edit-replace-background`, served by Comfy Router from Bria.
+
+## Quick start
+
+Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
+
+**Model ID:** `bria/video-edit-replace-background`
+
+**Endpoint:** `POST https://api.comfy.org/v2/models/bria/video-edit-replace-background`
+
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment. Each call sends a fresh
+# Idempotency-Key and waits up to 10 minutes for the finished result.
+with Comfy() as client:
+    result = client.models.run(
+        "bria/video-edit-replace-background",
+        {
+            # Request fields are the provider's own — see Input below.
+        },
+    )
+
+print(result)
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment. Each call sends a fresh
+// Idempotency-Key and waits up to 10 minutes for the finished result.
+const { data } = await comfy.models.run("bria/video-edit-replace-background", {
+  // Request fields are the provider's own — see Input below.
+});
+
+console.log(data);
+```
+
+```bash cURL
+# Request fields are the provider's own — see Input below.
+curl https://api.comfy.org/v2/models/bria/video-edit-replace-background \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+</CodeGroup>
+
+## Schema
+
+### Input
+
+<ParamField body="background_url" type="string" required>
+  Publicly accessible URL of the background asset (image or video) to composite behind the foreground. Must match the foreground aspect ratio.
+</ParamField>
+
+<ParamField body="output_container_and_codec" type="string">
+  Output container and codec preset.
+
+  Possible values: `mp4_h264`, `mp4_h265`, `webm_vp9`, `mov_h265`, `mov_proresks`, `mkv_h264`, `mkv_h265`, `mkv_vp9`, `gif`
+</ParamField>
+
+<ParamField body="preserve_audio" type="boolean">
+  Whether to preserve audio from the input (foreground) video.
+</ParamField>
+
+<ParamField body="video" type="string" required>
+  Publicly accessible URL of the input (foreground) video. Input resolution supported up to 16000x16000 (16K). Max duration 60 seconds.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/bria/video-edit-replace-background/openapi.json`, the same document it validates a call against before the request reaches the provider.
+
+### Output
+
+Router does not publish an output schema for this model.
+
+## Examples
+
+### Input
+
+```json
+{
+  "background_url": "https://example.com/background.mp4",
+  "video": "https://example.com/input.mp4"
+}
+```
+
+
+<RouterCodeFooter />

--- a/development/comfy-router/models/openai/gpt-6-astra/code.mdx
+++ b/development/comfy-router/models/openai/gpt-6-astra/code.mdx
@@ -1,0 +1,456 @@
+---
+title: "Use GPT 6 Astra with Comfy Router"
+description: "Call openai/gpt-6-astra through Comfy Router: endpoint, request shape and the response Router returns."
+sidebarTitle: "GPT 6 Astra"
+---
+
+{/* GENERATED FILE. Generated from router-schemas/openai/gpt-6-astra.json by `pnpm code-pages:gen`. */}
+
+import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
+
+API Reference for `openai/gpt-6-astra`, served by Comfy Router from OpenAI.
+
+## Quick start
+
+Create a key at [platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
+
+**Model ID:** `openai/gpt-6-astra`
+
+**Endpoint:** `POST https://api.comfy.org/v2/models/openai/gpt-6-astra`
+
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment. Each call sends a fresh
+# Idempotency-Key and waits up to 10 minutes for the finished result.
+with Comfy() as client:
+    result = client.models.run(
+        "openai/gpt-6-astra",
+        {
+            # Request fields are the provider's own — see Input below.
+        },
+    )
+
+print(result)
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment. Each call sends a fresh
+// Idempotency-Key and waits up to 10 minutes for the finished result.
+const { data } = await comfy.models.run("openai/gpt-6-astra", {
+  // Request fields are the provider's own — see Input below.
+});
+
+console.log(data);
+```
+
+```bash cURL
+# Request fields are the provider's own — see Input below.
+curl https://api.comfy.org/v2/models/openai/gpt-6-astra \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+</CodeGroup>
+
+## Schema
+
+### Input
+
+<Note>
+Router has not published an authored input schema for this model yet: `GET /v2/models/openai/gpt-6-astra/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to OpenAI unchanged, so [OpenAI's own API reference](https://platform.openai.com/docs/api-reference) is authoritative for the request fields, and nothing is validated server side.
+</Note>
+
+### Output
+
+<ResponseField name="instructions" type="string">
+  Inserts a system (or developer) message as the first item in the model's context.
+
+When using along with `previous_response_id`, the instructions from a previous
+response will not be carried over to the next response. This makes it simple
+to swap out system (or developer) messages in new responses.
+</ResponseField>
+
+<ResponseField name="max_output_tokens" type="integer">
+  An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).
+</ResponseField>
+
+<ResponseField name="model" type="string">
+  The model used to generate the response
+</ResponseField>
+
+<ResponseField name="temperature" type="number" default="1">
+  Controls randomness in the response
+
+  Range: `0` to `2`
+</ResponseField>
+
+<ResponseField name="top_p" type="number" default="1">
+  Controls diversity of the response via nucleus sampling
+
+  Range: `0` to `1`
+</ResponseField>
+
+<ResponseField name="truncation" type="string" default="&quot;disabled&quot;">
+  The truncation strategy to use for the model response.
+- `auto`: If the context of this response and previous ones exceeds
+  the model's context window size, the model will truncate the
+  response to fit the context window by dropping input items in the
+  middle of the conversation.
+- `disabled` (default): If a model response will exceed the context window
+  size for a model, the request will fail with a 400 error.
+
+  Possible values: `auto`, `disabled`
+</ResponseField>
+
+<ResponseField name="previous_response_id" type="string">
+  The unique ID of the previous response to the model. Use this to
+create multi-turn conversations. Learn more about
+[conversation state](https://platform.openai.com/docs/guides/conversation-state).
+</ResponseField>
+
+<ResponseField name="reasoning" type="object">
+  **o-series models only**
+
+Configuration options for
+[reasoning models](https://platform.openai.com/docs/guides/reasoning).
+</ResponseField>
+
+<ResponseField name="reasoning.context" type="string">
+  Controls which reasoning items are rendered back to the model on later turns, e.g. `auto`, `current_turn`, or `all_turns`.
+</ResponseField>
+
+<ResponseField name="reasoning.effort" type="string" default="&quot;medium&quot;">
+  **o-series models only**
+
+Constrains effort on reasoning for
+[reasoning models](https://platform.openai.com/docs/guides/reasoning).
+Currently supported values are `low`, `medium`, and `high`. Reducing
+reasoning effort can result in faster responses and fewer tokens used
+on reasoning in a response.
+
+  Possible values: `low`, `medium`, `high`
+</ResponseField>
+
+<ResponseField name="reasoning.generate_summary" type="string">
+  **Deprecated:** use `summary` instead.
+
+A summary of the reasoning performed by the model. This can be
+useful for debugging and understanding the model's reasoning process.
+One of `auto`, `concise`, or `detailed`.
+
+  Possible values: `auto`, `concise`, `detailed`
+</ResponseField>
+
+<ResponseField name="reasoning.mode" type="string">
+  The reasoning mode used for the response.
+</ResponseField>
+
+<ResponseField name="reasoning.summary" type="string">
+  A summary of the reasoning performed by the model. This can be
+useful for debugging and understanding the model's reasoning process.
+One of `auto`, `concise`, or `detailed`.
+
+  Possible values: `auto`, `concise`, `detailed`
+</ResponseField>
+
+<ResponseField name="text" type="object">
+   
+</ResponseField>
+
+<ResponseField name="text.format" type="object | object | object">
+  An object specifying the format that the model must output.
+
+Configuring `{ "type": "json_schema" }` enables Structured Outputs,
+which ensures the model will match your supplied JSON schema. Learn more in the
+[Structured Outputs guide](https://platform.openai.com/docs/guides/structured-outputs).
+
+The default format is `{ "type": "text" }` with no additional options.
+
+**Not recommended for gpt-4o and newer models:**
+
+Setting to `{ "type": "json_object" }` enables the older JSON mode, which
+ensures the message the model generates is valid JSON. Using `json_schema`
+is preferred for models that support it.
+</ResponseField>
+
+<ResponseField name="text.verbosity" type="string">
+  Constrains the verbosity of the model's response. One of `low`, `medium`, or `high`.
+</ResponseField>
+
+<ResponseField name="tool_choice" type="`none`, `auto`, `required` | object | object">
+  How the model should select which tool (or tools) to use when generating
+a response. See the `tools` parameter to see how to specify which tools
+the model can call.
+</ResponseField>
+
+<ResponseField name="tools" type="object | object | object | object[]">
+   
+</ResponseField>
+
+<ResponseField name="background" type="boolean">
+  Whether the model response runs in the background.
+</ResponseField>
+
+<ResponseField name="billing" type="object">
+  Billing information for the response.
+</ResponseField>
+
+<ResponseField name="billing.payer" type="string">
+  The party responsible for paying for the response.
+</ResponseField>
+
+<ResponseField name="completed_at" type="number">
+  Unix timestamp (in seconds) of when this Response was completed. Only present when the status is `completed`.
+</ResponseField>
+
+<ResponseField name="created_at" type="number">
+  Unix timestamp (in seconds) of when this Response was created.
+</ResponseField>
+
+<ResponseField name="error" type="object">
+  An error object returned when the model fails to generate a Response.
+</ResponseField>
+
+<ResponseField name="error.code" type="string" required>
+  The error code for the response.
+
+  Possible values: `server_error`, `rate_limit_exceeded`, `invalid_prompt`, `vector_store_timeout`, `invalid_image`, `invalid_image_format`, `invalid_base64_image`, `invalid_image_url`, `image_too_large`, `image_too_small`, `image_parse_error`, `image_content_policy_violation`, `invalid_image_mode`, `image_file_too_large`, `unsupported_image_media_type`, `empty_image_file`, `failed_to_download_image`, `image_file_not_found`
+</ResponseField>
+
+<ResponseField name="error.message" type="string" required>
+  A human-readable description of the error.
+</ResponseField>
+
+<ResponseField name="frequency_penalty" type="number">
+  Penalizes new tokens based on their existing frequency in the text so far.
+</ResponseField>
+
+<ResponseField name="id" type="string">
+  Unique identifier for this Response.
+</ResponseField>
+
+<ResponseField name="incomplete_details" type="object">
+  Details about why the response is incomplete.
+</ResponseField>
+
+<ResponseField name="incomplete_details.reason" type="string">
+  The reason why the response is incomplete.
+
+  Possible values: `max_output_tokens`, `content_filter`
+</ResponseField>
+
+<ResponseField name="max_tool_calls" type="integer">
+  The maximum number of total calls to built-in tools that can be processed in a response.
+</ResponseField>
+
+<ResponseField name="metadata" type="object">
+  Set of key-value pairs that can be attached to the response.
+</ResponseField>
+
+<ResponseField name="moderation" type="object">
+  Moderation results for the response input and output, if moderated completions were requested.
+</ResponseField>
+
+<ResponseField name="object" type="string">
+  The object type of this resource - always set to `response`.
+
+  Possible values: `response`
+</ResponseField>
+
+<ResponseField name="output" type="object | object | object | object | object | object | object[]">
+  An array of content items generated by the model.
+
+- The length and order of items in the `output` array is dependent
+  on the model's response.
+- Rather than accessing the first item in the `output` array and
+  assuming it's an `assistant` message with the content generated by
+  the model, you might consider using the `output_text` property where
+  supported in SDKs.
+</ResponseField>
+
+<ResponseField name="output_text" type="string">
+  SDK-only convenience property that contains the aggregated text output
+from all `output_text` items in the `output` array, if any are present.
+Supported in the Python and JavaScript SDKs.
+</ResponseField>
+
+<ResponseField name="parallel_tool_calls" type="boolean" default="true">
+  Whether to allow the model to run tool calls in parallel.
+</ResponseField>
+
+<ResponseField name="presence_penalty" type="number">
+  Penalizes new tokens based on whether they appear in the text so far.
+</ResponseField>
+
+<ResponseField name="prompt_cache_key" type="string">
+  Used by OpenAI to cache responses for similar requests to optimize cache hit rates. Replaces the `user` field.
+</ResponseField>
+
+<ResponseField name="prompt_cache_retention" type="string">
+  The retention policy for the prompt cache, e.g. `in_memory` or `24h`.
+</ResponseField>
+
+<ResponseField name="safety_identifier" type="string">
+  A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+</ResponseField>
+
+<ResponseField name="service_tier" type="string">
+  The processing tier used to serve the request, e.g. `auto`, `default`, `flex`, `scale`, or `priority`.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  The status of the response generation. One of `completed`, `failed`, `in_progress`, `cancelled`, `queued`, or `incomplete`.
+
+  Possible values: `completed`, `failed`, `in_progress`, `cancelled`, `queued`, `incomplete`
+</ResponseField>
+
+<ResponseField name="store" type="boolean">
+  Whether the response is stored for later retrieval via the API.
+</ResponseField>
+
+<ResponseField name="tool_usage" type="object">
+  Token and request usage broken down by built-in tool.
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen" type="object">
+  Image generation tool token usage.
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.input_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.input_tokens_details" type="object">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.input_tokens_details.image_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.input_tokens_details.text_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.output_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.output_tokens_details" type="object">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.output_tokens_details.image_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.output_tokens_details.text_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.image_gen.total_tokens" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="tool_usage.web_search" type="object">
+  Web search tool usage.
+</ResponseField>
+
+<ResponseField name="tool_usage.web_search.num_requests" type="integer">
+   
+</ResponseField>
+
+<ResponseField name="top_logprobs" type="integer">
+  The maximum number of most likely tokens to return at each token position, each with an associated log probability.
+</ResponseField>
+
+<ResponseField name="usage" type="object">
+  Represents token usage details including input tokens, output tokens,
+a breakdown of output tokens, and the total tokens used.
+</ResponseField>
+
+<ResponseField name="usage.input_tokens" type="integer" required>
+  The number of input tokens.
+</ResponseField>
+
+<ResponseField name="usage.input_tokens_details" type="object" required>
+  A detailed breakdown of the input tokens.
+</ResponseField>
+
+<ResponseField name="usage.input_tokens_details.cache_write_tokens" type="integer">
+  The number of input tokens that were written to the cache.
+</ResponseField>
+
+<ResponseField name="usage.input_tokens_details.cached_tokens" type="integer" required>
+  The number of tokens that were retrieved from the cache.
+[More on prompt caching](https://platform.openai.com/docs/guides/prompt-caching).
+</ResponseField>
+
+<ResponseField name="usage.output_tokens" type="integer" required>
+  The number of output tokens.
+</ResponseField>
+
+<ResponseField name="usage.output_tokens_details" type="object" required>
+  A detailed breakdown of the output tokens.
+</ResponseField>
+
+<ResponseField name="usage.output_tokens_details.reasoning_tokens" type="integer" required>
+  The number of reasoning tokens.
+</ResponseField>
+
+<ResponseField name="usage.total_tokens" type="integer" required>
+  The total number of tokens used.
+</ResponseField>
+
+<ResponseField name="user" type="string">
+  Deprecated identifier for the end-user. Replaced by `safety_identifier` and `prompt_cache_key`.
+</ResponseField>
+
+## Examples
+
+### Output
+
+```json
+{
+  "completed_at": 1767225601,
+  "created_at": 1767225600,
+  "id": "resp_0a1b2c3d4e5f6a7b8c9d0e1f",
+  "object": "response",
+  "output": [
+    {
+      "content": [
+        {
+          "annotations": [],
+          "text": "ok",
+          "type": "output_text"
+        }
+      ],
+      "id": "msg_0a1b2c3d4e5f6a7b8c9d0e1f",
+      "role": "assistant",
+      "status": "completed",
+      "type": "message"
+    }
+  ],
+  "output_text": "ok",
+  "status": "completed",
+  "usage": {
+    "input_tokens": 14,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 2,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 16
+  }
+}
+```
+
+
+<RouterCodeFooter />

--- a/development/comfy-router/models/recraft/recraftv2/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv2/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv2 \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv2/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv2/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv3/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv3/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv3 \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv3/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv3/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_pro_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-pro/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_pro \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_pro/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_utility_pro_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-pro/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_pro \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_utility_pro/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_utility_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-utility/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_utility \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_utility/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_utility/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-1/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-1/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_1 \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_1/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_1/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-pro/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_pro \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_pro/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_styles_pro_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-pro/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_pro \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_pro/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_styles_pro/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles-vector/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles_vector \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles_vector/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_styles_vector/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4-styles/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4_styles \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4_styles/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4_styles/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/development/comfy-router/models/recraft/recraftv4/code.mdx
+++ b/development/comfy-router/models/recraft/recraftv4/code.mdx
@@ -61,9 +61,63 @@ curl https://api.comfy.org/v2/models/recraft/recraftv4 \
 
 ### Input
 
-<Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/recraft/recraftv4/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Recraft unchanged, so [Recraft's own API reference](https://www.recraft.ai/docs) is authoritative for the request fields, and nothing is validated server side.
-</Note>
+<ParamField body="controls" type="object">
+  The controls for the generated image
+</ParamField>
+
+<ParamField body="controls.artistic_level" type="integer">
+  Defines artistic tone of your image. At a simple level, the person looks straight at the camera in a static and clean style. Dynamic and eccentric levels introduce movement and creativity.
+
+  Range: `0` to `5`
+</ParamField>
+
+<ParamField body="controls.background_color" type="object">
+  RGB color values
+</ParamField>
+
+<ParamField body="controls.background_color.rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.colors" type="object[]">
+  An array of preferable colors
+</ParamField>
+
+<ParamField body="controls.colors[].rgb" type="integer[]" required>
+   
+</ParamField>
+
+<ParamField body="controls.no_text" type="boolean">
+  Do not embed text layouts
+</ParamField>
+
+<ParamField body="model" type="string">
+  The model to use for generation (e.g., "recraftv3"). This field is NOT constrained to an enum: the proxy forwards whatever the caller sends. The spellings Comfy ships — the set Comfy Router addresses as `recraft/<model>` — are recraftv2, recraftv3, recraftv4, recraftv4_pro, recraftv4_1, recraftv4_1_utility, recraftv4_1_pro, recraftv4_1_utility_pro, recraftv4_styles, recraftv4_styles_pro, recraftv4_1_vector, recraftv4_1_utility_vector, recraftv4_1_pro_vector, recraftv4_1_utility_pro_vector, recraftv4_styles_vector and recraftv4_styles_pro_vector. They are written out here rather than named by reference because the RecraftGenerationModel component that declares them is `$ref`-ed by nothing and is therefore pruned from the spec served at GET /openapi, so a pointer to it would dangle in the served document. The four `recraftv4_styles*` spellings additionally require `style_id` — see that field.
+</ParamField>
+
+<ParamField body="n" type="integer">
+  The number of images to generate
+
+  Range: `1` to `6`
+</ParamField>
+
+<ParamField body="prompt" type="string" required>
+  The text prompt describing the image to generate
+</ParamField>
+
+<ParamField body="size" type="string">
+  The size of the generated image (e.g., "1024x1024")
+</ParamField>
+
+<ParamField body="style" type="string">
+  The style to apply to the generated image (e.g., "digital_illustration")
+</ParamField>
+
+<ParamField body="style_id" type="string">
+  The style ID to apply to the generated image (e.g., "123e4567-e89b-12d3-a456-426614174000"). If style_id is provided, style should not be provided. REQUIRED by the four `recraftv4_styles*` models: Recraft rejects those without a style_id or style reference. Mint one with `POST /proxy/recraft/styles`, which this same proxy serves under the same credentials. Nothing on this route enforces the pairing — the body is forwarded to Recraft unchanged, so a `recraftv4_styles*` call without it reaches the partner and comes back 4xx.
+</ParamField>
+
+Generated from the schema Router serves at `GET /v2/models/recraft/recraftv4/openapi.json`, the same document it validates a call against before the request reaches the provider.
 
 ### Output
 
@@ -88,6 +142,15 @@ Router has not published an authored input schema for this model yet: `GET /v2/m
 </ResponseField>
 
 ## Examples
+
+### Input
+
+```json
+{
+  "n": 1,
+  "prompt": "A single red maple leaf on a plain white background."
+}
+```
 
 ### Output
 

--- a/docs.json
+++ b/docs.json
@@ -3096,7 +3096,12 @@
                           "development/comfy-router/models/bria/image-edit-erase/code",
                           "development/comfy-router/models/bria/image-edit-expand/code",
                           "development/comfy-router/models/bria/image-edit-gen-fill/code",
-                          "development/comfy-router/models/bria/image-edit-remove-background/code"
+                          "development/comfy-router/models/bria/image-edit-increase-resolution/code",
+                          "development/comfy-router/models/bria/image-edit-remove-background/code",
+                          "development/comfy-router/models/bria/structured-instruction/code",
+                          "development/comfy-router/models/bria/video-edit-green-screen/code",
+                          "development/comfy-router/models/bria/video-edit-remove-background/code",
+                          "development/comfy-router/models/bria/video-edit-replace-background/code"
                         ]
                       },
                       {
@@ -3225,6 +3230,7 @@
                           "development/comfy-router/models/openai/gpt-5-mini/code",
                           "development/comfy-router/models/openai/gpt-5-nano/code",
                           "development/comfy-router/models/openai/gpt-5/code",
+                          "development/comfy-router/models/openai/gpt-6-astra/code",
                           "development/comfy-router/models/openai/gpt-image-1-5/code",
                           "development/comfy-router/models/openai/gpt-image-1/code",
                           "development/comfy-router/models/openai/gpt-image-2/code",


### PR DESCRIPTION
## ELI5

Some of these docs pages are not written by hand: a script reads Comfy Router's machine-readable model specs and stamps out one API-reference page per model. That script's output on `main` had fallen out of sync with the specs, so six models Router actually serves had no page for anyone to land on, and twenty existing pages described the wrong request fields. This re-runs the stamping machine so the published pages match what Router really accepts.

## Motivation

The Code Pages Freshness check exists to keep generated pages in lockstep with `router-schemas/`. That check ran red on #1608 — chore: sync Comfy API v2 specification and Comfy Router reference (cloud@5a81c69) — and the PR merged anyway, so `main` inherited the staleness and the check now fails for every subsequent PR that touches a watched path. Left alone it also means the docs site is missing pages for six live models and is publishing "Router has not published an authored input schema for this model yet" on sixteen Recraft pages that now do have authored schemas.

## Provenance

- **Authored by:** interactive session
- **Verified:** `bun .github/scripts/snippets/gen-code-pages.ts --check --validate` on `main` reproduced the failure (6 missing, 20 stale, plus `docs.json`), and after regeneration reports `163 code page(s) fresh (9 curated, 154 derived)`; `bun test ./.github/scripts/snippets/`: 16 pass, 0 fail; `bun .github/scripts/snippets/check-provider-schemas.ts --verbose`: 14 models checked, 0 errors, 263 warnings (warnings are pre-existing undocumented provider fields, not introduced here)
- **Deviations:** unknown — this was driven by the red check on `main` rather than a ticket with acceptance criteria

## Reviewer context

- **Type:** hygiene — regenerated output only, restoring `main` to green on Code Pages Freshness
- **Slots into:** follows #1608 — chore: sync Comfy API v2 specification and Comfy Router reference (cloud@5a81c69) and #1609 — fix(code-pages): report per-variant provider defaults instead of collapsing a oneOf last-wins; no epic
- **Not in scope:** why #1608 was able to merge with a required-looking check red. That is a branch-protection question, not a docs one.

## Summary

- Ran `bun .github/scripts/snippets/gen-code-pages.ts`. Nothing in `.github/scripts/`, `router-schemas/`, or the curated pages was hand-edited.
- Added six missing pages for models Comfy Router serves: `bria/image-edit-increase-resolution`, `bria/structured-instruction`, `bria/video-edit-green-screen`, `bria/video-edit-remove-background`, `bria/video-edit-replace-background`, `openai/gpt-6-astra`.
- Refreshed twenty stale pages: four `bria/image-edit-*` pages and sixteen `recraft/*` pages. The Recraft pages replace the "no authored input schema" note with the real `ParamField` input reference.
- Updated `docs.json` navigation to list the six new pages under their existing provider groups.

## Test plan

- [ ] Code Pages Freshness passes on this PR (`code-pages`, `snippet-script-tests`, `provider-schemas` jobs)
- [ ] Spot-check a new page renders: `development/comfy-router/models/openai/gpt-6-astra/code`
- [ ] Spot-check a refreshed page's input table: `development/comfy-router/models/recraft/recraftv4/code`
- [ ] Confirm the six new pages appear in site navigation under Bria and OpenAI
- [ ] No feature flag needed: generated documentation content only
