### PR TITLE
docs: add v0.34.6 and v0.35.0 changelog and CMS release notes

### DIFF
--- a/.cursor/skills/cms-changelog-sync/SKILL.md
+++ b/.cursor/skills/cms-changelog-sync/SKILL.md
@@ -99,7 +99,7 @@ Config: `.github/scripts/cms/cms-config.json` → `simplify`
 | Bullet format | `[**Name**](pr_url): 6–12 words with one key trait` |
 | PR links | **Keep** when source has them; never invent URLs |
 | New Node Updates | **Optional by default.** Omit from CMS popup even if docs has **New Nodes**; add only when a human explicitly asks |
-| Drop | Bug fixes, performance, pure Load3D plumbing, internal refactors, **ComfyUI-WIKI dependency bumps** (see below), and New Nodes unless requested |
+| Drop | Bug fixes, performance, pure Load3D plumbing, internal refactors, **ComfyUI-WIKI dependency bumps** (see below), and New Nodes unless requested. **Do not drop** partner removals, deprecations, or EOL |
 
 Style: principle-only prompt in `cms-simplify-prompt.ts` (no concrete version examples — avoids LLM contamination).
 
@@ -108,6 +108,12 @@ Style: principle-only prompt in `cms-simplify-prompt.ts` (no concrete version ex
 **Copy length (local vs Cloud):** Cloud popup users skim. After merge, shorten Cloud bullets so they do not list every node, mode, or task type. One short clause is enough: added the model, or one capability. Local CMS (`staging/en/`) and docs `changelog/index.mdx` can keep the fuller scope (which nodes, which modes). Do not shorten local to match Cloud.
 
 Example: docs/local may say H3 Max landed on text-to-video, first-last-frame, and reference nodes. Cloud: `Added H3 Max model support`.
+
+**OSS bullets name the model, not the plumbing.** After `prepare:en`, rewrite open-source bullets to match names users already see in `tutorials/` (checkpoint family, `fl2va` / `ref2va`, ControlNet Union, and similar). If a tutorial page already documents the model, the popup should say we added support for that model. Do not describe loader internals: optional VAE, keyframe wiring, skipped LoRA keys, unless that is the only user-facing change.
+
+**LoRA / trainer format:** say we support LoRAs trained in that format (or by that trainer). Do not mention the previous load bug.
+
+**Removals, deprecations, EOL:** keep them on the popup (do not drop as housekeeping). On Cloud, still list the retired node or model names so users know which graphs break. The "one short clause" Cloud rule does not apply to removal bullets.
 
 ## Bullet links (docs, local CMS, Cloud CMS)
 
@@ -118,9 +124,9 @@ Resolve each feature bullet **before** `cms:prepare:locales`. Search these sourc
 | Template index | [templates/index.json](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.json) (raw: `https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/index.json`) |
 | Blog | [blog.comfy.org](https://blog.comfy.org/) ([archive](https://blog.comfy.org/archive)) |
 
-Match a template by `name`, `title`, or `models` to the changelog item. Match a blog post only if it covers **this** product or version (MiniMax H3 day-0 is not MiniMax H3 Max).
+Match a template by `name`, `title`, or `models` to the changelog item. Search the **whole** index: partner `api_*` and OSS `video_*`, `image_*`, `3d_*` (and any other prefix). Do not grep `api_` only. Match a blog post only if it covers **this** product or version (MiniMax H3 day-0 is not MiniMax H3 Max).
 
-**Video templates:** when several templates exist, pick one by suffix on `name`, in this order: **r2v → i2v → t2v**. Example: `api_minimax_h3_max_r2v` over `_i2v` / `_t2v`. If none of those suffixes exist, use the remaining matching template (`flf2v`, `edit`, and similar). Cloud URL shape: `https://cloud.comfy.org/?template=<name>` (no UTM unless the user supplied one).
+**Video templates:** when several templates exist, pick one by suffix on `name`, in this order: **r2v → i2v → t2v**. Example: `api_minimax_h3_max_r2v` over `_i2v` / `_t2v`. If none of those suffixes exist, use the remaining matching template (`flf2v`, `edit`, `fun_controlnet_union`, and similar). Cloud URL shape: `https://cloud.comfy.org/?template=<name>` (no UTM unless the user supplied one).
 
 | Surface | Link priority (first match wins) |
 |---------|----------------------------------|
@@ -293,8 +299,10 @@ Re-run with `--force`. Staging without `--force` **skips** existing `<Update>` b
 When user asks to update CMS release notes:
 
 - [ ] Confirm `changelog/index.mdx` has the new `<Update>` block
-- [ ] Resolve bullet URLs: search template `index.json` and [blog.comfy.org/archive](https://blog.comfy.org/archive); Cloud = user UTM then `?template=` (video r2v → i2v → t2v); docs/local = blog then PR then repo
-- [ ] Shorten Cloud EN bullets (added model support, skip node lists). Keep local/docs more detailed
+- [ ] Resolve bullet URLs: search the **full** template `index.json` (`api_*` and OSS `video_*` / `image_*` / `3d_*`) and [blog.comfy.org/archive](https://blog.comfy.org/archive); Cloud = user UTM then `?template=` (video r2v → i2v → t2v); docs/local = blog then PR then repo
+- [ ] Align OSS popup names with existing `tutorials/` model names (added support for X). Not loader plumbing
+- [ ] Shorten Cloud EN bullets (added model support, skip node lists). Keep local/docs more detailed. Exception: Cloud removal/EOL bullets still list what was retired
+- [ ] LoRA format bullets: support that trainer/format, not the previous skip-keys bug
 - [ ] Omit ComfyUI-WIKI items (embedded docs, workflow templates, model blueprints) unless user explicitly asks
 - [ ] Run `pnpm cms:prepare:en`; rewrite Cloud EN links; show staging EN → **wait for user approval**
 - [ ] Run `pnpm cms:prepare:locales` (not `cms:prepare:en`) → **wait for user approval**

--- a/.github/scripts/cms/cms-simplify-prompt.ts
+++ b/.github/scripts/cms/cms-simplify-prompt.ts
@@ -32,10 +32,13 @@ Emit only sections that have source items, in the order above. When open-source 
 **New Open-Source Model Support:**
 - Include every open-source model from the source (within the bullet limit)
 - Do not drop models to make room for partner items
+- Name the model or checkpoint family from the source, not loader plumbing (optional VAE, key wiring, skipped weights)
+- For LoRA or trainer-format items: say we support LoRAs trained in that format. Do not mention a previous load failure
 - Preserve 1–2 distinguishing traits per model from the source (variants, sizes, encoder, modality, key capability)
 
 **Partner Node Updates:**
 - Include partner/API node additions or updates from the source
+- Keep removals, deprecations, and EOL from the source. List the retired models or nodes. Do not drop them as housekeeping
 - Preserve scope or capability details when stated (e.g. number of new nodes, supported modality)
 - Always the second section when open-source models are also present (right after Open-Source Model Support)
 

--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -861,6 +861,62 @@
         "zh"
       ],
       "published_at": "2026-09-05T03:58:03.365Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.34.6",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-09T12:17:38.366Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.34.6",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-09T12:16:36.574Z"
+    },
+    {
+      "project": "cloud",
+      "version": "0.35.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-09T12:17:49.994Z"
+    },
+    {
+      "project": "comfyui",
+      "version": "0.35.0",
+      "locales": [
+        "en",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "ru",
+        "zh"
+      ],
+      "published_at": "2026-09-09T12:16:46.188Z"
     }
   ]
 }

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="September 9, 2026">
+
+**New Open-Source Model Support**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Added Pixal3D multi-view reconstruction
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Added SenseNova U1.5 support
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Added H3 PDD LoRA support
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Added Fun ControlNet Union support for `fl2va` and `ref2va`
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Support DiffSynth-Studio and ModelScope trained LoRAs
+
+**Partner Node Updates**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): Added GPT Image 2.5 Flare and Sunburst
+
+</Update>
+
+<Update label="v0.34.6" description="September 7, 2026">
+
+**Partner Node Updates**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra): Added GPT-6 Astra
+* [**Retired partner models**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Removed DALL·E 2/3, Kling Video Extend, LTX-2 partner T2V/I2V, ByteDance Image (Seedream 3), and Seedance 1.0 Lite. Graphs that still use them will fail.
+
+</Update>
+
 <Update label="v0.34.4" description="September 4, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="September 9, 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Se añadió la reconstrucción multivista de Pixal3D
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Se añadió soporte para SenseNova U1.5
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Se añadió soporte para H3 PDD LoRA
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Se añadió soporte para Fun ControlNet Union en `fl2va` y `ref2va`
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Se añadió soporte para LoRAs entrenados con DiffSynth-Studio y ModelScope
+
+**Actualizaciones de nodos de socios**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): Se añadieron GPT Image 2.5 Flare y Sunburst
+
+</Update>
+
+<Update label="v0.34.6" description="7 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra): Se añadió GPT-6 Astra
+* [**Modelos de socios retirados**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Se eliminaron DALL·E 2/3, Kling Video Extend, LTX-2 partner T2V/I2V, ByteDance Image (Seedream 3) y Seedance 1.0 Lite. Los grafos que aún los utilicen fallarán.
+
+</Update>
+
 <Update label="v0.34.4" description="4 de septiembre de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="9 septembre 2026">
+
+**Prise en charge de nouveaux modèles open-source**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Ajout de la reconstruction multi-vues Pixal3D
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Ajout de la prise en charge de SenseNova U1.5
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Ajout de la prise en charge du LoRA H3 PDD
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Ajout de la prise en charge de Fun ControlNet Union pour `fl2va` et `ref2va`
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Prise en charge des LoRA entraînés avec DiffSynth-Studio et ModelScope
+
+**Mises à jour des nœuds partenaires**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): Ajout de GPT Image 2.5 Flare et Sunburst
+
+</Update>
+
+<Update label="v0.34.6" description="September 7, 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra) : Ajout de GPT-6 Astra
+* [**Modèles partenaires retirés**](https://github.com/Comfy-Org/ComfyUI/pull/16121) : Suppression de DALL·E 2/3, Kling Video Extend, les modèles partenaires T2V/I2V de LTX-2, ByteDance Image (Seedream 3) et Seedance 1.0 Lite. Les graphes qui les utilisent encore échoueront.
+
+</Update>
+
 <Update label="v0.34.4" description="September 4, 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026年9月9日">
+
+**オープンソースモデルの新規サポート**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Pixal3Dのマルチビュー再構成のサポートを追加しました。
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): SenseNova U1.5のサポートを追加しました。
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3 PDD LoRAのサポートを追加しました。
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): `fl2va`と`ref2va`向けのFun ControlNet Unionサポートを追加しました。
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-StudioとModelScopeでトレーニングされたLoRAをサポートしました。
+
+**パートナーノードの更新**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): GPT Image 2.5 FlareとSunburstを追加しました。
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**パートナーノードの更新**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra): GPT-6 Astra を追加しました。
+* [**廃止されたパートナーモデル**](https://github.com/Comfy-Org/ComfyUI/pull/16121): DALL·E 2/3、Kling Video Extend、LTX-2 パートナー T2V/I2V、ByteDance画像（Seedream 3）、Seedance 1.0 Lite を削除しました。これらを引き続き使用しているグラフは失敗します。
+
+</Update>
+
 <Update label="v0.34.4" description="2026年9月4日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026년 9월 9일">
+
+**새로운 오픈소스 모델 지원**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Pixal3D 멀티뷰 재구성 추가
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): SenseNova U1.5 지원 추가
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3 PDD LoRA 지원 추가
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): `fl2va` 및 `ref2va`용 Fun ControlNet Union 지원 추가
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-Studio 및 ModelScope에서 학습된 LoRA 지원
+
+**파트너 노드 업데이트**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): GPT Image 2.5 Flare 및 Sunburst 지원 추가
+
+</Update>
+
+<Update label="v0.34.6" description="2026년 9월 7일">
+
+**파트너 노드 업데이트**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra): GPT-6 Astra 추가
+* [**파트너 모델 단종**](https://github.com/Comfy-Org/ComfyUI/pull/16121): DALL·E 2/3, Kling 비디오 확장, LTX-2 파트너 T2V/I2V, ByteDance 이미지(Seedream 3) 및 Seedance 1.0 Lite가 제거되었습니다. 이를 계속 사용하는 그래프는 실패합니다.
+
+</Update>
+
 <Update label="v0.34.4" description="2026년 9월 4일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="9 сентября 2026">
+
+**Поддержка новых моделей с открытым исходным кодом**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Добавлена многовидовая реконструкция Pixal3D
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Добавлена поддержка SenseNova U1.5
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Добавлена поддержка H3 PDD LoRA
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Добавлена поддержка Fun ControlNet Union для `fl2va` и `ref2va`
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Поддержаны LoRA, обученные с помощью DiffSynth-Studio и ModelScope
+
+**Обновления партнёрских узлов**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i): Добавлены GPT Image 2.5 Flare и Sunburst
+
+</Update>
+
+<Update label="v0.34.6" description="7 сентября 2026 года">
+
+**Обновления партнёрских узлов**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra): Добавлена модель
+* [**Снятые с поддержки партнёрские модели**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Удалены DALL·E 2/3, Kling Video Extend, партнёрские LTX-2 T2V/I2V, ByteDance Image (Seedream 3) и Seedance 1.0 Lite. Графы, которые всё ещё используют их, перестанут работать.
+
+</Update>
+
 <Update label="v0.34.4" description="September 4, 2026">
 
 **Обновления партнёрских узлов**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -4,6 +4,28 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026年9月9日">
+
+**新的开源模型支持**
+* [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views)：新增 Pixal3D 多视图重建
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922)：新增 SenseNova U1.5 支持
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908)：新增 H3 PDD LoRA 支持
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union)：新增对 `fl2va` 和 `ref2va` 的 Fun ControlNet Union 支持
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662)：支持 DiffSynth-Studio 和 ModelScope 训练的 LoRA
+
+**合作伙伴节点更新**
+* [**GPT Image 2.5**](https://cloud.comfy.org/?template=api_openai_gpt_image_25_flare_t2i)：新增 GPT Image 2.5 Flare 和 Sunburst
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**合作伙伴节点更新**
+* [**GPT-6 Astra**](https://cloud.comfy.org/?template=api_openai_gpt6_astra)：新增 GPT-6 Astra
+* [**已下架的合作伙伴模型**](https://github.com/Comfy-Org/ComfyUI/pull/16121)：移除了 DALL·E 2/3、Kling 视频扩展、LTX-2 合作伙伴 T2V/I2V、字节跳动图片 (Seedream 3) 和 Seedance 1.0 Lite。仍然使用这些模型的工作流图将无法运行。
+
+</Update>
+
 <Update label="v0.34.4" description="2026年9月4日">
 
 **合作伙伴节点更新**

--- a/.github/scripts/cms/staging/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/en/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="September 9, 2026">
+
+**New Open-Source Model Support**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Reconstruct textured meshes from four view angles
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Native pixel-space generation and multi-reference editing with up to 10 images
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Load Parallel Decoding Distillation LoRAs for faster H3 sampling
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): Added Fun ControlNet Union support for `fl2va` and `ref2va`
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): Support `ref2va` text-encoder-only references without a VAE
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Support DiffSynth-Studio and ModelScope trained LoRAs
+
+**Partner Node Updates**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): Adds Flare and Sunburst models to the OpenAI GPT Image node
+
+</Update>
+
+<Update label="v0.34.6" description="September 7, 2026">
+
+**Partner Node Updates**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): Adds GPT-6 Astra plus reasoning effort levels on OpenAI Chat models
+* [**Retired partner models**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Removes DALL·E 2/3, Kling Video Extend, LTX-2 partner video, Seedream 3, and Seedance 1.0 Lite
+
+</Update>
+
 <Update label="v0.34.5" description="September 5, 2026">
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/es/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="9 de septiembre de 2026">
+
+**Nuevo soporte para modelos de código abierto**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Reconstruye mallas texturizadas desde cuatro ángulos de vista
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Generación nativa en espacio de píxeles y edición multirreferencia con hasta 10 imágenes
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Carga LoRAs de destilación de decodificación paralela para un muestreo H3 más rápido
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): Se agregó compatibilidad con Fun ControlNet Union para `fl2va` y `ref2va`
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): Admite referencias `ref2va` solo con codificador de texto sin VAE
+* [**MiniMax-H3 y HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Admite LoRAs entrenados con DiffSynth-Studio y ModelScope
+
+**Actualizaciones de nodos de socios**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): Añade los modelos Flare y Sunburst al nodo OpenAI GPT Image
+
+</Update>
+
+<Update label="v0.34.6" description="7 de septiembre de 2026">
+
+**Actualizaciones de nodos de socios**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): Añade GPT-6 Astra y niveles de esfuerzo de razonamiento en los modelos de chat de OpenAI
+* [**Modelos de socios retirados**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Elimina DALL·E 2/3, Kling Video Extend, el video de socio LTX-2, Seedream 3 y Seedance 1.0 Lite
+
+</Update>
+
 <Update label="v0.34.5" description="5 de septiembre de 2026">
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/fr/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="September 9, 2026">
+
+**Nouveau support de modèles open source**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048) : Reconstruisez des maillages texturés à partir de quatre angles de vue
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922) : Génération native dans l’espace pixel et édition multi-référence avec jusqu’à 10 images
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908) : Chargez des LoRA de distillation de décodage parallèle pour un échantillonnage H3 plus rapide
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020) : Ajout de la prise en charge de Fun ControlNet Union pour `fl2va` et `ref2va`
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065) : Prise en charge des références `ref2va` avec encodeur de texte uniquement, sans VAE
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662) : Prise en charge des LoRA entraînés avec DiffSynth-Studio et ModelScope
+
+**Mises à jour des nœuds partenaires**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190) : Ajoute les modèles Flare et Sunburst au nœud OpenAI GPT Image
+
+</Update>
+
+<Update label="v0.34.6" description="7 septembre 2026">
+
+**Mises à jour des nœuds partenaires**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125) : Ajoute GPT-6 Astra ainsi que les niveaux d'effort de raisonnement aux modèles OpenAI Chat
+* [**Modèles partenaires retirés**](https://github.com/Comfy-Org/ComfyUI/pull/16121) : Supprime DALL·E 2/3, Kling Video Extend, LTX-2 partner video, Seedream 3 et Seedance 1.0 Lite
+
+</Update>
+
 <Update label="v0.34.5" description="5 septembre 2026">
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ja/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026年9月9日">
+
+**新規オープンソースモデルのサポート**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): 4つの視点からテクスチャ付きメッシュを再構築します
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): ネイティブなピクセル空間生成と、最大10枚の画像を使用したマルチリファレンス編集
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3サンプリングを高速化するParallel Decoding Distillation LoRAを読み込みます
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): `fl2va`と`ref2va`向けのFun ControlNet Unionサポートを追加しました
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): VAEなしで`ref2va`のテキストエンコーダーのみのリファレンスをサポートします
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-StudioおよびModelScopeでトレーニングされたLoRAをサポートします
+
+**パートナーノードの更新**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): OpenAI GPT ImageノードにFlareモデルとSunburstモデルを追加しました
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**パートナーノードの更新**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): OpenAI Chat モデルに GPT-6 Astra と推論努力レベルを追加
+* [**廃止されたパートナーモデル**](https://github.com/Comfy-Org/ComfyUI/pull/16121): DALL·E 2/3、Kling Video Extend、LTX-2 パートナービデオ、Seedream 3、Seedance 1.0 Lite を削除
+
+</Update>
+
 <Update label="v0.34.5" description="2026年9月5日">
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ko/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026년 9월 9일">
+
+**새로운 오픈소스 모델 지원**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): 4개의 시점에서 텍스처가 적용된 메시를 재구성합니다.
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): 네이티브 픽셀 공간 생성과 최대 10개의 이미지를 사용한 다중 레퍼런스 편집을 지원합니다.
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): 더 빠른 H3 샘플링을 위해 병렬 디코딩 증류(PDD) LoRA를 로드합니다.
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): `fl2va` 및 `ref2va`에 대한 Fun ControlNet Union 지원이 추가되었습니다.
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): VAE 없이 `ref2va` 텍스트 인코더 전용 레퍼런스를 지원합니다.
+* [**MiniMax-H3 및 HiDream O1 LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-Studio 및 ModelScope에서 학습된 LoRA를 지원합니다.
+
+**파트너 노드 업데이트**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): OpenAI GPT Image 노드에 Flare 및 Sunburst 모델을 추가합니다.
+
+</Update>
+
+<Update label="v0.34.6" description="2026년 9월 7일">
+
+**파트너 노드 업데이트**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): OpenAI Chat 모델에 GPT-6 Astra 및 추론 노력 수준을 추가합니다.
+* [**지원 중단된 파트너 모델**](https://github.com/Comfy-Org/ComfyUI/pull/16121): DALL·E 2/3, Kling 비디오 확장, LTX-2 파트너 비디오, Seedream 3 및 Seedance 1.0 Lite를 제거합니다.
+
+</Update>
+
 <Update label="v0.34.5" description="2026년 9월 5일">
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/ru/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="9 сентября 2026 г.">
+
+**Новая поддержка моделей с открытым исходным кодом**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Реконструкция текстурированных 3D-сеток по четырём ракурсам
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Нативная генерация в пиксельном пространстве и редактирование по нескольким референсам — до 10 изображений
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Загрузка LoRA Parallel Decoding Distillation для более быстрого семплирования H3
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): Добавлена поддержка Fun ControlNet Union для `fl2va` и `ref2va`
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): Поддержка `ref2va`-референсов только через текстовый энкодер, без VAE
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Поддержка LoRA, обученных с помощью DiffSynth-Studio и ModelScope
+
+**Обновления партнёрских узлов**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): Добавлены модели Flare и Sunburst в узел OpenAI GPT Image
+
+</Update>
+
+<Update label="v0.34.6" description="7 сентября 2026">
+
+**Обновления партнёрских узлов**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): Добавляет GPT-6 Astra и уровни усилий рассуждения для чат-моделей OpenAI
+* [**Выведенные из эксплуатации партнёрские модели**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Удаляет DALL·E 2/3, Kling Video Extend, партнёрскую видеомодель LTX-2, Seedream 3 и Seedance 1.0 Lite
+
+</Update>
+
 <Update label="v0.34.5" description="September 5, 2026">
 
 **Обновления партнерских узлов**

--- a/.github/scripts/cms/staging/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/zh/changelog/index.mdx
@@ -4,6 +4,29 @@ cmsStaging: true
 ---
 
 
+<Update label="v0.35.0" description="2026年9月9日">
+
+**新增开源模型支持**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): 从四个视角重建带纹理的网格
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): 原生像素空间生成，支持最多 10 张图像的多参考编辑
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): 加载并行解码蒸馏 LoRA（Parallel Decoding Distillation LoRA），以加速 H3 采样
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): 为 `fl2va` 和 `ref2va` 添加了 Fun ControlNet Union 支持
+* [**MiniMax-H3 参考转视频**](https://github.com/Comfy-Org/ComfyUI/pull/16065): 支持无 VAE 的 `ref2va` 仅文本编码器参考
+* [**MiniMax-H3 与 HiDream O1 LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15662): 支持 DiffSynth-Studio 和 ModelScope 训练的 LoRA
+
+**合作伙伴节点更新**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): 为 OpenAI GPT Image 节点添加了 Flare 和 Sunburst 模型
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**合作伙伴节点更新**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125)：新增 GPT-6 Astra，并支持在 OpenAI Chat 模型上设置推理努力级别。
+* [**已退役的合作伙伴模型**](https://github.com/Comfy-Org/ComfyUI/pull/16121)：移除了 DALL·E 2/3、Kling 视频扩展、LTX-2 合作伙伴视频、Seedream 3 和 Seedance 1.0 Lite。
+
+</Update>
+
 <Update label="v0.34.5" description="2026年9月5日">
 
 **合作伙伴节点更新**

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,7 +4,55 @@ description: "ComfyUI changelog: the latest features, improvements, and bug fixe
 icon: "clock-rotate-left"
 ---
 
+<Update label="v0.35.0" description="September 9, 2026">
+
+**New Open-Source Model Support**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Reconstruct textured meshes from front, back, left, and right views with Pixal3D Multi-View Conditioning
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Native pixel-space generation and multi-reference editing with up to 10 reference images
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Load Parallel Decoding Distillation LoRAs for faster H3 sampling
+* [**MiniMax-H3 Fun Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): Use reference and keyframe conditioning together with Fun Union ControlNet
+* [**MiniMax-H3 text-encoder refs**](https://github.com/Comfy-Org/ComfyUI/pull/16065): Make VAE optional so references can condition the text encoder only
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Load DiffSynth-Studio and ModelScope-trained LoRAs that previously skipped every key
+
+**New Node Updates**
+* [**LTXV generated keyframes**](https://github.com/Comfy-Org/ComfyUI/pull/16040): Add, separate, and re-pin generated keyframes, plus Freeze Latent
+* [**LTXV Add Latent Guide**](https://github.com/Comfy-Org/ComfyUI/pull/16176): Pin a pre-encoded latent as a guide without a VAE round trip
+* [**Sparse Attention**](https://github.com/Comfy-Org/ComfyUI/pull/16072): Model Sparse Attention node for comfy-kitchen sparse backends
+* [**Color space conversion**](https://github.com/Comfy-Org/ComfyUI/pull/16135): Convert between sRGB, HDR HLG, and HDR PQ
+* [**File3DToMesh**](https://github.com/Comfy-Org/ComfyUI/pull/15919): Parse GLB, GLTF, OBJ, and STL files into the MESH pipeline
+* [**VideoTrim & VideoCrop**](https://github.com/Comfy-Org/ComfyUI/pull/15637): Trim and crop video with frontend VIDEO_EDIT widgets
+* [**Save Image Advanced AVIF**](https://github.com/Comfy-Org/ComfyUI/pull/15891): Added AVIF output to Save Image Advanced
+* [**cfgpp_ud10_ab sampler**](https://github.com/Comfy-Org/ComfyUI/pull/15951): Added a CFG++ sampler that works well at lower steps on Anima
+* [**ResolutionSelector preview**](https://github.com/Comfy-Org/ComfyUI/pull/16013): Live width and height readout from aspect ratio and megapixel settings
+
+**Partner Node Updates**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): Added Flare and Sunburst models to the OpenAI GPT Image node
+
+**Performance & Stability**
+* [**Comfy Compiler**](https://github.com/Comfy-Org/ComfyUI/pull/15861): Aimdo memory compiler plus CUDA graphs to cut allocation thrash
+* [**TRELLIS memory**](https://github.com/Comfy-Org/ComfyUI/pull/16054): Lowered peak VRAM and RAM in TRELLIS workflows
+* [**Container cgroup RAM**](https://github.com/Comfy-Org/ComfyUI/pull/15927): Respect container memory limits instead of host RAM
+* [**RDNA3.5 attention**](https://github.com/Comfy-Org/ComfyUI/pull/16014): Enable PyTorch SDPA and FP8 ops on gfx1170 and gfx1171
+
+**Bug Fixes**
+* [**MiniMax H3 denoise masks**](https://github.com/Comfy-Org/ComfyUI/pull/15988): Scale video and audio velocities by denoise masks before x0 conversion
+* [**SAM 3 text masks**](https://github.com/Comfy-Org/ComfyUI/pull/15979): Fix empty text-prompt masks when scalp=1 sent four FPN levels
+* [**Image alpha**](https://github.com/Comfy-Org/ComfyUI/pull/15632): Preserve alpha on RGB/YUV, Canny, quantize, overlay, blend, invert, and color-adjust nodes
+* [**Switch inputs**](https://github.com/Comfy-Org/ComfyUI/pull/16083): Allow disconnected Switch inputs
+* [**MPS int8**](https://github.com/Comfy-Org/ComfyUI/pull/16130): Disable int8 weight-only quantization when `torch._int_mm` is missing
+
+</Update>
+
+<Update label="v0.34.6" description="September 7, 2026">
+
+**Partner Node Updates**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): Added GPT-6 Astra and reasoning effort levels on supported OpenAI Chat models
+* [**Retired partner models**](https://github.com/Comfy-Org/ComfyUI/pull/16121): Removed DALL·E 2/3, Kling Video Extend, LTX-2 partner video nodes, ByteDance Image (Seedream 3), and Seedance 1.0 Lite options
+
+</Update>
+
 <Update label="v0.34.5" description="September 5, 2026">
+
 
 **Partner Node Updates**
 * [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Added beta nodes that run curated Flux 2, Z-Image Turbo, Mage Flow, MiniMax H3, and Music 3 workflows on Comfy Cloud GPUs

--- a/ja/changelog/index.mdx
+++ b/ja/changelog/index.mdx
@@ -2,10 +2,12 @@
 title: "変更履歴"
 description: "ComfyUI の変更ログ：各リリースの最新機能、改善点、バグ修正を、新バージョンのリリースに合わせて更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 451e9d44
+translationSourceHash: 4487ee86
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.34.5": 599d1216
+  "v0.35.0": 5d1f806b
+  "v0.34.6": fb20c363
+  "v0.34.5": ac9a5306
   "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
@@ -127,7 +129,55 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.35.0" description="2026年9月9日">
+
+**新しいオープンソースモデルのサポート**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Pixal3D Multi-View Conditioning で、前・後・左・右のビューからテクスチャ付きメッシュを再構築します
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): ネイティブなピクセル空間生成と、最大10枚の参照画像によるマルチリファレンス編集
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3サンプリングを高速化する Parallel Decoding Distillation LoRA を読み込みます
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): `fl2va` と `ref2va` 向けの Fun ControlNet Union サポートを追加し、リファレンスとキーフレームの条件付けを併用できます
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): VAE を任意にし、リファレンスをテキストエンコーダーのみで条件付けできるようにしました
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-Studio および ModelScope でトレーニングされた LoRA をサポートします
+
+**新しいノードの更新**
+* [**LTXV generated keyframes**](https://github.com/Comfy-Org/ComfyUI/pull/16040): 生成キーフレームの追加、分離、再ピン、および Freeze Latent
+* [**LTXV Add Latent Guide**](https://github.com/Comfy-Org/ComfyUI/pull/16176): 事前エンコード済み latent をガイドとして固定し、VAE の往復を不要にします
+* [**Sparse Attention**](https://github.com/Comfy-Org/ComfyUI/pull/16072): comfy-kitchen のスパースバックエンド向け Model Sparse Attention ノード
+* [**Color space conversion**](https://github.com/Comfy-Org/ComfyUI/pull/16135): sRGB、HDR HLG、HDR PQ 間の変換
+* [**File3DToMesh**](https://github.com/Comfy-Org/ComfyUI/pull/15919): GLB、GLTF、OBJ、STL ファイルを MESH パイプラインに解析します
+* [**VideoTrim & VideoCrop**](https://github.com/Comfy-Org/ComfyUI/pull/15637): フロントエンドの VIDEO_EDIT ウィジェットで動画をトリムおよびクロップします
+* [**Save Image Advanced AVIF**](https://github.com/Comfy-Org/ComfyUI/pull/15891): Save Image Advanced に AVIF 出力を追加しました
+* [**cfgpp_ud10_ab sampler**](https://github.com/Comfy-Org/ComfyUI/pull/15951): Anima の低ステップで有効な CFG++ サンプラーを追加しました
+* [**ResolutionSelector preview**](https://github.com/Comfy-Org/ComfyUI/pull/16013): アスペクト比とメガピクセル設定から幅と高さをライブ表示します
+
+**パートナーノードの更新**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): OpenAI GPT Image ノードに Flare と Sunburst モデルを追加しました
+
+**パフォーマンスと安定性**
+* [**Comfy Compiler**](https://github.com/Comfy-Org/ComfyUI/pull/15861): Aimdo メモリコンパイラと CUDA graphs で割り当てのスラッシングを削減します
+* [**TRELLIS memory**](https://github.com/Comfy-Org/ComfyUI/pull/16054): TRELLIS ワークフローのピーク VRAM と RAM を削減しました
+* [**Container cgroup RAM**](https://github.com/Comfy-Org/ComfyUI/pull/15927): ホスト RAM ではなくコンテナのメモリ上限を尊重します
+* [**RDNA3.5 attention**](https://github.com/Comfy-Org/ComfyUI/pull/16014): gfx1170 と gfx1171 で PyTorch SDPA と FP8 演算を有効化します
+
+**バグ修正**
+* [**MiniMax H3 denoise masks**](https://github.com/Comfy-Org/ComfyUI/pull/15988): x0 変換前に denoise mask で動画と音声の速度をスケールします
+* [**SAM 3 text masks**](https://github.com/Comfy-Org/ComfyUI/pull/15979): scalp=1 で FPN が4レベル渡されるとテキストプロンプトのマスクが空になる問題を修正しました
+* [**Image alpha**](https://github.com/Comfy-Org/ComfyUI/pull/15632): RGB/YUV、Canny、量子化、オーバーレイ、ブレンド、反転、色調整ノードでアルファを保持します
+* [**Switch inputs**](https://github.com/Comfy-Org/ComfyUI/pull/16083): 未接続の Switch 入力を許可します
+* [**MPS int8**](https://github.com/Comfy-Org/ComfyUI/pull/16130): `torch._int_mm` がない場合に int8 weight-only 量子化を無効化します
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**パートナーノードの更新**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125)：サポート対象のOpenAI ChatモデルにGPT-6 Astraと推論努力レベルを追加しました
+* [**廃止されたパートナーモデル**](https://github.com/Comfy-Org/ComfyUI/pull/16121)：DALL·E 2/3、Kling Video Extend、LTX-2パートナービデオノード、ByteDance画像（Seedream 3）、Seedance 1.0 Liteオプションを削除しました
+
+</Update>
+
 <Update label="v0.34.5" description="2026年9月5日">
+
 
 **パートナーノードの更新**
 * [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Comfy Cloud の GPU 上で、精選された Flux 2、Z-Image Turbo、Mage Flow、MiniMax H3、Music 3 のワークフローを実行するベータノードを追加しました。

--- a/ko/changelog/index.mdx
+++ b/ko/changelog/index.mdx
@@ -2,10 +2,12 @@
 title: "변경 로그"
 description: "ComfyUI 변경 로그: 각 릴리스의 최신 기능, 개선 사항, 버그 수정을 새 버전 출시에 맞춰 업데이트합니다."
 icon: "clock-rotate-left"
-translationSourceHash: 451e9d44
+translationSourceHash: 4487ee86
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.34.5": 599d1216
+  "v0.35.0": 5d1f806b
+  "v0.34.6": fb20c363
+  "v0.34.5": ac9a5306
   "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
@@ -127,7 +129,55 @@ translationBlockHashes:
   "v0.3.40": 24608eaf
 ---
 
+<Update label="v0.35.0" description="2026년 9월 9일">
+
+**새로운 오픈소스 모델 지원**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048): Pixal3D Multi-View Conditioning으로 전면, 후면, 좌측, 우측 뷰에서 텍스처가 있는 메시를 재구성합니다
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): 네이티브 픽셀 공간 생성과 최대 10장의 참조 이미지를 사용한 다중 참조 편집을 지원합니다
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3 샘플링을 더 빠르게 하는 Parallel Decoding Distillation LoRA를 로드합니다
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020): `fl2va`와 `ref2va`에 Fun ControlNet Union 지원을 추가하고, 참조와 키프레임 조건을 함께 사용할 수 있습니다
+* [**MiniMax-H3 Reference to Video**](https://github.com/Comfy-Org/ComfyUI/pull/16065): VAE를 선택 사항으로 만들어 참조가 텍스트 인코더만 조건으로 사용되도록 합니다
+* [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-Studio 및 ModelScope로 학습된 LoRA를 지원합니다
+
+**새로운 노드 업데이트**
+* [**LTXV generated keyframes**](https://github.com/Comfy-Org/ComfyUI/pull/16040): 생성된 키프레임을 추가, 분리, 다시 고정하고 Freeze Latent를 제공합니다
+* [**LTXV Add Latent Guide**](https://github.com/Comfy-Org/ComfyUI/pull/16176): 미리 인코딩된 latent를 가이드로 고정하여 VAE 왕복 없이 사용합니다
+* [**Sparse Attention**](https://github.com/Comfy-Org/ComfyUI/pull/16072): comfy-kitchen 희소 백엔드용 Model Sparse Attention 노드
+* [**Color space conversion**](https://github.com/Comfy-Org/ComfyUI/pull/16135): sRGB, HDR HLG, HDR PQ 간 변환
+* [**File3DToMesh**](https://github.com/Comfy-Org/ComfyUI/pull/15919): GLB, GLTF, OBJ, STL 파일을 MESH 파이프라인으로 파싱합니다
+* [**VideoTrim & VideoCrop**](https://github.com/Comfy-Org/ComfyUI/pull/15637): 프론트엔드 VIDEO_EDIT 위젯으로 비디오를 자르고 크롭합니다
+* [**Save Image Advanced AVIF**](https://github.com/Comfy-Org/ComfyUI/pull/15891): Save Image Advanced에 AVIF 출력을 추가했습니다
+* [**cfgpp_ud10_ab sampler**](https://github.com/Comfy-Org/ComfyUI/pull/15951): Anima에서 낮은 스텝에 적합한 CFG++ 샘플러를 추가했습니다
+* [**ResolutionSelector preview**](https://github.com/Comfy-Org/ComfyUI/pull/16013): 종횡비와 메가픽셀 설정에서 너비와 높이를 실시간으로 표시합니다
+
+**파트너 노드 업데이트**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190): OpenAI GPT Image 노드에 Flare 및 Sunburst 모델을 추가했습니다
+
+**성능 및 안정성**
+* [**Comfy Compiler**](https://github.com/Comfy-Org/ComfyUI/pull/15861): Aimdo 메모리 컴파일러와 CUDA graphs로 할당 스래싱을 줄입니다
+* [**TRELLIS memory**](https://github.com/Comfy-Org/ComfyUI/pull/16054): TRELLIS 워크플로의 피크 VRAM과 RAM을 낮췄습니다
+* [**Container cgroup RAM**](https://github.com/Comfy-Org/ComfyUI/pull/15927): 호스트 RAM 대신 컨테이너 메모리 한도를 따릅니다
+* [**RDNA3.5 attention**](https://github.com/Comfy-Org/ComfyUI/pull/16014): gfx1170 및 gfx1171에서 PyTorch SDPA와 FP8 연산을 활성화합니다
+
+**버그 수정**
+* [**MiniMax H3 denoise masks**](https://github.com/Comfy-Org/ComfyUI/pull/15988): x0 변환 전에 denoise mask로 비디오와 오디오 속도를 스케일합니다
+* [**SAM 3 text masks**](https://github.com/Comfy-Org/ComfyUI/pull/15979): scalp=1에서 FPN 4레벨이 전달되어 텍스트 프롬프트 마스크가 비던 문제를 수정했습니다
+* [**Image alpha**](https://github.com/Comfy-Org/ComfyUI/pull/15632): RGB/YUV, Canny, 양자화, 오버레이, 블렌드, 반전, 색 보정 노드에서 알파를 유지합니다
+* [**Switch inputs**](https://github.com/Comfy-Org/ComfyUI/pull/16083): 연결되지 않은 Switch 입력을 허용합니다
+* [**MPS int8**](https://github.com/Comfy-Org/ComfyUI/pull/16130): `torch._int_mm`이 없으면 int8 weight-only 양자화를 비활성화합니다
+
+</Update>
+
+<Update label="v0.34.6" description="2026년 9월 7일">
+
+**파트너 노드 업데이트**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125): 지원되는 OpenAI Chat 모델에 GPT-6 Astra 및 추론 노력 수준을 추가했습니다
+* [**지원 중단된 파트너 모델**](https://github.com/Comfy-Org/ComfyUI/pull/16121): DALL·E 2/3, Kling 비디오 확장, LTX-2 파트너 비디오 노드, ByteDance 이미지(Seedream 3), Seedance 1.0 Lite 옵션을 제거했습니다
+
+</Update>
+
 <Update label="v0.34.5" description="2026년 9월 5일">
+
 
 **파트너 노드 업데이트**
 * [**Comfy Cloud**](https://github.com/Comfy-Org/ComfyUI/pull/15935): Comfy Cloud GPU에서 선별된 FLUX 2, Z-Image Turbo, Mage Flow, MiniMax H3, Music 3 워크플로를 실행하는 베타 노드를 추가했습니다

--- a/zh/changelog/index.mdx
+++ b/zh/changelog/index.mdx
@@ -2,10 +2,12 @@
 title: "更新日志"
 description: "ComfyUI 变更日志：每个版本的最新功能、改进和错误修复，随新版本发布持续更新。"
 icon: "clock-rotate-left"
-translationSourceHash: 451e9d44
+translationSourceHash: 4487ee86
 translationFrom: changelog/index.mdx
 translationBlockHashes:
-  "v0.34.5": 599d1216
+  "v0.35.0": 5d1f806b
+  "v0.34.6": fb20c363
+  "v0.34.5": ac9a5306
   "v0.34.4": e273f769
   "v0.34.3": e91d84d1
   "v0.34.2": dd51aaab
@@ -126,6 +128,53 @@ translationBlockHashes:
   "v0.3.41": f15a2902
   "v0.3.40": 24608eaf
 ---
+
+<Update label="v0.35.0" description="2026年9月9日">
+
+**新增开源模型支持**
+* [**Pixal3D Multi-View**](https://github.com/Comfy-Org/ComfyUI/pull/16048)：通过 Pixal3D Multi-View Conditioning，从前、后、左、右视图重建带纹理的网格
+* [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922)：原生像素空间生成与多参考编辑，最多支持 10 张参考图像
+* [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908)：加载并行解码蒸馏 LoRA，以加速 H3 采样
+* [**MiniMax-H3 Fun ControlNet Union**](https://github.com/Comfy-Org/ComfyUI/pull/16020)：为 `fl2va` 和 `ref2va` 添加 Fun ControlNet Union 支持，可同时使用参考与关键帧条件
+* [**MiniMax-H3 参考转视频**](https://github.com/Comfy-Org/ComfyUI/pull/16065)：使 VAE 可选，以便参考仅通过文本编码器进行条件控制
+* [**MiniMax-H3 与 HiDream O1 LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15662)：支持 DiffSynth-Studio 和 ModelScope 训练的 LoRA
+
+**新节点更新**
+* [**LTXV 生成关键帧**](https://github.com/Comfy-Org/ComfyUI/pull/16040)：添加、分离并重新固定生成的关键帧，以及 Freeze Latent
+* [**LTXV Add Latent Guide**](https://github.com/Comfy-Org/ComfyUI/pull/16176)：将已编码的 latent 固定为引导，无需 VAE 往返
+* [**Sparse Attention**](https://github.com/Comfy-Org/ComfyUI/pull/16072)：用于 comfy-kitchen 稀疏后端的 Model Sparse Attention 节点
+* [**色彩空间转换**](https://github.com/Comfy-Org/ComfyUI/pull/16135)：在 sRGB、HDR HLG 和 HDR PQ 之间转换
+* [**File3DToMesh**](https://github.com/Comfy-Org/ComfyUI/pull/15919)：将 GLB、GLTF、OBJ 和 STL 文件解析到 MESH 管线
+* [**VideoTrim 与 VideoCrop**](https://github.com/Comfy-Org/ComfyUI/pull/15637)：通过前端 VIDEO_EDIT 控件裁剪和修剪视频
+* [**Save Image Advanced AVIF**](https://github.com/Comfy-Org/ComfyUI/pull/15891)：为 Save Image Advanced 添加 AVIF 输出
+* [**cfgpp_ud10_ab 采样器**](https://github.com/Comfy-Org/ComfyUI/pull/15951)：新增在较低步数下对 Anima 效果更好的 CFG++ 采样器
+* [**ResolutionSelector 预览**](https://github.com/Comfy-Org/ComfyUI/pull/16013)：根据宽高比和百万像素设置实时显示宽度和高度
+
+**合作伙伴节点更新**
+* [**GPT Image 2.5**](https://github.com/Comfy-Org/ComfyUI/pull/16190)：为 OpenAI GPT Image 节点添加了 Flare 和 Sunburst 模型
+
+**性能与稳定性**
+* [**Comfy Compiler**](https://github.com/Comfy-Org/ComfyUI/pull/15861)：Aimdo 内存编译器加上 CUDA graphs，减少分配抖动
+* [**TRELLIS 内存**](https://github.com/Comfy-Org/ComfyUI/pull/16054)：降低 TRELLIS 工作流的峰值显存和内存占用
+* [**容器 cgroup 内存**](https://github.com/Comfy-Org/ComfyUI/pull/15927)：遵循容器内存上限，而不是主机 RAM
+* [**RDNA3.5 attention**](https://github.com/Comfy-Org/ComfyUI/pull/16014)：在 gfx1170 和 gfx1171 上启用 PyTorch SDPA 和 FP8 运算
+
+**Bug 修复**
+* [**MiniMax H3 denoise masks**](https://github.com/Comfy-Org/ComfyUI/pull/15988)：在 x0 转换前按 denoise mask 缩放视频和音频速度
+* [**SAM 3 文本遮罩**](https://github.com/Comfy-Org/ComfyUI/pull/15979)：修复 scalp=1 传入四级 FPN 时文本提示遮罩为空的问题
+* [**图像 Alpha**](https://github.com/Comfy-Org/ComfyUI/pull/15632)：在 RGB/YUV、Canny、量化、叠加、混合、反相和颜色调整节点上保留 alpha
+* [**Switch 输入**](https://github.com/Comfy-Org/ComfyUI/pull/16083)：允许 Switch 输入断开连接
+* [**MPS int8**](https://github.com/Comfy-Org/ComfyUI/pull/16130)：在缺少 `torch._int_mm` 时禁用 int8 仅权重量化
+
+</Update>
+
+<Update label="v0.34.6" description="2026年9月7日">
+
+**合作伙伴节点更新**
+* [**GPT-6 Astra**](https://github.com/Comfy-Org/ComfyUI/pull/16125)：为受支持的 OpenAI 聊天模型添加了 GPT-6 Astra 与推理努力级别
+* [**已停用的合作伙伴模型**](https://github.com/Comfy-Org/ComfyUI/pull/16121)：移除了 DALL·E 2/3、Kling 视频扩展、LTX-2 合作伙伴视频节点、字节跳动图片（Seedream 3）和 Seedance 1.0 Lite 选项
+
+</Update>
 
 <Update label="v0.34.5" description="2026年9月5日">
 


### PR DESCRIPTION
## Summary
- Add full docs changelog for ComfyUI v0.34.6 (GPT-6 Astra, retired partner models) and v0.35.0 (Pixal3D Multi-View, SenseNova U1.5, MiniMax-H3, GPT Image 2.5, and related nodes).
- Sync and publish CMS popup copy for **comfyui** and **cloud** in en/zh/ja/ko/fr/ru/es, with Cloud template links and fuller removal notes.
- Tighten CMS staging skill and simplify prompt: name OSS models from tutorials, search the full template index, keep partner EOL on Cloud.

## Test plan
- [x] `pnpm cms:prepare:locales -- --force v0.34.6 v0.35.0`
- [x] `pnpm cms:sync` + `pnpm cms:publish` for `--project comfyui` and `--project cloud`
- [ ] Confirm in-app / Strapi popup for v0.35.0 in a non-EN locale
- [ ] Confirm Cloud Fun Union bullet opens `?template=video_minimax_h3_fun_controlnet_union`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, CMS staging, and LLM prompt/skill text only; no application runtime or auth changes.
> 
> **Overview**
> Adds **v0.34.6** and **v0.35.0** release documentation and syncs them through the CMS pipeline for in-app and Cloud popups.
> 
> **Docs** `changelog/index.mdx` (and **ja/ko/zh**) get full **v0.35.0** notes (OSS models, new nodes, partner GPT Image 2.5, performance/bugs) and **v0.34.6** (GPT-6 Astra plus retired partner models). **Staging** under `.github/scripts/cms/staging/` mirrors shortened popup copy for **comfyui** and **cloud** in seven locales, with Cloud bullets using `?template=` links where applicable and explicit removal lists for **v0.34.6**. **`published-versions.json`** records publish timestamps for both versions on both projects.
> 
> **Process changes:** `cms-changelog-sync` **SKILL.md** and **`cms-simplify-prompt.ts`** now require OSS bullets to use tutorial-style model names (not loader plumbing), full workflow template index search (`api_*` and OSS prefixes), keeping partner EOL/removals on Cloud (even when other bullets are shortened), and positive LoRA/trainer wording without past load bugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938933ee39ce906e467fa9ec74a5222089eddecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->