### PR TITLE
docs(custom-nodes): rewrite custom node backend docs to the V3 schema (en)

### DIFF
--- a/custom-nodes/backend/datatypes.mdx
+++ b/custom-nodes/backend/datatypes.mdx
@@ -1,96 +1,111 @@
 ---
 title: "ComfyUI Custom Node Datatypes"
-description: "Reference for ComfyUI custom node data types: Python types, tensor formats (IMAGE, LATENT, MASK), custom types, and wildcards in INPUT_TYPES."
+description: "Reference for ComfyUI custom node data types: Python types, tensor formats (IMAGE, LATENT, MASK), custom types, and wildcards for V3 custom nodes."
 ---
 
-These are the most important built in datatypes. You can also [define your own]( ./more_on_inputs#custom-datatypes).
+These are the most important built in datatypes. You can also [define your own](./more_on_inputs#custom-datatypes).
 
-Datatypes are used on the client side to prevent a workflow from passing the wrong form of data into a node - a bit like strong typing.
-The JavaScript client side code will generally not allow a node output to be connected to an input of a different datatype,
-although a few exceptions are noted below.
+In the V3 schema every datatype is a class in the `io` module, such as `io.Image` or `io.Int`. You declare
+an input with its `.Input(...)` constructor and an output with `.Output(...)`. See the
+[V3 Migration guide](/custom-nodes/v3_migration) for the full mapping between the V1 type strings and the
+`io` classes.
+
+Datatypes are used on the client side to prevent a workflow from passing the wrong form of data into a
+node - a bit like strong typing. The JavaScript client side code will generally not allow a node output to
+be connected to an input of a different datatype, although a few exceptions are noted below.
 
 ## Comfy datatypes
 
 ### COMBO
 
-* No additional parameters in `INPUT_TYPES`
+`io.Combo` represents a dropdown menu widget. The value of the input is a `str`; the widget options are
+provided with the `options` parameter.
 
-* Python datatype: defined as `list[str]`, output value is `str`
-
-Represents a dropdown menu widget.
-Unlike other datatypes, `COMBO` it is not specified in `INPUT_TYPES` by a `str`, but by a `list[str]`
-corresponding to the options in the dropdown list, with the first option selected by default.
-
-`COMBO` inputs are often dynamically generated at run time. For instance, in the built-in `CheckpointLoaderSimple` node, you find
-
-```
-"ckpt_name": (folder_paths.get_filename_list("checkpoints"), )
+```python
+io.Combo.Input("play_sound", options=["no", "yes"])
 ```
 
-or they might just be a fixed list of options,
+`COMBO` inputs are often dynamically generated at run time. Because `define_schema` is a class method, the
+options can be computed when the node is loaded. For instance, a checkpoint loader node might do:
 
+```python
+io.Combo.Input("ckpt_name", options=folder_paths.get_filename_list("checkpoints"))
 ```
-"play_sound": (["no","yes"], {}),
-```
+
+There is also `io.MultiCombo` for dropdowns where more than one option can be selected; its value is a
+`list[str]`.
 
 ### Primitive and reroute
 
-Primitive and reroute nodes only exist on the client side. They do not have an intrinsic datatype, but when connected they take on
-the datatype of the input or output to which they have been connected (which is why they can't connect to a `*` input...)
+Primitive and reroute nodes only exist on the client side. They do not have an intrinsic datatype, but
+when connected they take on the datatype of the input or output to which they have been connected (which
+is why they can't connect to a `*` input...)
 
 ## Python datatypes
 
 ### INT
 
-* Additional parameters in `INPUT_TYPES`:
+`io.Int` is an integer widget input.
 
-  * `default` is required
+* Parameters: `default`, `min`, `max`, `step` (all optional)
 
-  * `min` and `max` are optional
+* Python datatype: `int`
 
-* Python datatype `int`
+```python
+io.Int.Input("count", default=1, min=0, max=4096, step=1)
+```
 
 ### FLOAT
 
-* Additional parameters in `INPUT_TYPES`:
+`io.Float` is a float widget input.
 
-  * `default` is required
+* Parameters: `default`, `min`, `max`, `step` (all optional)
 
-  * `min`, `max`, `step` are optional
+* Python datatype: `float`
 
-* Python datatype `float`
+```python
+io.Float.Input("strength", default=1.0, min=0.0, max=10.0, step=0.1)
+```
 
 ### STRING
 
-* Additional parameters in `INPUT_TYPES`:
+`io.String` is a text widget input.
 
-  * `default` is required
+* Parameters: `default`, `multiline`, `placeholder`, `dynamic_prompts` (all optional)
 
-* Python datatype `str`
+* Python datatype: `str`
+
+```python
+io.String.Input("text", default="Hello", multiline=True)
+```
 
 ### BOOLEAN
 
-* Additional parameters in `INPUT_TYPES`:
+`io.Boolean` is a toggle widget input.
 
-  * `default` is required
+* Parameters: `default`, `label_on`, `label_off` (all optional)
 
-* Python datatype `bool`
+* Python datatype: `bool`
+
+```python
+io.Boolean.Input("enabled", default=True, label_on="On", label_off="Off")
+```
 
 ## Tensor datatypes
 
 ### IMAGE
 
-* No additional parameters in `INPUT_TYPES`
+* Declared with `io.Image.Input(...)`
 
-* Python datatype `torch.Tensor` with *shape* \[B,H,W,C]
+* Python datatype: `torch.Tensor` with *shape* \[B,H,W,C]
 
 A batch of `B` images, height `H`, width `W`, with `C` channels (generally `C=3` for `RGB`).
 
 ### LATENT
 
-* No additional parameters in `INPUT_TYPES`
+* Declared with `io.Latent.Input(...)`
 
-* Python datatype `dict`, containing a `torch.Tensor` with *shape* \[B,C,H,W]
+* Python datatype: `dict`, containing a `torch.Tensor` with *shape* \[B,C,H,W]
 
 The `dict` passed contains the key `samples`, which is a `torch.Tensor` with *shape* \[B,C,H,W] representing
 a batch of `B` latents, with `C` channels (generally `C=4` for existing stable diffusion models), height `H`, width `W`.
@@ -105,15 +120,15 @@ Other entries in the dictionary contain things like latent masks.
 
 ### MASK
 
-* No additional parameters in `INPUT_TYPES`
+* Declared with `io.Mask.Input(...)`
 
-* Python datatype `torch.Tensor` with *shape* \[H,W] or \[B,C,H,W]
+* Python datatype: `torch.Tensor` with *shape* \[H,W] or \[B,C,H,W]
 
 ### AUDIO
 
-* No additional parameters in `INPUT_TYPES`
+* Declared with `io.Audio.Input(...)`
 
-* Python datatype `dict`, containing a `torch.Tensor` with *shape* \[B, C, T] and a sample rate.
+* Python datatype: `dict`, containing a `torch.Tensor` with *shape* \[B, C, T] and a sample rate.
 
 The `dict` passed contains the key `waveform`, which is a `torch.Tensor` with *shape* \[B, C, T] representing a batch of `B` audio samples, with `C` channels (`C=2` for stereo and `C=1` for mono), and `T` time steps (i.e., the number of audio samples).
 
@@ -165,29 +180,35 @@ The `__call__` method takes (in `args[0]`) a batch of noisy latents (tensor `[B,
 
 ## Model datatypes
 
-There are a number of more technical datatypes for stable diffusion models. The most significant ones are `MODEL`, `CLIP`, `VAE` and `CONDITIONING`.
+There are a number of more technical datatypes for stable diffusion models. The most significant ones are `io.Model`, `io.CLIP`,
+`io.VAE` and `io.Conditioning`.
 Working with these is (for the time being) beyond the scope of this guide! {/* TODO but maybe not forever */}
 
 ## Additional Parameters
 
-Below is a list of officially supported keys that can be used in the 'extra options' portion of an input definition.
+The `Input` constructors of the widget datatypes accept a number of optional parameters that configure the
+widget. Below is a list of the officially supported parameters. (The legacy V1 schema spelled these as keys
+in the input options dictionary, e.g. `forceInput` and `rawLink`; in V3 they are snake_case parameters of
+the `Input` constructors.)
 
-<Warning>You can use additional keys for your own custom widgets, but should *not* reuse any of the keys below for other purposes.</Warning>
+<Warning>You can use additional keys for your own custom widgets, but should *not* reuse any of the parameters below for other purposes.</Warning>
 
-{/* TODO -- did I actually get everything? */}
-
-| Key              | Description                                                                                                                                                                                                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default`        | The default value of the widget                                                                                                                                                                            |
-| `min`            | The minimum value of a number (`FLOAT` or `INT`)                                                                                                                                                           |
-| `max`            | The maximum value of a number (`FLOAT` or `INT`)                                                                                                                                                           |
-| `step`           | The amount to increment or decrement a widget                                                                                                                                                              |
-| `label_on`       | The label to use in the UI when the bool is `True` (`BOOL`)                                                                                                                                                |
-| `label_off`      | The label to use in the UI when the bool is `False` (`BOOL`)                                                                                                                                               |
-| `defaultInput`   | Defaults to an input socket rather than a supported widget                                                                                                                                                 |
-| `forceInput`     | `defaultInput` and also don't allow converting to a widget                                                                                                                                                 |
-| `multiline`      | Use a multiline text box (`STRING`)                                                                                                                                                                        |
-| `placeholder`    | Placeholder text to display in the UI when empty (`STRING`)                                                                                                                                                |
-| `dynamicPrompts` | Causes the front-end to evaluate dynamic prompts                                                                                                                                                           |
-| `lazy`           | Declares that this input uses [Lazy Evaluation](./lazy_evaluation)                                                                                                                               |
-| `rawLink`        | When a link exists, rather than receiving the evaluated value, you will receive the link (i.e. `["nodeId", <outputIndex>]`). Primarily useful when your node uses [Node Expansion](./expansion). |
+| Parameter             | Applies to                | Description                                                                                                                   |
+| --------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `default`             | widget inputs             | The default value of the widget                                                                                               |
+| `min`                 | `io.Int`, `io.Float`      | The minimum value of the widget                                                                                               |
+| `max`                 | `io.Int`, `io.Float`      | The maximum value of the widget                                                                                               |
+| `step`                | `io.Int`, `io.Float`      | The amount to increment or decrement a widget                                                                                  |
+| `multiline`           | `io.String`               | Use a multiline text box                                                                                                      |
+| `placeholder`         | `io.String`               | Placeholder text to display in the UI when empty                                                                               |
+| `dynamic_prompts`     | `io.String`               | Causes the front-end to evaluate dynamic prompts                                                                               |
+| `options`             | `io.Combo`, `io.MultiCombo` | The dropdown options                                                                                                        |
+| `label_on`, `label_off` | `io.Boolean`            | The labels to use in the UI when the bool is `True` / `False`                                                                  |
+| `control_after_generate` | `io.Int`, `io.Combo`    | Adds a "control after generate" widget (pass `True`, or an `io.ControlAfterGenerate` enum value)                              |
+| `socketless`          | widget inputs             | Hide the input socket, so the widget cannot be connected to an upstream node                                                   |
+| `force_input`         | widget inputs             | Display the input as a socket instead of a widget, and don't allow converting it back to a widget                              |
+| `optional`            | all inputs                | Declares the input optional, so it does not have to be connected                                                               |
+| `lazy`                | all inputs                | Declares that this input uses [Lazy Evaluation](./lazy_evaluation)                                                            |
+| `raw_link`            | all inputs                | When a link exists, rather than receiving the evaluated value, you will receive the link (i.e. `["nodeId", <outputIndex>]`). Primarily useful when your node uses [Node Expansion](./expansion). |
+| `tooltip`             | all inputs                | Tooltip text to display when hovering over the input                                                                           |
+| `advanced`            | all inputs                | Hides the input behind an "Advanced" toggle in the UI                                                                          |

--- a/custom-nodes/backend/interface.mdx
+++ b/custom-nodes/backend/interface.mdx
@@ -11,29 +11,38 @@ If you prefer to read code, check out the [example](https://github.com/Comfy-Org
 
 ## Interface
 
-Let's examine the interface of a custom node by looking at ComfyUI's built-in [Load Checkpoint](https://github.com/Comfy-Org/ComfyUI/blob/master/nodes.py#L529C7-L529C29) node. This loads a checkpoint file.
+Let's examine the interface of a custom node by looking at the bundled example node.
 
 ### Functions
 
 Every custom node can implement the following methods.
 
-#### INPUT_TYPES
+#### define_schema
 
-This defines the parameters that the custom node can take as an input.
+This defines the parameters that the custom node can take as input, and which outputs it produces.
 
 ```python
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "ckpt_name": (folder_paths.
-            get_filename_list("checkpoints"),),
-        }}
+from comfy_api.latest import io
+
+@classmethod
+def define_schema(cls) -> io.Schema:
+    return io.Schema(
+        node_id="ExampleNode",
+        display_name="Example Node",
+        category="examples",
+        inputs=[
+            io.Image.Input("image"),
+            io.String.Input("text", multiline=True, default="Hello"),
+        ],
+        outputs=[
+            io.Image.Output(),
+        ],
+    )
 ```
 
-Here you can see that input types is defined as a dictionary in Python. You can define inputs as `required`, `hidden`, or `optional`.
+Here you can see that inputs and outputs are defined by `io` objects. You can define inputs as `optional=True`, or request [hidden inputs](./more_on_inputs#hidden-inputs).
 
-Each input must have a type (eg. VAE). If you use one of the special built-in types: `INT`, `STRING`, or `FLOAT`, then they can be lists.
+Each input has a type (eg. `io.Image`). Widget inputs: `io.Int`, `io.String`, `io.Float`, `io.Boolean` and `io.Combo`, can also have `default`, `min`, `max`, `step` and other options.
 
 <Accordion title="Optional Fields">
 
@@ -47,59 +56,77 @@ Each input must have a type (eg. VAE). If you use one of the special built-in ty
 
 </Accordion>
 
-#### IS_CHANGED
+#### fingerprint_inputs
 
 Optional. Allows the node to control when it is re-executed. ComfyUI attempts to only execute nodes that have changed in order to be more efficient.
 
+#### validate_inputs
+
+Optional. Allows the node to validate its inputs before execution.
+
+#### check_lazy_status
+
+Optional. Allows the node to defer evaluation of lazy inputs.
+
 ### Attributes
 
-#### RETURN_TYPES
+Attributes are properties of the node, and are defined in the `io.Schema` returned by `define_schema`.
 
-Tuple. The type of each element in the output tuple.
+#### outputs
+
+The types of each output.
 
 ```python
-RETURN_TYPES = ("MODEL", "CLIP", "VAE")
+outputs=[
+    io.Model.Output(),
+    io.CLIP.Output(),
+    io.VAE.Output(),
+]
 ```
 
-#### RETURN_NAMES
+#### display_name
 
-Optional: The name of each output in the output tuple.
+Optional: The friendly name of the node shown in the UI.
 
 ```python
-CATEGORY = "loaders"
+display_name="Load Checkpoint",
 ```
 
-#### FUNCTION
+#### category
 
-The name of the Python function in the custom node class to call.
-
-For LoadCheckpointSimple, the function is defined like this:
+The category in which the node appears in the UI.
 
 ```python
-FUNCTION = "load_checkpoint"
+category="loaders",
 ```
 
 #### Entry Point Function
 
-This Python function is called when the node is invoked. Needs to match the string under FUNCTION.
+The execution method is fixed to `execute` and is a class method:
 
 ```python
-def load_checkpoint(self, ckpt_name, output_vae=True, output_clip=True):
-        ckpt_path = folder_paths.get_full_path("checkpoints", ckpt_name)
-        out = comfy.sd.load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, embedding_directory=folder_paths.get_folder_paths("embeddings"))
-        return out[:3]
+@classmethod
+def execute(cls, image) -> io.NodeOutput:
+    # do some processing
+    return io.NodeOutput(result)
 ```
 
-#### OUTPUT_NODE
+#### Registering the node
 
-Bool. Defaults to False. Set to true if your node will output a result/image from the graph.
-
-#### CATEGORY
-
-String. The category you want the node to appear under the UI.
+Instead of dictionaries, custom nodes are registered through a `ComfyExtension` and a module-level `comfy_entrypoint` function:
 
 ```python
-CATEGORY = "loaders"
+from comfy_api.latest import ComfyExtension, io
+
+class ExampleExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            ExampleNode,
+            # add more nodes here
+        ]
+
+async def comfy_entrypoint() -> ExampleExtension:
+    return ExampleExtension()
 ```
 
 #### WEB_DIRECTORY
@@ -109,23 +136,3 @@ Custom nodes can have custom UI.
 This attribute sets the web directory. Any `.js` file in that directory will be loaded as a frontend extension.
 
 Custom nodes can also include markdown documentation in the `WEB_DIRECTORY/docs` folder. See the [Help Page](/custom-nodes/help_page) section for details on how to add rich documentation for your nodes.
-
-#### NODE_CLASS_MAPPINGS
-
-A dictionary that contains all nodes you want to export along with their class names. Class names should be unique. This also means you can define multiple nodes in one "custom node" and export them all together.
-
-```python
-NODE_CLASS_MAPPINGS = {
-    "CheckpointLoaderSimple": CheckpointLoaderSimple,
-}
-```
-
-#### NODE_DISPLAY_NAME_MAPPINGS
-
-If you want to define more human-readable names for each node.
-
-```python
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "CheckpointLoaderSimple": "Load Checkpoint",
-}
-```

--- a/custom-nodes/backend/lazy_evaluation.mdx
+++ b/custom-nodes/backend/lazy_evaluation.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Lazy Evaluation"
-description: "Learn how lazy evaluation works in ComfyUI (v0.2.0+). Discover how to defer input evaluation, optimize VRAM usage, and implement lazy: True in custom nodes."
+description: "Learn how lazy evaluation works in ComfyUI (v0.2.0+). Discover how to defer input evaluation, optimize VRAM usage, and implement lazy inputs in V3 custom nodes."
 ---
 
 ## Lazy Evaluation
 
-By default, all `required` and `optional` inputs are evaluated before a node can be run. Sometimes, however, an
-input won't necessarily be used and evaluating it would result in unnecessary processing. Here are some examples
-of nodes where lazy evaluation may be beneficial:
-1. A `ModelMergeSimple` node where the ratio is either `0.0` (in which case the first model doesn't need to be loaded)
-or `1.0` (in which case the second model doesn't need to be loaded).
+By default, all inputs are evaluated before a node can be run. Sometimes, however, an input won't
+necessarily be used and evaluating it would result in unnecessary processing. Here are some examples of
+nodes where lazy evaluation may be beneficial:
+
+1. A `ModelMergeSimple` node where the ratio is either `0.0` (in which case the first model doesn't need to be loaded) or `1.0` (in which case the second model doesn't need to be loaded).
 2. Interpolation between two images where the ratio (or mask) is either entirely `0.0` or entirely `1.0`.
 3. A Switch node where one input determines which of the other inputs will be passed through.
 
@@ -19,128 +19,162 @@ or `1.0` (in which case the second model doesn't need to be loaded).
 
 There are two steps to making an input a "lazy" input. They are:
 
-1. Mark the input as lazy in the dictionary returned by `INPUT_TYPES`
-2. Define a method named `check_lazy_status` (note: *not* a class method) that will be called prior to evaluation to determine if any more inputs are necessary.
+1. Mark the input as lazy in the schema, by passing `lazy=True` to its `Input` definition
+2. Define a class method named `check_lazy_status` that will be called prior to evaluation to determine if any more inputs are necessary.
 
-To demonstrate these, we'll make a "MixImages" node that interpolates between two images according to a mask. If the entire mask is `0.0`, we don't need to evaluate any part of the tree leading up to the second image. If the entire mask is `1.0`, we can skip evaluating the first image.
+To demonstrate these, we'll make a "MixImages" node that interpolates between two images according to a
+mask. If the entire mask is `0.0`, we don't need to evaluate any part of the tree leading up to the second
+image. If the entire mask is `1.0`, we can skip evaluating the first image.
 
-#### Defining `INPUT_TYPES`
+#### Defining the schema
 
-Declaring that an input is lazy is as simple as adding a `lazy: True` key-value pair to the input's options dictionary.
+Declaring that an input is lazy is as simple as passing `lazy=True` to the input's definition.
 
 ```python
-@classmethod
-def INPUT_TYPES(cls):
-    return {
-        "required": {
-            "image1": ("IMAGE",{"lazy": True}),
-            "image2": ("IMAGE",{"lazy": True}),
-            "mask": ("MASK",),
-        },
-    }
+from comfy_api.latest import io
+
+
+class LazyMixImages(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="LazyMixImages",
+            display_name="Lazy Mix Images",
+            category="examples",
+            inputs=[
+                io.Image.Input("image1", lazy=True),
+                io.Image.Input("image2", lazy=True),
+                io.Mask.Input("mask"),
+            ],
+            outputs=[
+                io.Image.Output(),
+            ],
+        )
 ```
 
 In this example, `image1` and `image2` are both marked as lazy inputs, but `mask` will always be evaluated.
 
 #### Defining `check_lazy_status`
 
-A `check_lazy_status` method is called if there are one or more lazy inputs that are not yet available. This method receives the same arguments as the standard execution function. All available inputs are passed in with their final values while unavailable lazy inputs have a value of `None`.
+A `check_lazy_status` method is called if there are one or more lazy inputs that are not yet available. It
+receives the same arguments as `execute`. All available inputs are passed in with their final values while
+unavailable lazy inputs have a value of `None`.
 
-The responsibility of the `check_lazy_status` function is to return a list of the names of any lazy inputs that are needed to proceed. If all lazy inputs are available, the function should return an empty list.
+The responsibility of `check_lazy_status` is to return a list of the names of any lazy inputs that are
+needed to proceed. If all lazy inputs are available, the function should return an empty list.
 
-Note that `check_lazy_status` may be called multiple times. (For example, you might find after evaluating one lazy input that you need to evaluate another.)
+Note that `check_lazy_status` may be called multiple times. (For example, you might find after evaluating
+one lazy input that you need to evaluate another.)
 
-<Tip>Note that because the function uses actual input values, it is *not* a class method.</Tip>
+<Tip>In V3 `check_lazy_status` is a class method, like `execute`. (In the legacy V1 schema it was a plain method.)</Tip>
+
 ```python
-def check_lazy_status(self, mask, image1, image2):
-    mask_min = mask.min()
-    mask_max = mask.max()
+@classmethod
+def check_lazy_status(cls, mask, image1=None, image2=None):
+    mask_min = float(mask.min())
+    mask_max = float(mask.max())
     needed = []
-    if image1 is None and (mask_min != 1.0 or mask_max != 1.0):
+    if image1 is None and not (mask_min == 1.0 and mask_max == 1.0):
         needed.append("image1")
-    if image2 is None and (mask_min != 0.0 or mask_max != 0.0):
+    if image2 is None and not (mask_min == 0.0 and mask_max == 0.0):
         needed.append("image2")
     return needed
+
+@classmethod
+def execute(cls, mask, image1=None, image2=None) -> io.NodeOutput:
+    mask_min = float(mask.min())
+    mask_max = float(mask.max())
+    if mask_min == 0.0 and mask_max == 0.0:
+        return io.NodeOutput(image1)
+    if mask_min == 1.0 and mask_max == 1.0:
+        return io.NodeOutput(image2)
+    # Not trying to handle different batch sizes here just to keep the demo simple
+    return io.NodeOutput(image1 * (1.0 - mask) + image2 * mask)
 ```
 
 ### Full Example
 
-
 ```python
-class LazyMixImages:
+from comfy_api.latest import ComfyExtension, io
+
+
+class LazyMixImages(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "image1": ("IMAGE",{"lazy": True}),
-                "image2": ("IMAGE",{"lazy": True}),
-                "mask": ("MASK",),
-            },
-        }
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="LazyMixImages",
+            display_name="Lazy Mix Images",
+            category="examples",
+            inputs=[
+                io.Image.Input("image1", lazy=True),
+                io.Image.Input("image2", lazy=True),
+                io.Mask.Input("mask"),
+            ],
+            outputs=[
+                io.Image.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "mix"
-
-    CATEGORY = "Examples"
-
-    def check_lazy_status(self, mask, image1, image2):
-        mask_min = mask.min()
-        mask_max = mask.max()
+    @classmethod
+    def check_lazy_status(cls, mask, image1=None, image2=None):
+        mask_min = float(mask.min())
+        mask_max = float(mask.max())
         needed = []
-        if image1 is None and (mask_min != 1.0 or mask_max != 1.0):
+        if image1 is None and not (mask_min == 1.0 and mask_max == 1.0):
             needed.append("image1")
-        if image2 is None and (mask_min != 0.0 or mask_max != 0.0):
+        if image2 is None and not (mask_min == 0.0 and mask_max == 0.0):
             needed.append("image2")
         return needed
 
-    # Not trying to handle different batch sizes here just to keep the demo simple
-    def mix(self, mask, image1, image2):
-        mask_min = mask.min()
-        mask_max = mask.max()
+    @classmethod
+    def execute(cls, mask, image1=None, image2=None) -> io.NodeOutput:
+        mask_min = float(mask.min())
+        mask_max = float(mask.max())
         if mask_min == 0.0 and mask_max == 0.0:
-            return (image1,)
-        elif mask_min == 1.0 and mask_max == 1.0:
-            return (image2,)
+            return io.NodeOutput(image1)
+        if mask_min == 1.0 and mask_max == 1.0:
+            return io.NodeOutput(image2)
+        # Not trying to handle different batch sizes here just to keep the demo simple
+        return io.NodeOutput(image1 * (1.0 - mask) + image2 * mask)
 
-        result = image1 * (1. - mask) + image2 * mask,
-        return (result[0],)
+
+class ExampleExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [LazyMixImages]
+
+
+async def comfy_entrypoint() -> ExampleExtension:
+    return ExampleExtension()
 ```
 
 ## Execution Blocking
 
-While Lazy Evaluation is the recommended way to "disable" part of a graph, there are times when you want to disable an `OUTPUT` node that doesn't implement lazy evaluation itself. If it's an output node that you developed yourself, you should just add lazy evaluation as follows:
+While Lazy Evaluation is the recommended way to "disable" part of a graph, there are times when you want to
+disable a node that doesn't implement lazy evaluation itself. If it's an output node that you developed
+yourself, you should just add lazy evaluation as follows:
 
 1. Add a required (if this is a new node) or optional (if you care about backward compatibility) input for `enabled` that defaults to `True`
-2. Make all other inputs `lazy` inputs
+2. Make all other inputs lazy inputs
 3. Only evaluate the other inputs if `enabled` is `True`
 
-If it's not a node you control, you can make use of a `comfy_execution.graph.ExecutionBlocker`. This special object can be returned as an output from any socket. Any nodes which receive an `ExecutionBlocker` as input will skip execution and return that `ExecutionBlocker` for any outputs.
-
-<Tip>**There is intentionally no way to stop an ExecutionBlocker from propagating forward.** If you think you want this, you should really be using Lazy Evaluation.</Tip>
-
-### Usage
-
-There are two ways to construct and use an `ExecutionBlocker`
-
-1. Pass `None` into the constructor to silently block execution. This is useful for cases where blocking execution is part of a successful run -- like disabling an output.
-```python
-def silent_passthrough(self, passthrough, blocked):
-    if blocked:
-        return (ExecutionBlocker(None),)
-    else:
-        return (passthrough,)
-```
-
-2. Pass a string into the constructor to display an error message when a node is blocked due to receiving the object. This can be useful if you want to display a meaningful error message if someone uses a meaningless output -- for example, the `VAE` output when loading a model that doesn't contain VAEs.
+To block execution from a node whose output may be invalid or meaningless, return an
+`io.NodeOutput` with a `block_execution` message. Comfy replaces every output of the node with an
+`ExecutionBlocker` carrying that message. Any nodes which receive an `ExecutionBlocker` as input will skip
+execution and return that `ExecutionBlocker` for any outputs, so the message is reported to the user when a
+blocked output is actually used.
 
 ```python
-def load_checkpoint(self, ckpt_name):
+@classmethod
+def execute(cls, ckpt_name) -> io.NodeOutput:
     ckpt_path = folder_paths.get_full_path("checkpoints", ckpt_name)
     model, clip, vae = load_checkpoint(ckpt_path)
     if vae is None:
         # This error is more useful than a "'NoneType' has no attribute" error
         # in a later node
-        vae = ExecutionBlocker(f"No VAE contained in the loaded model {ckpt_name}")
-    return (model, clip, vae)
+        return io.NodeOutput(
+            block_execution=f"No VAE contained in the loaded model {ckpt_name}"
+        )
+    return io.NodeOutput(model, clip, vae)
 ```
 
+<Tip>**There is intentionally no way to stop an ExecutionBlocker from propagating forward.** If you think you want this, you should really be using Lazy Evaluation.</Tip>

--- a/custom-nodes/backend/lazy_evaluation.mdx
+++ b/custom-nodes/backend/lazy_evaluation.mdx
@@ -60,6 +60,10 @@ A `check_lazy_status` method is called if there are one or more lazy inputs that
 receives the same arguments as `execute`. All available inputs are passed in with their final values while
 unavailable lazy inputs have a value of `None`.
 
+<Note>When a lazy input was defined with `INPUT_IS_LIST = True`, an unevaluated input is passed to
+`check_lazy_status` as `(None,)` rather than `None`, so an `is None` check would miss it. Instead, check for
+the `(None,)` sentinel to ensure required inputs are not omitted.</Note>
+
 The responsibility of `check_lazy_status` is to return a list of the names of any lazy inputs that are
 needed to proceed. If all lazy inputs are available, the function should return an empty list.
 

--- a/custom-nodes/backend/lifecycle.mdx
+++ b/custom-nodes/backend/lifecycle.mdx
@@ -10,8 +10,8 @@ A module is treated as an extension when it exports a `comfy_entrypoint` functio
 `NODE_CLASS_MAPPINGS` dictionary (the legacy V1 schema). See the
 [V3 Migration guide](/custom-nodes/v3_migration) for the differences between the two.
 
-<Tip>A python module is a directory containing an `__init__.py` file.
-The module exports whatever is listed in the `__all__` attribute defined in `__init__.py`.</Tip>
+<Tip>A custom-node package is a directory containing an `__init__.py` file.
+`__all__` affects wildcard imports only and does not control custom-node discovery.</Tip>
 
 ### __init__.py
 

--- a/custom-nodes/backend/lifecycle.mdx
+++ b/custom-nodes/backend/lifecycle.mdx
@@ -1,43 +1,74 @@
 ---
 title: "Lifecycle"
-description: "Understand how ComfyUI loads custom nodes via init.py, including NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS, and WEB_DIRECTORY for deploying client-side JavaScript."
+description: "Understand how ComfyUI loads custom nodes: the comfy_entrypoint function and ComfyExtension class that register V3 nodes, plus WEB_DIRECTORY for deploying client-side JavaScript."
 ---
 
 ## How Comfy loads custom nodes
 
-When Comfy starts, it scans the directory `custom_nodes` for Python modules, and attempts to load them. 
-If the module exports `NODE_CLASS_MAPPINGS`, it will be treated as a custom node.
-<Tip>A python module is a directory containing an `__init__.py` file. 
+When Comfy starts, it scans the directory `custom_nodes` for Python modules, and attempts to load them.
+A module is treated as an extension when it exports a `comfy_entrypoint` function (the V3 schema) or a
+`NODE_CLASS_MAPPINGS` dictionary (the legacy V1 schema). See the
+[V3 Migration guide](/custom-nodes/v3_migration) for the differences between the two.
+
+<Tip>A python module is a directory containing an `__init__.py` file.
 The module exports whatever is listed in the `__all__` attribute defined in `__init__.py`.</Tip>
 
 ### __init__.py
 
-`__init__.py` is executed when Comfy attempts to import the module. For a module to be recognized as containing
-custom node definitions, it needs to export `NODE_CLASS_MAPPINGS`. If it does (and if nothing goes wrong in the import),
-the nodes defined in the module will be available in Comfy. If there is an error in your code, 
-Comfy will continue, but will report the module as having failed to load. So check the Python console!
+`__init__.py` is executed when Comfy attempts to import the module. If the import succeeds, Comfy calls
+the module's `comfy_entrypoint` function, which returns a `ComfyExtension` instance. The extension's
+`get_node_list` method provides the node classes defined by the module, and those nodes become available
+in Comfy. If there is an error in your code, Comfy will continue, but will report the module as having
+failed to load. So check the Python console!
 
 A very simple `__init__.py` file would look like this:
+
 ```python
+from comfy_api.latest import ComfyExtension
+
 from .python_file import MyCustomNode
-NODE_CLASS_MAPPINGS = { "My Custom Node" : MyCustomNode }
-__all__ = ["NODE_CLASS_MAPPINGS"]
+
+
+class MyExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[MyCustomNode]]:
+        return [MyCustomNode]
+
+
+async def comfy_entrypoint() -> MyExtension:
+    return MyExtension()
 ```
 
-#### NODE_CLASS_MAPPINGS
+#### comfy_entrypoint
 
-`NODE_CLASS_MAPPINGS` must be a `dict` mapping custom node names (unique across the Comfy install) 
-to the corresponding node class. 
+`comfy_entrypoint` is the function Comfy calls to discover the nodes in your module. It may be declared
+`async` or not, but it must return an instance of `ComfyExtension`. The `get_node_list` method on the
+extension must be `async`, and returns the list of node classes the extension provides.
 
-#### NODE_DISPLAY_NAME_MAPPINGS
+The `node_id` of each node (its unique name across the Comfy install) and its display name, category and
+other properties are defined in the node class's `define_schema` method, rather than in the
+`__init__.py`. See [Properties](./server_overview) for the schema fields.
 
-`__init__.py` may also export `NODE_DISPLAY_NAME_MAPPINGS`, which maps the same unique name to a display name for the node.
-If `NODE_DISPLAY_NAME_MAPPINGS` is not provided, Comfy will use the unique name as the display name.
+#### NODE_CLASS_MAPPINGS (legacy V1)
+
+Modules written against the legacy V1 schema can still export `NODE_CLASS_MAPPINGS`, a `dict` mapping
+each custom node name (unique across the Comfy install) to its node class. Comfy loads those modules
+without calling `comfy_entrypoint`.
+
+```python
+from .python_file import MyCustomNode
+NODE_CLASS_MAPPINGS = {"MyCustomNode": MyCustomNode}
+```
+
+`NODE_DISPLAY_NAME_MAPPINGS` was the legacy way to give a node a display name different from its unique
+name. In V3 this is done with the `display_name` field of the schema.
 
 #### WEB_DIRECTORY
 
-If you are deploying client side code, you will also need to export the path, relative to the module, in which the 
-JavaScript files are to be found. It is conventional to place these in a subdirectory of your custom node named `js`.
+If you are deploying client side code, you will also need to export the path, relative to the module, in
+which the JavaScript files are to be found. It is conventional to place these in a subdirectory of your
+custom node named `js`. Comfy also registers a web directory automatically when your `pyproject.toml`
+contains a `[tool.comfy]` section with a `web` key pointing at one.
+
 <Tip>*Only* `.js` files will be served; you can't deploy `.css` or other types in this way</Tip>
 
 <Warning>In previous versions of Comfy, `__init__.py` was required to copy the JavaScript files into the main Comfy web

--- a/custom-nodes/backend/lists.mdx
+++ b/custom-nodes/backend/lists.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Data lists"
-description: "Learn how ComfyUI handles data as Python lists internally, including length-one processing, list processing for batches, and how to use INPUT_IS_LIST and OUTPUT_IS_LIST when developing custom nodes."
+description: "Learn how ComfyUI handles data as Python lists internally, including length-one processing, list processing for batches, and how to use the V3 is_input_list and is_output_list schema options when developing custom nodes."
 ---
 
 ## Length one processing
 
-Internally, the Comfy server represents data flowing from one node to the next as a Python `list`, normally length 1, of the relevant datatype.
-In normal operation, when a node returns an output, each element in the output `tuple` is separately wrapped in a list (length 1); then when the 
-next node is called, the data is unwrapped and passed to the main function.
+Internally, the Comfy server represents data flowing from one node to the next as a Python `list`, normally
+length 1, of the relevant datatype. In normal operation, when a node returns an output, each element in the
+output is separately wrapped in a list (length 1); then when the next node is called, the data is unwrapped
+and passed to the `execute` method.
 
 <Tip>You generally don't need to worry about this, since Comfy does the wrapping and unwrapping.</Tip>
 
@@ -15,44 +16,58 @@ next node is called, the data is unwrapped and passed to the main function.
 
 ## List processing
 
-In some circumstance, multiple data instances are processed in a single workflow, in which case the internal data will be a list containing the data instances.
-An example of this might be processing a series of images one at a time to avoid running out of VRAM, or handling images of different sizes.
+In some circumstance, multiple data instances are processed in a single workflow, in which case the internal
+data will be a list containing the data instances. An example of this might be processing a series of images
+one at a time to avoid running out of VRAM, or handling images of different sizes.
 
-By default, Comfy will process the values in the list sequentially: 
+By default, Comfy will process the values in the list sequentially:
+
 - if the inputs are `list`s of different lengths, the shorter ones are padded by repeating the last value
-- the main method is called once for each value in the input lists
+- the `execute` method is called once for each value in the input lists
 - the outputs are `list`s, each of which is the same length as the longest input
 
 The relevant code can be found in the method `map_node_over_list` in `execution.py`.
 
-However, as Comfy wraps node outputs into a `list` of length one, if the `tuple` returned by
-a custom node contains a `list`, that `list` will be wrapped, and treated as a single piece of data.
-In order to tell Comfy that the list being returned should not be wrapped, but treated as a series of data for sequential processing, 
-the node should provide a class attribute `OUTPUT_IS_LIST`, which is a `tuple[bool]`, of the same length as `RETURN_TYPES`, specifying 
-which outputs which should be so treated.
+However, as Comfy wraps node outputs into a `list` of length one, if the values returned by a custom node
+contain a `list`, that `list` will be wrapped, and treated as a single piece of data.
 
-A node can also override the default input behaviour and receive the whole list in a single call. This is done by setting a class attribute
-`INPUT_IS_LIST` to `True`.
+Two V3 schema options change this behaviour:
 
-Here's a (lightly annotated) example from the built in nodes - `ImageRebatch` takes one or more batches of images (received as a list, because `INPUT_IS_LIST - True`)
-and rebatches them into batches of the requested size.
+- `is_input_list=True` on the schema: the node receives the *whole* list in a single call, instead of being
+  called once per item. All inputs become `list[type]`, regardless of how many items are passed in. This
+  replaces the legacy V1 class attribute `INPUT_IS_LIST`.
+- `is_output_list=True` on an output: the list returned for that output is not wrapped, and is treated as a
+  series of data for sequential processing by downstream nodes. This replaces the legacy V1 class attribute
+  `OUTPUT_IS_LIST`.
 
-<Tip>`INPUT_IS_LIST` is node level - all inputs get the same treatment. So the value of the `batch_size` widget is given by `batch_size[0]`.</Tip>
+To show how the two options work together, here's an `ImageRebatch`-style node written in the V3 schema. It
+takes one or more batches of images (received as a list, because `is_input_list=True`) and rebatches them
+into batches of the requested size:
 
-```Python
+<Tip>`is_input_list` is node level - all inputs get the same treatment. So the value of the `batch_size` widget is given by `batch_size[0]`.</Tip>
 
-class ImageRebatch:
+```python
+from comfy_api.latest import ComfyExtension, io
+
+
+class ImageRebatch(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": { "images": ("IMAGE",),
-                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 4096}) }}
-    RETURN_TYPES = ("IMAGE",)
-    INPUT_IS_LIST = True
-    OUTPUT_IS_LIST = (True, )
-    FUNCTION = "rebatch"
-    CATEGORY = "image/batch"
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="ImageRebatch",
+            category="image/batch",
+            inputs=[
+                io.Image.Input("images"),
+                io.Int.Input("batch_size", default=1, min=1, max=4096),
+            ],
+            outputs=[
+                io.Image.Output(is_output_list=True),
+            ],
+            is_input_list=True,
+        )
 
-    def rebatch(self, images, batch_size):
+    @classmethod
+    def execute(cls, images, batch_size) -> io.NodeOutput:
         batch_size = batch_size[0]    # everything comes as a list, so batch_size is list[int]
 
         output_list = []
@@ -61,17 +76,8 @@ class ImageRebatch:
             for i in range(img.shape[0]):     # each i is a single image
                 all_images.append(img[i:i+1])
 
-        for i in range(0, len(all_images), batch_size): # take batch_size chunks and turn each into a new batch
+        for i in range(0, len(all_images), batch_size):  # take batch_size chunks and turn each into a new batch
             output_list.append(torch.cat(all_images[i:i+batch_size], dim=0))  # will die horribly if the image batches had different width or height!
 
-        return (output_list,)
+        return io.NodeOutput(output_list)
 ```
-
-
-
-
-
-
-
-#### INPUT_IS_LIST
-

--- a/custom-nodes/backend/manager.mdx
+++ b/custom-nodes/backend/manager.mdx
@@ -71,6 +71,6 @@ a custom node. These are all optional.
 - `disable.py`, `enable.py` - executed when a custom node is disabled or re-enabled 
 <Tip>`enable.py` is only run when a disabled node is re-enabled - it should just reverse anything done in `disable.py`</Tip>
 <Tip>Disabled custom node subdirectory have `.disabled` appended to their names, and Comfy ignores these modules</Tip>
-- `node_list.json` - only required if the custom nodes pattern of NODE_CLASS_MAPPINGS is not conventional.
+- `node_list.json` - only required if the custom node's registration pattern is not conventional: the manager detects nodes from a V3 `comfy_entrypoint` / `ComfyExtension` or a legacy V1 `NODE_CLASS_MAPPINGS`, and `node_list.json` spells the mapping out explicitly when neither can be inferred.
 
 See the [ComfyUI Manager guide](https://github.com/Comfy-Org/ComfyUI-Manager?tab=readme-ov-file#custom-node-support-guide) for official details.

--- a/custom-nodes/backend/more_on_inputs.mdx
+++ b/custom-nodes/backend/more_on_inputs.mdx
@@ -5,104 +5,148 @@ description: "ComfyUI hidden inputs (UNIQUE_ID, PROMPT, EXTRA_PNGINFO, DYNPROMPT
 
 ## Hidden inputs
 
-Alongside the `required` and `optional` inputs, which create corresponding inputs or widgets on the client-side,
-there are three `hidden` input options which allow the custom node to request certain information from the server.
+Alongside the inputs declared in the schema, which create corresponding inputs or widgets on the
+client-side, custom nodes can request certain information from the server through *hidden* inputs. Hidden
+inputs are not visible in the UI.
 
-These are accessed by returning a value for `hidden` in the `INPUT_TYPES` `dict`, with the signature `dict[str,str]`,
-containing one or more of `PROMPT`, `EXTRA_PNGINFO`, or `UNIQUE_ID`
+In the V3 schema, hidden inputs are requested by passing a list of `io.Hidden` enum values to the `hidden`
+parameter of the schema. During execution, the values are available on the node class as `cls.hidden`, so
+an `execute` method can read them by name:
 
 ```python
-@classmethod
-def INPUT_TYPES(s):
-    return {
-        "required": {...},
-        "optional": {...},
-        "hidden": {
-            "unique_id": "UNIQUE_ID",
-            "prompt": "PROMPT", 
-            "extra_pnginfo": "EXTRA_PNGINFO",
-        }
-    }
+from comfy_api.latest import io
+
+class MyNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="MyNode",
+            inputs=[io.String.Input("text")],
+            outputs=[io.String.Output()],
+            hidden=[
+                io.Hidden.unique_id,
+                io.Hidden.prompt,
+                io.Hidden.extra_pnginfo,
+            ],
+        )
+
+    @classmethod
+    def execute(cls, text) -> io.NodeOutput:
+        # hidden values are accessed via cls.hidden
+        print(cls.hidden.unique_id)
+        print(cls.hidden.prompt)
+        print(cls.hidden.extra_pnginfo)
+        return io.NodeOutput(text)
 ```
 
-### UNIQUE_ID 
-`UNIQUE_ID` is the unique identifier of the node, and matches the `id` property of the node on the client side. 
-It is commonly used in client-server communications (see [messages](/development/comfyui-server/comms_messages#getting-node-id)).
+Available hidden values (see the [V3 Migration guide](/custom-nodes/v3_migration) for the full list):
+
+### UNIQUE_ID
+
+`io.Hidden.unique_id` provides the unique identifier of the node, and matches the `id` property of the
+node on the client side. It is commonly used in client-server communications (see
+[messages](/development/comfyui-server/comms_messages#getting-node-id)).
 
 ### PROMPT
-`PROMPT` is the complete prompt sent by the client to the server. 
-See [the prompt object](/custom-nodes/js/javascript_objects_and_hijacking#prompt) for a full description.
+
+`io.Hidden.prompt` provides the complete prompt sent by the client to the server. See
+[the prompt object](/custom-nodes/js/javascript_objects_and_hijacking#prompt) for a full description.
 
 ### EXTRA_PNGINFO
-`EXTRA_PNGINFO` is a dictionary that will be copied into the metadata of any `.png` files saved. Custom nodes can store additional
-information in this dictionary for saving (or as a way to communicate with a downstream node).
+
+`io.Hidden.extra_pnginfo` provides a dictionary that will be copied into the metadata of any `.png` files
+saved. Custom nodes can store additional information in this dictionary for saving (or as a way to
+communicate with a downstream node).
 
 <Tip>Note that if Comfy is started with the `disable_metadata` option, this data won't be saved.</Tip>
 
 ### DYNPROMPT
-`DYNPROMPT` is an instance of `comfy_execution.graph.DynamicPrompt`. It differs from `PROMPT` in that it may mutate during the course of execution in response to [Node Expansion](/custom-nodes/backend/expansion).
+
+`io.Hidden.dynprompt` provides an instance of `comfy_execution.graph.DynamicPrompt`. It differs from
+`PROMPT` in that it may mutate during the course of execution in response to [Node Expansion](/custom-nodes/backend/expansion).
+
 <Tip>`DYNPROMPT` should only be used for advanced cases (like implementing loops in custom nodes).</Tip>
 
 ## Flexible inputs
 
 ### Custom datatypes
 
-If you want to pass data between your own custom nodes, you may find it helpful to define a custom datatype. This is (almost) as simple as 
-just choosing a name for the datatype, which should be a unique string in upper case, such as `CHEESE`.
+If you want to pass data between your own custom nodes, you may find it helpful to define a custom
+datatype. This is (almost) as simple as just choosing a name for the datatype, which should be a unique
+string in upper case, such as `CHEESE`.
 
-You can then use `CHEESE` in your node `INPUT_TYPES` and `RETURN_TYPES`, and the Comfy client will only allow `CHEESE` outputs to connect to a `CHEESE` input. 
-`CHEESE` can be any python object.
-
-The only point to note is that because the Comfy client doesn't know about `CHEESE` you need (unless you define a custom widget for `CHEESE`, 
-which is a topic for another day), to force it to be an input rather than a widget. This can be done with the `forceInput` option in the input options dictionary:
+Create the type with the `io.Custom` helper (or the `@io.comfytype` decorator for a full class
+definition), then use it for inputs and outputs. The Comfy client will only allow `CHEESE` outputs to
+connect to a `CHEESE` input. A `CHEESE` value can be any Python object.
 
 ```python
-@classmethod
-def INPUT_TYPES(s):
-    return {
-        "required": { "my_cheese": ("CHEESE", {"forceInput":True}) }
-    }
+from comfy_api.latest import io
+
+# Create the custom type once, then reuse it
+Cheese = io.Custom("CHEESE")
+
+class CheeseNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="CheeseNode",
+            inputs=[Cheese.Input("my_cheese")],
+            outputs=[Cheese.Output()],
+        )
 ```
+
+Because the Comfy client doesn't know anything about `CHEESE`, it can't display a widget for it. Custom
+datatype inputs are therefore socket inputs: they must be connected to an upstream node, and the widget
+conversion options (`force_input` and `socketless`) don't apply to them. If you want a widget fallback for
+your custom type, you need to define a custom widget for it, which is a topic for another day.
 
 ### Wildcard inputs
 
-```python
-@classmethod
-def INPUT_TYPES(s):
-    return {
-        "required": { "anything": ("*",{})},
-    }
+The frontend allows `*` to indicate that an input can be connected to any source. In the V3 schema,
+`io.AnyType` provides this wildcard type directly:
 
-@classmethod
-def VALIDATE_INPUTS(s, input_types):
-    return True
+```python
+class AnyNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="AnyNode",
+            inputs=[
+                io.AnyType.Input("anything"),
+            ],
+            outputs=[io.AnyType.Output()],
+        )
 ```
 
-The frontend allows `*` to indicate that an input can be connected to any source. Because this is not officially supported by the backend, you can skip the backend validation of types by accepting a parameter named `input_types` in your `VALIDATE_INPUTS` function. (See [VALIDATE_INPUTS](./server_overview#validate_inputs) for more information.)
-It's up to the node to make sense of the data that is passed.
+With `io.AnyType`, type validation accepts any input, so the legacy V1 workaround (adding an
+`input_types` argument to `VALIDATE_INPUTS` in order to skip backend validation) is not needed. It's up to
+the node to make sense of the data that is passed.
 
 ### Dynamically created inputs
 
 If inputs are dynamically created on the client side, they can't be defined in the Python source code.
-In order to access this data we need an `optional` dictionary that allows Comfy to pass data with 
-arbitrary names. Since the Comfy server 
+
+The V3 schema handles this with the `accept_all_inputs` flag. When it is `True`, all inputs from the
+prompt that are not defined in the schema are passed through to `execute` as keyword arguments:
 
 ```python
-class ContainsAnyDict(dict):
-    def __contains__(self, key):
-        return True
-...
+class FlexibleNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="FlexibleNode",
+            inputs=[
+                # inputs that are always present can still be declared here
+            ],
+            outputs=[io.Image.Output()],
+            accept_all_inputs=True,
+        )
 
-@classmethod
-def INPUT_TYPES(s):
-    return {
-        "required": {},
-        "optional": ContainsAnyDict()
-    }
-...
-
-def main_method(self, **kwargs):
-    # the dynamically created input data will be in the dictionary kwargs
-
+    @classmethod
+    def execute(cls, **kwargs) -> io.NodeOutput:
+        # the dynamically created input data will be in the keyword arguments
+        ...
 ```
-<Tip>Hat tip to rgthree for this pythonic trick!</Tip>
+
+Note that inputs declared in the schema are still validated and dispatched normally; `accept_all_inputs`
+only affects the inputs that are *not* declared.

--- a/custom-nodes/backend/server_overview.mdx
+++ b/custom-nodes/backend/server_overview.mdx
@@ -4,7 +4,7 @@ description: "Properties of a custom node"
 ---
 
 <Info>
-The node definitions on this page use the legacy V1 schema (`INPUT_TYPES` / `RETURN_TYPES`), which is still fully supported. New nodes can also be written with the modern V3 schema (`io.ComfyNode` with `define_schema` and a `comfy_entrypoint` function), which is how the bundled [`custom_nodes/example_node.py.example`](https://github.com/comfyanonymous/ComfyUI/blob/master/custom_nodes/example_node.py.example) is written. For the differences and how to migrate, see the [V3 Migration guide](/custom-nodes/v3_migration).
+The node definitions on this page use the modern V3 schema (`io.ComfyNode` with `define_schema` and a `comfy_entrypoint` function), which is how the bundled [`custom_nodes/example_node.py.example`](https://github.com/comfyanonymous/ComfyUI/blob/master/custom_nodes/example_node.py.example) is written. The legacy V1 schema (`INPUT_TYPES` / `RETURN_TYPES`) is still fully supported. For the differences and how to migrate, see the [V3 Migration guide](/custom-nodes/v3_migration).
 </Info>
 
 ### Simple Example
@@ -12,73 +12,77 @@ The node definitions on this page use the legacy V1 schema (`INPUT_TYPES` / `RET
 Here's the code for the Invert Image Node, which gives an overview of the key concepts in custom node development.
 
 ```python
-class InvertImageNode:
+from comfy_api.latest import ComfyExtension, io
+
+class InvertImageNode(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": { "image_in" : ("IMAGE", {}) },
-        }
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="InvertImageNode",
+            display_name="Invert Image",
+            category="examples",
+            inputs=[
+                io.Image.Input("image_in"),
+            ],
+            outputs=[
+                io.Image.Output(display_name="image_out"),
+            ],
+        )
 
-    RETURN_TYPES = ("IMAGE",)
-    RETURN_NAMES = ("image_out",)
-    CATEGORY = "examples"
-    FUNCTION = "invert"
-
-    def invert(self, image_in):
+    @classmethod
+    def execute(cls, image_in) -> io.NodeOutput:
         image_out = 1 - image_in
-        return (image_out,)
+        return io.NodeOutput(image_out)
+
+class ExampleExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            InvertImageNode,
+        ]
+
+async def comfy_entrypoint() -> ExampleExtension:  # ComfyUI calls this to load your extension and its nodes.
+    return ExampleExtension()
 ```
 
 ### Main properties
 
-Every custom node is a Python class, with the following key properties:
+Every custom node is a Python class inheriting from `io.ComfyNode`, with the following key properties:
 
-#### INPUT_TYPES
+#### define_schema
 
-`INPUT_TYPES`, as the name suggests, defines the inputs for the node. The method returns a `dict`
-which _must_ contain the key `required`, and _may_ also include the keys `optional` and/or `hidden`. The only difference
-between `required` and `optional` inputs is that `optional` inputs can be left unconnected. 
-For more information on `hidden` inputs, see [Hidden Inputs](./more_on_inputs#hidden-inputs).
+`define_schema`, as the name suggests, defines the schema for the node. The class method returns an `io.Schema` object which contains the node's metadata, inputs and outputs.
 
-Each key has, as its value, another `dict`, in which key-value pairs specify the names and types of the inputs.
-The types are defined by a `tuple`, the first element of which defines the data type, 
-and the second element of which is a `dict` of additional parameters. 
+The schema fields are:
 
-Here we have just one required input, named `image_in`, of type `IMAGE`, with no additional parameters.
+- `node_id`: a unique identifier for the node, used in the API and workflow JSON.
+- `display_name`: the friendly name shown in the UI. Optional; defaults to `node_id`.
+- `category`: where the node is found in the ComfyUI **Add Node** menu. Submenus can be specified as a path, eg. `examples/trivial`.
+- `inputs`: a list of input objects.
+- `outputs`: a list of output objects.
+- `description`: the tooltip shown when hovering over the node. Optional.
+- `search_aliases`: a list of alternative names users might search for when looking for this node. Optional.
 
-Note that unlike the next few attributes, this `INPUT_TYPES` is a `@classmethod`. This is so
-that the options in dropdown widgets (like the name of the checkpoint to be loaded) can be
-computed by Comfy at run time. We'll go into this more later. {/* TODO link when written */}
+Each input is an object like `io.Int.Input("count", default=1, min=0, max=4096)`. The available input types are `io.Image`, `io.Mask`, `io.Model`, `io.VAE`, `io.CLIP`, `io.Conditioning`, `io.Latent`, `io.Audio`, `io.Int`, `io.Float`, `io.String`, `io.Combo`, `io.Boolean`, and more. See the [Datatypes](/custom-nodes/backend/datatypes) page for details.
 
-#### RETURN_TYPES
+As in V1, `define_schema` is a `@classmethod` so that widget options (like the name of the checkpoint to be loaded) can be computed at runtime. Let's go into this more later.
 
-A `tuple` of `str` defining the data types returned by the node. 
-If the node has no outputs this must still be provided `RETURN_TYPES = ()`
-<Warning>If you have exactly one output, remember the trailing comma: `RETURN_TYPES = ("IMAGE",)`. 
-This is required for Python to make it a `tuple`</Warning> 
+Outputs are listed as `io.Image.Output()` and so on, with an optional `display_name` to label the output in the UI.
 
-#### RETURN_NAMES
+#### execute
 
-The names to be used to label the outputs. This is optional; if omitted, the names are simply the `RETURN_TYPES` in lowercase.
+The execution function is fixed to the name `execute`, and is a class method. It is called with named arguments matching the input ids defined in the schema.
 
-#### CATEGORY
+The function returns an `io.NodeOutput`, wrapping the result values. If the node has multiple outputs, pass them as multiple arguments:
 
-Where the node will be found in the ComfyUI **Add Node** menu. Submenus can be specified as a path, eg. `examples/trivial`.
+```python
+return io.NodeOutput(model, clip, vae)
+```
 
-#### FUNCTION
-
-The name of the Python function in the class that should be called when the node is executed.
-
-The function is called with named arguments. All `required` (and `hidden`) inputs will be included; 
-`optional` inputs will be included only if they are connected, so you should provide default values for them in the function
-definition (or capture them with `**kwargs`).
-
-The function returns a tuple corresponding to the `RETURN_TYPES`. This is required even if nothing is returned (`return ()`). 
-Again, if you only have one output, remember that trailing comma `return (image_out,)`!
+If the node has no outputs, return `io.NodeOutput()` (or simply nothing after processing side effects, but the return value must be `io.NodeOutput`, so `return` a bare `io.NodeOutput()`).
 
 ### Execution Control Extras
 
-A great feature of Comfy is that it caches outputs, 
+A great feature of Comfy is that it caches outputs,
 and only executes nodes that might produce a different result than the previous run.
 This can greatly speed up lots of workflows.
 
@@ -87,35 +91,36 @@ backwards to identify which nodes provide data that might have changed since the
 
 Two optional features of a custom node assist in this process.
 
-#### OUTPUT_NODE
+#### is_output_node
 
-By default, a node is not considered an output. Set `OUTPUT_NODE = True` to specify that it is. 
+By default, a node is not considered an output. Set `is_output_node=True` in the schema to specify that it is.
 
-#### IS_CHANGED
+```python
+return io.Schema(
+    node_id="SaveImage",
+    ...
+    is_output_node=True,
+)
+```
 
-By default, Comfy considers that a node has changed if any of its inputs or widgets have changed. 
-This is normally correct, but you may need to override this if, for instance, the node uses a random 
-number (and does not specify a seed - it's best practice to have a seed input in this case so that 
+#### fingerprint_inputs
+
+By default, Comfy considers that a node has changed if any of its inputs or widgets have changed.
+This is normally correct, but you may need to override this if, for instance, the node uses a random
+number (and does not specify a seed - it's best practice to have a seed input in this case so that
 the user can control reproducibility and avoid unnecessary execution), or loads an input that may have
 changed externally, or sometimes ignores inputs (so doesn't need to execute just because those inputs changed).
 
-<Warning>Despite the name, IS_CHANGED should not return a `bool`</Warning> 
+`fingerprint_inputs` (formerly `IS_CHANGED` in V1) receives the same arguments as `execute` and returns a
+value that Comfy compares with the one returned in the previous run. If the value differs, the node is executed.
 
-`IS_CHANGED` is passed the same arguments as the main function defined by `FUNCTION`, and can return any 
-Python object. This object is compared with the one returned in the previous run (if any) and the node
-will be considered to have changed if `is_changed != is_changed_old` (this code is in `execution.py` if you need to dig).
+<Warning>The name of this method was misleading in V1: `IS_CHANGED` is not "changed"; it is a cache key. Returning `True` every time makes the node run only once.</Warning>
 
-Since `True == True`, a node that returns `True` to say it has changed will be considered not to have! I'm sure this would
-be changed in the Comfy code if it wasn't for the fact that it might break existing nodes to do so. 
+A good example of actually checking for changes is the code from the built-in LoadImage node, which loads the image and returns a hash:
 
-To specify that your node should always be considered to have changed (which you should avoid if possible, since it 
-stops Comfy optimising what gets run), `return float("NaN")`. This returns a `NaN` value, which is not equal
-to anything, even another `NaN`.
-
-A good example of actually checking for changes is the code from the built-in LoadImage node, which loads the image and returns a hash
 ```python
     @classmethod
-    def IS_CHANGED(s, image):
+    def fingerprint_inputs(s, image):
         image_path = folder_paths.get_annotated_filepath(image)
         m = hashlib.sha256()
         with open(image_path, 'rb') as f:
@@ -123,43 +128,53 @@ A good example of actually checking for changes is the code from the built-in Lo
         return m.digest().hex()
 ```
 
-#### SEARCH_ALIASES
+To specify that your node should always be considered to have changed (which you should avoid if possible, since it
+stops Comfy optimising what gets run), return a value that is never equal to the previous one, such as `float("NaN")`.
 
-Optional. A list of alternative names users might search for when looking for this node.
-This is included in the `/object_info` API response as `search_aliases`.
+#### not_idempotent
 
-```python
-SEARCH_ALIASES = ["text concat", "join text", "merge strings"]
-```
+If your node produces an output that depends on something other than its inputs (for example, a random number without a seed), set `not_idempotent=True` in the schema. This tells Comfy to skip the fast-path that assumes identical inputs produce identical outputs.
 
-### Other attributes
+### Other schema flags
 
-There are three other attributes that can be used to modify the default Comfy treatment of a node.
+There are several other flags that can be used to modify how Comfy treats a node:
 
-#### INPUT_IS_LIST, OUTPUT_IS_LIST
+- `is_deprecated`: flags the node as deprecated, telling users to find alternatives.
+- `is_experimental`: flags the node as experimental, warning users that it may change.
+- `is_input_list`: controls sequential processing of data, described [later](./lists).
+- `hidden`: a list of hidden inputs (see [Hidden Inputs](./more_on_inputs#hidden-inputs)).
+- `enable_expand`: allows the node to expand into a subgraph (see [Node Expansion](./expansion)).
+- `accept_all_inputs`: passes all inputs that are not defined in the schema through to `execute` (see [Dynamically created inputs](./more_on_inputs#dynamically-created-inputs)).
 
-These are used to control sequential processing of data, and are described [later](./lists).
+### validate_inputs
 
-### VALIDATE_INPUTS
-
-If a class method `VALIDATE_INPUTS` is defined, it will be called before the workflow begins execution.
-`VALIDATE_INPUTS` should return `True` if the inputs are valid, or a message (as a `str`) describing the error (which will prevent execution).
+If a class method `validate_inputs` is defined, it will be called before the workflow begins execution.
+`validate_inputs` should return `True` if the inputs are valid, or a message (as a `str`) describing the error (which will prevent execution).
 
 #### Validating Constants
-<Warning>Note that `VALIDATE_INPUTS` will only receive inputs that are defined as constants within the workflow. Any inputs that are received from other nodes will *not* be available in `VALIDATE_INPUTS`.</Warning>
 
-`VALIDATE_INPUTS` is called with only the inputs that its signature requests (those returned by `inspect.getfullargspec(obj_class.VALIDATE_INPUTS).args`). Any inputs which are received in this way will *not* run through the default validation rules. For example, in the following snippet, the front-end will use the specified `min` and `max` values of the `foo` input, but the back-end will not enforce it. 
-    
+<Warning>Note that `validate_inputs` will only receive inputs that are defined as constants within the workflow. Any inputs that are received from other nodes will *not* be available in `validate_inputs`.</Warning>
+
+`validate_inputs` is called with only the inputs that its signature requests (those returned by `inspect.getfullargspec(obj_class.validate_inputs).args`). Any inputs which are received in this way will *not* run through the default validation rules.
+
+For example, in the following snippet, the front-end will use the specified `min` and `max` values of the `foo` input, but the back-end will not enforce it.
+
 ```python
-class CustomNode:
+from comfy_api.latest import io
+
+class CustomNode(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": { "foo" : ("INT", {"min": 0, "max": 10}) },
-        }
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="CustomNode",
+            inputs=[
+                io.Int.Input("foo", min=0, max=10),
+            ],
+            outputs=[],
+        )
 
     @classmethod
-    def VALIDATE_INPUTS(cls, foo):
+    def validate_inputs(cls, foo):
         # YOLO, anything goes!
         return True
 ```
@@ -168,28 +183,38 @@ Additionally, if the function takes a `**kwargs` input, it will receive *all* av
 
 #### Validating Types
 
-If the `VALIDATE_INPUTS` method receives an argument named `input_types`, it will be passed a dictionary in which the key is the name of each input which is connected to an output from another node and the value is the type of that output.
+If the `validate_inputs` method receives an argument named `input_types`, it will be passed a dictionary in which the key is the name of each input which is connected to an output from another node and the value is the type of that output.
 
 When this argument is present, all default validation of input types is skipped. Here's an example making use of the fact that the front-end allows for the specification of multiple types:
 
 ```python
-class AddNumbers:
+from comfy_api.latest import io
+
+class AddNumbers(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "input1" : ("INT,FLOAT", {"min": 0, "max": 1000})
-                "input2" : ("INT,FLOAT", {"min": 0, "max": 1000})
-            },
-        }
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="AddNumbers",
+            inputs=[
+                io.MultiType.Input(
+                    io.Int.Input("input1", min=0, max=1000),
+                    types=[io.Int, io.Float],
+                ),
+                io.MultiType.Input(
+                    io.Int.Input("input2", min=0, max=1000),
+                    types=[io.Int, io.Float],
+                ),
+            ],
+            outputs=[io.Int.Output()],
+        )
 
     @classmethod
-    def VALIDATE_INPUTS(cls, input_types):
+    def validate_inputs(cls, input_types):
         # The min and max of input1 and input2 are still validated because
         # we didn't take `input1` or `input2` as arguments
-        if input_types["input1"] not in ("INT", "FLOAT"):
+        if not any(t in (io.Int, io.Float) for t in input_types["input1"]):
             return "input1 must be an INT or FLOAT type"
-        if input_types["input2"] not in ("INT", "FLOAT"):
+        if not any(t in (io.Int, io.Float) for t in input_types["input2"]):
             return "input2 must be an INT or FLOAT type"
         return True
 ```

--- a/custom-nodes/backend/server_overview.mdx
+++ b/custom-nodes/backend/server_overview.mdx
@@ -212,9 +212,9 @@ class AddNumbers(io.ComfyNode):
     def validate_inputs(cls, input_types):
         # The min and max of input1 and input2 are still validated because
         # we didn't take `input1` or `input2` as arguments
-        if not any(t in (io.Int, io.Float) for t in input_types["input1"]):
+        if input_types["input1"] not in (io.Int.io_type, io.Float.io_type):
             return "input1 must be an INT or FLOAT type"
-        if not any(t in (io.Int, io.Float) for t in input_types["input2"]):
+        if input_types["input2"] not in (io.Int.io_type, io.Float.io_type):
             return "input2 must be an INT or FLOAT type"
         return True
 ```

--- a/custom-nodes/walkthrough.mdx
+++ b/custom-nodes/walkthrough.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Getting Started"
-description: "Getting Started with Custom Nodes: a step-by-step ComfyUI walkthrough covering backend node setup, defining CATEGORY, INPUT_TYPES, and FUNCTION, registering nodes, adding options, and building a client-side JS extension."
+description: "Getting Started with Custom Nodes: a step-by-step ComfyUI walkthrough covering backend node setup, defining a schema, the execute method, registering nodes, adding options, and building a client-side JS extension."
 ---
 
-This page will take you step-by-step through the process of creating a custom node. 
+This page will take you step-by-step through the process of creating a custom node.
 
 Our example will take a batch of images, and return one of the images. Initially, the node
 will return the image which is, on average, the lightest in color; we'll then extend
@@ -11,7 +11,7 @@ it to have a range of selection criteria, and then finally add some client side 
 
 This page assumes very little knowledge of Python or Javascript.
 
-After this walkthrough, dive into the details of [backend code](./backend/server_overview), and 
+After this walkthrough, dive into the details of [backend code](./backend/server_overview), and
 [frontend code](./js/javascript_overview).
 
 ## Write a basic node
@@ -21,7 +21,7 @@ After this walkthrough, dive into the details of [backend code](./backend/server
 - A working ComfyUI [installation](/installation/manual_install). For development, we recommend installing ComfyUI manually.
 - A working comfy-cli [installation](/comfy-cli/getting-started).
 
-### Setting up 
+### Setting up
 
 ```bash
 cd ComfyUI/custom_nodes
@@ -53,37 +53,47 @@ Initialized empty Git repository in firstcomfynode/.git/
 ✓ Custom node project created successfully!
 ```
 
+<Note>
+The scaffold generates a legacy V1 example node. In this walkthrough, we'll replace it with the modern V3 schema. See the [V3 Migration guide](/custom-nodes/v3_migration) if you're migrating an existing node.
+</Note>
+
 ### Defining the node
 
 Add the following code to the end of `src/nodes.py`:
 
 ```Python src/nodes.py
-class ImageSelector:
-    CATEGORY = "example"
-    @classmethod    
-    def INPUT_TYPES(s):
-        return { "required":  { "images": ("IMAGE",), } }
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "choose_image"
+from comfy_api.latest import ComfyExtension, io
+
+class ImageSelector(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="ImageSelector",
+            display_name="Image Selector",
+            category="example",
+            inputs=[
+                io.Image.Input("images"),
+            ],
+            outputs=[
+                io.Image.Output(display_name="image"),
+            ],
+        )
 ```
 
 <Info>The basic structure of a custom node is described in detail [here](/custom-nodes/backend/server_overview). </Info>
 
-A custom node is defined using a Python class, which must include these four things: `CATEGORY`, 
-which specifies where in the add new node menu the custom node will be located, 
-`INPUT_TYPES`, which is a class method defining what inputs the node will take
-(see [later](/custom-nodes/backend/server_overview#input_types) for details of the dictionary returned),
-`RETURN_TYPES`, which defines what outputs the node will produce, and `FUNCTION`, the name
-of the function that will be called when the node is executed.
+A custom node is defined using a Python class inheriting from `io.ComfyNode`, which must include `define_schema`, a class method defining the node's metadata and inputs/outputs
+(see [later](/custom-nodes/backend/server_overview#define_schema) for details of the schema fields),
+and an `execute` method that is called when the node is run.
 
-<Tip>Notice that the data type for input and output is `IMAGE` (singular) even though 
+<Tip>Notice that the data type for input and output is `io.Image` even though 
 we expect to receive a batch of images, and return just one. In Comfy, `IMAGE` means
 image batch, and a single image is treated as a batch of size 1.</Tip>
 
 ### The main function
 
-The main function, `choose_image`, receives named arguments as defined in `INPUT_TYPES`, and
-returns a `tuple` as defined in `RETURN_TYPES`. Since we're dealing with images, which are internally
+The main function, `execute`, receives named arguments as defined in the schema, and
+returns an `io.NodeOutput`. Since we're dealing with images, which are internally
 stored as `torch.Tensor`, 
 
 ```Python
@@ -97,67 +107,88 @@ this into a one dimensional tensor, of length `H*W*C`, `torch.mean()` takes the 
 turns a single value tensor into a Python float. 
 
 ```Python
-def choose_image(self, images):
-    brightness = list(torch.mean(image.flatten()).item() for image in images)
-    brightest = brightness.index(max(brightness))
-    result = images[brightest].unsqueeze(0)
-    return (result,)
+    @classmethod
+    def execute(cls, images) -> io.NodeOutput:
+        brightness = list(torch.mean(image.flatten()).item() for image in images)
+        brightest = brightness.index(max(brightness))
+        result = images[brightest].unsqueeze(0)
+        return io.NodeOutput(result)
 ```
 
 Notes on those last two lines: 
 
 - `images[brightest]` will return a Tensor of shape `[H,W,C]`. `unsqueeze` is used to insert a (length 1) dimension at, in this case, dimension zero, to give 
 us `[B,H,W,C]` with `B=1`: a single image.
-- in `return (result,)`, the trailing comma is essential to ensure you return a tuple.
+- `io.NodeOutput` wraps the result values, matching the order of the schema's `outputs`.
 
 ### Register the node
 
-To make Comfy recognize the new node, it must be available at the package level. Modify the `NODE_CLASS_MAPPINGS` variable at the end of `src/nodes.py`. You must restart ComfyUI to see any changes.  
+To make Comfy recognize the new node, it must be exposed through a `ComfyExtension` and a `comfy_entrypoint` function. Modify the end of `src/nodes.py`:
 
 ```Python src/nodes.py
+class ImageSelectorExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            ImageSelector,
+        ]
 
-NODE_CLASS_MAPPINGS = {
-    "Example" : Example,
-    "Image Selector" : ImageSelector,
-}
-
-# Optionally, you can rename the node in the `NODE_DISPLAY_NAME_MAPPINGS` dictionary.
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "Example": "Example Node",
-    "Image Selector": "Image Selector",
-}
+async def comfy_entrypoint() -> ImageSelectorExtension:
+    return ImageSelectorExtension()
 ```
+
+Then update `__init__.py` to export `comfy_entrypoint` (the scaffold generates a number of V1-related exports, like `NODE_CLASS_MAPPINGS`, which you can remove):
+
+```Python __init__.py
+from .src.firstcomfynode.nodes import comfy_entrypoint
+
+__all__ = ["comfy_entrypoint"]
+```
+
+You must restart ComfyUI to see any changes.
 
 <Info>For a detailed explanation of how ComfyUI discovers and loads custom nodes, see the [node lifecycle documentation](/custom-nodes/backend/lifecycle).</Info>
 
 ## Add some options
 
 That node is maybe a bit boring, so we might add some options; a widget that allows you to 
-choose the brightest image, or the reddest, bluest, or greenest. Edit your `INPUT_TYPES` to look like:
+choose the brightest image, or the reddest, bluest, or greenest. Edit your schema's `inputs` to look like:
 
 ```Python
-@classmethod    
-def INPUT_TYPES(s):
-    return { "required":  { "images": ("IMAGE",), 
-                            "mode": (["brightest", "reddest", "greenest", "bluest"],)} }
+from comfy_api.latest import io
+
+@classmethod
+def define_schema(cls) -> io.Schema:
+    return io.Schema(
+        node_id="ImageSelector",
+        display_name="Image Selector",
+        category="example",
+        inputs=[
+            io.Image.Input("images"),
+            io.Combo.Input("mode", options=["brightest", "reddest", "greenest", "bluest"]),
+        ],
+        outputs=[
+            io.Image.Output(display_name="image"),
+        ],
+    )
 ```
 
 Then update the main function. We'll use a fairly naive definition of 'reddest' as being the average
 `R` value of the pixels divided by the average of all three colors. So:
 
 ```Python
-def choose_image(self, images, mode):
-    batch_size = images.shape[0]
-    brightness = list(torch.mean(image.flatten()).item() for image in images)
-    if (mode=="brightest"):
-        scores = brightness
-    else:
-        channel = 0 if mode=="reddest" else (1 if mode=="greenest" else 2)
-        absolute = list(torch.mean(image[:,:,channel].flatten()).item() for image in images)
-        scores = list( absolute[i]/(brightness[i]+1e-8) for i in range(batch_size) )
-    best = scores.index(max(scores))
-    result = images[best].unsqueeze(0)
-    return (result,)
+    @classmethod
+    def execute(cls, images, mode) -> io.NodeOutput:
+        batch_size = images.shape[0]
+        brightness = list(torch.mean(image.flatten()).item() for image in images)
+        if (mode=="brightest"):
+            scores = brightness
+        else:
+            channel = 0 if mode=="reddest" else (1 if mode=="greenest" else 2)
+            absolute = list(torch.mean(image[:,:,channel].flatten()).item() for image in images)
+            scores = list( absolute[i]/(brightness[i]+1e-8) for i in range(batch_size) )
+        best = scores.index(max(scores))
+        result = images[best].unsqueeze(0)
+        return io.NodeOutput(result)
 ```
 
 ## Tweak the UI
@@ -172,12 +203,12 @@ This requires two lines to be added to the Python code:
 from server import PromptServer
 ```
 
-and, at the end of the `choose_image` method, add a line to send a message to the front end (`send_sync` takes a message
+and, at the end of the `execute` method, add a line to send a message to the front end (`send_sync` takes a message
 type, which should be unique, and a dictionary)
 
 ```Python
 PromptServer.instance.send_sync("example.imageselector.textmessage", {"message":f"Picked image {best+1}"})
-return (result,)
+return io.NodeOutput(result)
 ```
 
 ### Write a client extension
@@ -187,7 +218,7 @@ to tell Comfy about it by exporting `WEB_DIRECTORY`:
 
 ```Python
 WEB_DIRECTORY = "./web/js"
-__all__ = ['NODE_CLASS_MAPPINGS', 'WEB_DIRECTORY']
+__all__ = ["comfy_entrypoint", "WEB_DIRECTORY"]
 ```
 
 The client extension is saved as a `.js` file in the `web/js` subdirectory, so create `image_selector/web/js/imageSelector.js` with the 
@@ -208,10 +239,9 @@ All we've done is register an extension and add a listener for the message type 
 
 Stop the Comfy server, start it again, reload the webpage, and run your workflow.
 
-
 ### The complete example
 
-The complete example is available [here](https://gist.github.com/robinjhuang/fbf54b7715091c7b478724fc4dffbd03). You can download the example workflow [JSON file](https://github.com/Comfy-Org/docs/blob/main/public/workflow.json) or view it below:
+The complete example is available at the end of the bundled [`custom_nodes/example_node.py.example`](https://github.com/comfyanonymous/ComfyUI/blob/master/custom_nodes/example_node.py.example). You can download the example workflow [JSON file](https://github.com/Comfy-Org/docs/blob/main/public/workflow.json) or view it below:
 
 <div align="center">
   <img src="/images/firstnodeworkflow.png" alt="Image Selector Workflow" width="100%" />

--- a/custom-nodes/walkthrough.mdx
+++ b/custom-nodes/walkthrough.mdx
@@ -203,12 +203,11 @@ This requires two lines to be added to the Python code:
 from server import PromptServer
 ```
 
-and, at the end of the `execute` method, add a line to send a message to the front end (`send_sync` takes a message
-type, which should be unique, and a dictionary)
+Then, inside the body of `execute` (after computing the result), send the message and return the output:
 
 ```Python
-PromptServer.instance.send_sync("example.imageselector.textmessage", {"message":f"Picked image {best+1}"})
-return io.NodeOutput(result)
+        PromptServer.instance.send_sync("example.imageselector.textmessage", {"message":f"Picked image {best+1}"})
+        return io.NodeOutput(result)
 ```
 
 ### Write a client extension


### PR DESCRIPTION
## Summary

The custom-nodes backend development docs still teach the legacy V1 schema (`INPUT_TYPES` / `RETURN_TYPES` / `NODE_CLASS_MAPPINGS`), while ComfyUI's own [`custom_nodes/example_node.py.example`](https://github.com/comfyanonymous/ComfyUI/blob/master/custom_nodes/example_node.py.example) is written against the V3 schema (`io.ComfyNode` + `define_schema` + `comfy_entrypoint`). Addresses #1574 and extends the fix to the whole section.

Rewrites 9 English pages to teach V3 (EN only; zh/ja/ko will follow via the hash-synced translate pipeline after review):

- `custom-nodes/backend/server_overview.mdx` (Properties, the issue's target page)
- `custom-nodes/backend/interface.mdx`
- `custom-nodes/backend/datatypes.mdx`
- `custom-nodes/backend/more_on_inputs.mdx` (hidden inputs, custom datatypes, wildcards, dynamic inputs)
- `custom-nodes/backend/lazy_evaluation.mdx`
- `custom-nodes/backend/lifecycle.mdx`
- `custom-nodes/backend/lists.mdx`
- `custom-nodes/backend/manager.mdx`
- `custom-nodes/walkthrough.mdx`

Every V3 API fact is verified against ComfyUI master (`comfy_api/latest/_io.py`, `nodes.py` loader, `execution.py`): schema fields (`is_input_list`, `accept_all_inputs`, `hidden`, ...), `io.Hidden` / `cls.hidden`, `io.AnyType`, `io.Custom`, `io.NodeOutput(block_execution=...)`, classmethod `check_lazy_status`, per-output `is_output_list`, and `comfy_entrypoint` / `ComfyExtension` loading (incl. `WEB_DIRECTORY` and `[tool.comfy] web`).

Legacy V1 is referenced only as "legacy" callouts where readers need the migration path.

## Checks

- anchor check: all 9 files pass (changed headings preserved)
- `validate-links.py`: all links valid
- every Python code block parses (`ast.parse`)
- no em dashes

## Out of scope

- Translations (zh/ja/ko) for these pages: pending review, then translated via the standard i18n pipeline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to MDX examples and prose; no application or API implementation changes in this repo.
> 
> **Overview**
> **Rewrites nine English custom-node backend pages** so they teach the **V3 API** (`io.ComfyNode`, `define_schema`, classmethod `execute`, `io.NodeOutput`, `ComfyExtension` / `comfy_entrypoint`) instead of legacy V1 (`INPUT_TYPES`, `RETURN_TYPES`, `NODE_CLASS_MAPPINGS`, `FUNCTION`).
> 
> **Properties, interface, datatypes, and the getting-started walkthrough** now use `io.*` input/output types, schema metadata (`node_id`, `display_name`, `is_output_node`, `fingerprint_inputs`, `not_idempotent`), and extension registration. **Datatypes** adds V3 widget/tensor patterns (`io.Combo` / `io.MultiCombo`, snake_case `Input` parameters) and an expanded parameter table (`force_input`, `accept_all_inputs`-related options, etc.).
> 
> **Topic pages** are aligned with V3 behavior: hidden inputs via `io.Hidden` / `cls.hidden`; custom and wildcard types (`io.Custom`, `io.AnyType`); dynamic inputs via `accept_all_inputs`; list handling via `is_input_list` and per-output `is_output_list`; lazy inputs with classmethod `check_lazy_status` and execution blocking via `io.NodeOutput(block_execution=...)`; lifecycle and Manager notes for `comfy_entrypoint` vs V1 discovery.
> 
> Legacy V1 is kept only in short migration callouts pointing at the V3 migration guide. **No runtime code changes**—documentation and examples only (EN; i18n called out as follow-up in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16b4d284fbdd911d5b7a4662b37398720de3c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->