### PR TITLE
docs(desktop): fix Linux install guide for Ubuntu 26.04

### DIFF
--- a/installation/desktop/faq.mdx
+++ b/installation/desktop/faq.mdx
@@ -98,7 +98,7 @@ Default log folders:
 
 - **Windows:** `%APPDATA%\Comfy Desktop\logs`
 - **macOS:** `~/Library/Logs/Comfy Desktop`
-- **Linux:** `~/.config/comfyui-desktop-2/logs`
+- **Linux:** `~/.config/Comfy Desktop/logs`
 
 Look for `app.log`. Previous sessions rotate to timestamped `app.log_*.log` files.
 

--- a/installation/desktop/faq.mdx
+++ b/installation/desktop/faq.mdx
@@ -24,15 +24,15 @@ See [system requirements](/installation/system_requirements) for full details.
 
 - **Windows:** Windows 10+, x64 or ARM64. A dedicated GPU (NVIDIA / AMD) is recommended, but not required.
 - **macOS:** macOS 13+ (Ventura), Apple Silicon (M1+)
-- **Linux:** No official installer yet. [Build from source](/installation/desktop/linux). A dedicated GPU is recommended.
+- **Linux:** Official `.deb` and AppImage packages are on the [Downloads page](https://comfy.org/download). A dedicated GPU is recommended.
 - **Disk:** At least 4.85 GB per standalone installation
 - **RAM:** 8 GB minimum, 16 GB recommended
 </Accordion>
 <Accordion title="Can I install Comfy Desktop without admin rights?">
-On **Windows**, the standalone installation does not require admin rights. On **macOS**, you'll need admin rights for the initial system-wide installation. On **Linux**, you run from source in user space. You may need admin rights only to install Node.js or other system packages.
+On **Windows**, the standalone installation does not require admin rights. On **macOS**, you'll need admin rights for the initial system-wide installation. On **Linux**, installing the `.deb` package requires `sudo`; the AppImage runs in user space without admin rights.
 </Accordion>
 <Accordion title="How do I download Comfy Desktop?">
-Download the latest Windows or macOS build from the official [ComfyUI Download page](https://comfy.org/download). Linux has no published installer; [build it from source](/installation/desktop/linux).
+Download the latest build from the official [ComfyUI Download page](https://comfy.org/download). Linux installers (`.deb` and AppImage) are also available there. To run from source instead, see [Linux install guide](/installation/desktop/linux).
 </Accordion>
 <Accordion title="Can I have both Legacy Desktop and Comfy Desktop installed?">
 Yes, they can coexist. However, we recommend migrating your installations to the new Comfy Desktop and eventually uninstalling Legacy Desktop. See the [Migration Guide](/installation/desktop/usage/migrate).

--- a/installation/desktop/faq.mdx
+++ b/installation/desktop/faq.mdx
@@ -24,7 +24,7 @@ See [system requirements](/installation/system_requirements) for full details.
 
 - **Windows:** Windows 10+, x64 or ARM64. A dedicated GPU (NVIDIA / AMD) is recommended, but not required.
 - **macOS:** macOS 13+ (Ventura), Apple Silicon (M1+)
-- **Linux:** Official `.deb` and AppImage packages are on the [Downloads page](https://comfy.org/download). A dedicated GPU is recommended.
+- **Linux:** Official `.deb` and AppImage packages are distributed through the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop). A dedicated GPU is recommended.
 - **Disk:** At least 4.85 GB per standalone installation
 - **RAM:** 8 GB minimum, 16 GB recommended
 </Accordion>
@@ -32,7 +32,7 @@ See [system requirements](/installation/system_requirements) for full details.
 On **Windows**, the standalone installation does not require admin rights. On **macOS**, you'll need admin rights for the initial system-wide installation. On **Linux**, installing the `.deb` package requires `sudo`; the AppImage runs in user space without admin rights.
 </Accordion>
 <Accordion title="How do I download Comfy Desktop?">
-Download the latest build from the official [ComfyUI Download page](https://comfy.org/download). Linux installers (`.deb` and AppImage) are also available there. To run from source instead, see [Linux install guide](/installation/desktop/linux).
+Download the latest Windows or macOS build from the official [ComfyUI Download page](https://comfy.org/download). On Linux, download the `.deb` or AppImage with the [universal download link](https://dl.todesktop.com/241130tqe9q3y) from the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop). To run from source instead, see the [Linux install guide](/installation/desktop/linux).
 </Accordion>
 <Accordion title="Can I have both Legacy Desktop and Comfy Desktop installed?">
 Yes, they can coexist. However, we recommend migrating your installations to the new Comfy Desktop and eventually uninstalling Legacy Desktop. See the [Migration Guide](/installation/desktop/usage/migrate).

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -5,7 +5,7 @@ icon: "linux"
 sidebarTitle: "Linux"
 ---
 
-**Comfy Desktop** can run on Linux. The [Downloads page](https://comfy.org/download) ships an official `.deb` package (Debian/Ubuntu) and AppImage. Most users should use one of those. If you want to run the app from source instead, clone the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop).
+**Comfy Desktop** can run on Linux. Official `.deb` (Debian/Ubuntu) and AppImage packages are distributed through the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop). Download them with the [universal download link](https://dl.todesktop.com/241130tqe9q3y), which auto-detects your platform. Most users should use one of those packages. If you want to run the app from source instead, clone the repository and follow the steps below.
 
 ## System Requirements
 
@@ -19,7 +19,7 @@ sidebarTitle: "Linux"
 
 ## Install the official package
 
-Download the `.deb` or AppImage from the [Downloads page](https://comfy.org/download) and install it:
+Download the Linux package with the [universal download link](https://dl.todesktop.com/241130tqe9q3y) (it auto-detects your platform), then install it:
 
 ```bash
 sudo apt install ./*.deb

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -118,3 +118,5 @@ To fully remove everything:
 3. **Delete the data, cache, and state folders**: `~/.local/share/comfyui-desktop-2`, `~/.cache/comfyui-desktop-2`, and `~/.local/state/comfyui-desktop-2`
 4. **Delete individual installations** from within the app, or manually delete `~/ComfyUI-Installs` plus any custom installation directories you configured
 5. **Delete the shared model library** at `~/ComfyUI-Shared` (only if you no longer need these files)
+
+Packaged installs (`.deb` or AppImage) also keep the app profile and logs in `~/.config/Comfy Desktop`. To clear those, run the repository's [reset-linux.sh](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/scripts/reset-linux.sh) script; it removes every known app data location but leaves your `~/ComfyUI-Installs` untouched.

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -29,7 +29,7 @@ For the AppImage:
 
 ```bash
 chmod +x ./*.AppImage
-./<name>.AppImage
+./*.AppImage
 ```
 
 If the app fails to launch, your distribution may be blocking Electron's sandbox (Ubuntu 24.04+ restricts unprivileged user namespaces through AppArmor). In that case retry with `--no-sandbox`. Note that this flag disables Electron sandboxing for every process, so only use it when sandboxed launches fail.

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -29,10 +29,10 @@ For the AppImage:
 
 ```bash
 chmod +x ./*.AppImage
-./*.AppImage --no-sandbox
+./<name>.AppImage
 ```
 
-The `--no-sandbox` flag is needed because Electron's sandbox often fails on Linux without extra setup. It disables Electron sandboxing for every process.
+If the app fails to launch, your distribution may be blocking Electron's sandbox (Ubuntu 24.04+ restricts unprivileged user namespaces through AppArmor). In that case retry with `--no-sandbox`. Note that this flag disables Electron sandboxing for every process, so only use it when sandboxed launches fail.
 
 ## Build and run from source
 

--- a/installation/desktop/linux.mdx
+++ b/installation/desktop/linux.mdx
@@ -1,20 +1,38 @@
 ---
 title: "Comfy Desktop on Linux"
-description: "Comfy Desktop on Linux: no official installer exists. Clone the repo and run from source instead. Requires Ubuntu 22.04+, x64, and Node.js v22 LTS."
+description: "Comfy Desktop on Linux: install from the official .deb or AppImage, or clone the repo and run from source. Requires Ubuntu 22.04+, x64, and Node.js v22 LTS for a source build."
 icon: "linux"
 sidebarTitle: "Linux"
 ---
 
-**Comfy Desktop** can run on Linux, but there is no official published Linux installer yet. The [Downloads page](https://comfy.org/download) ships Windows and macOS only. On Linux, clone the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop) and run it from source.
+**Comfy Desktop** can run on Linux. The [Downloads page](https://comfy.org/download) ships an official `.deb` package (Debian/Ubuntu) and AppImage. Most users should use one of those. If you want to run the app from source instead, clone the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop).
 
 ## System Requirements
 
 - **OS:** Linux (Ubuntu 22.04 or later recommended)
 - **Architecture:** x64
-- **Node.js:** v22 LTS or later
-- **pnpm:** v10 or later (enable with Corepack)
+- **Node.js:** v22 LTS or later (source build only)
+- **pnpm:** v10 or later, enabled with Corepack (source build only)
+- **Build tools:** `build-essential` and `git` (source build only)
 - **GPU:** A dedicated GPU (NVIDIA / AMD) is recommended, but not required
 - **Disk Space:** At least 4.85 GB recommended per ComfyUI installation
+
+## Install the official package
+
+Download the `.deb` or AppImage from the [Downloads page](https://comfy.org/download) and install it:
+
+```bash
+sudo apt install ./*.deb
+```
+
+For the AppImage:
+
+```bash
+chmod +x ./*.AppImage
+./*.AppImage --no-sandbox
+```
+
+The `--no-sandbox` flag is needed because Electron's sandbox often fails on Linux without extra setup. It disables Electron sandboxing for every process.
 
 ## Build and run from source
 
@@ -22,7 +40,13 @@ These steps match the [Development](https://github.com/Comfy-Org/Comfy-Desktop#d
 
 ### Prerequisites
 
-Install Node.js 22, then enable pnpm:
+Install the build tools and git first. A fresh Ubuntu install ships without them, and `pnpm run init` compiles native modules such as `node-pty`, which fails with `Error: not found: make` if `build-essential` is missing:
+
+```bash
+sudo apt install build-essential git
+```
+
+Then install Node.js 22 and enable pnpm:
 
 ```bash
 nvm install 22 && nvm use 22

--- a/installation/desktop/overview.mdx
+++ b/installation/desktop/overview.mdx
@@ -11,7 +11,7 @@ To put it simply: **Comfy Desktop** is the app that manages and launches **Comfy
 
 ![Comfy Desktop screenshot](/images/desktop/usage/01-homepage.png)
 
-Comfy Desktop runs on **Windows 10+** and **macOS 13+ (Apple Silicon)**. Linux has no official installer yet; you can [build it from source](/installation/desktop/linux). Each standalone installation requires at least **4.85 GB** of disk space and **8 GB RAM (16 GB recommended)**. Check the platform-specific pages for full details.
+Comfy Desktop runs on **Windows 10+**, **macOS 13+ (Apple Silicon)**, and **Linux** (official `.deb` and AppImage packages). Each standalone installation requires at least **4.85 GB** of disk space and **8 GB RAM (16 GB recommended)**. Check the platform-specific pages for full details.
 
 ## Get Started
 
@@ -27,7 +27,7 @@ Choose your platform to begin:
   </Card>
 
   <Card title="Linux" icon="linux" href="/installation/desktop/linux">
-    Build and run from source. No official Linux installer yet.
+    Install the official `.deb` or AppImage, or build from source.
   </Card>
 </CardGroup>
 

--- a/ja/installation/desktop/faq.mdx
+++ b/ja/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop FAQ"
 description: "Comfy Desktop に関するよくある質問とトラブルシューティング"
 sidebarTitle: "FAQ"
-translationSourceHash: 140c8d7c
+translationSourceHash: 4bd257d6
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": 99b8522c
+  "Installation & Setup": a8b07570
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,15 +32,15 @@ Comfy Desktop は複数のインストール方法の一つです。**Portable�
 
 - **Windows：** Windows 10+、x64 または ARM64。専用 GPU（NVIDIA / AMD）が推奨されますが、必須ではありません。
 - **macOS：** macOS 13+ (Ventura)、Apple Silicon (M1+)
-- **Linux：** 公式インストーラーはまだありません。[ソースからビルド](/ja/installation/desktop/linux)してください。専用 GPU が推奨されます。
+- **Linux：** 公式の `.deb` および AppImage パッケージは[ダウンロードページ](https://comfy.org/download)にあります。専用 GPU が推奨されます。
 - **ディスク：** スタンドアロンインストールごとに最低 4.85 GB
 - **RAM：** 最低 8 GB、推奨 16 GB
 </Accordion>
 <Accordion title="管理者権限なしで Comfy Desktop をインストールできますか？">
-**Windows** のスタンドアロンインストールは管理者権限を必要としません。**macOS** は、システム全体への初回インストール時に管理者権限が必要です。**Linux** はソースからユーザースペースで実行します。Node.js などのシステムパッケージを入れるときだけ管理者権限が必要になることがあります。
+**Windows** のスタンドアロンインストールは管理者権限を必要としません。**macOS** は、システム全体への初回インストール時に管理者権限が必要です。**Linux** では `.deb` パッケージのインストールに `sudo` が必要です。AppImage は管理者権限なしでユーザースペースで実行できます。
 </Accordion>
 <Accordion title="Comfy Desktop をダウンロードするには？">
-公式 [ComfyUI ダウンロードページ](https://comfy.org/download) から最新の Windows または macOS ビルドをダウンロードしてください。Linux には公開インストーラーがなく、[ソースからビルド](/ja/installation/desktop/linux)します。
+公式 [ComfyUI ダウンロードページ](https://comfy.org/download) から最新ビルドをダウンロードしてください。Linux 用インストーラー（`.deb` と AppImage）も同じページにあります。ソースから実行する場合は [Linux インストールガイド](/ja/installation/desktop/linux) を参照してください。
 </Accordion>
 <Accordion title="Legacy Desktop と Comfy Desktop の両方をインストールできますか？">
 はい、共存できます。ただし、インストール済みの環境を新しい Comfy Desktop に移行し、最終的に Legacy Desktop をアンインストールすることを推奨します。[移行ガイド](/ja/installation/desktop/usage/migrate) を参照してください。

--- a/ja/installation/desktop/faq.mdx
+++ b/ja/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop FAQ"
 description: "Comfy Desktop に関するよくある質問とトラブルシューティング"
 sidebarTitle: "FAQ"
-translationSourceHash: 4bd257d6
+translationSourceHash: 63620620
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": a8b07570
+  "Installation & Setup": b5578878
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,7 +32,7 @@ Comfy Desktop は複数のインストール方法の一つです。**Portable�
 
 - **Windows：** Windows 10+、x64 または ARM64。専用 GPU（NVIDIA / AMD）が推奨されますが、必須ではありません。
 - **macOS：** macOS 13+ (Ventura)、Apple Silicon (M1+)
-- **Linux：** 公式の `.deb` および AppImage パッケージは[ダウンロードページ](https://comfy.org/download)にあります。専用 GPU が推奨されます。
+- **Linux：** 公式の `.deb` および AppImage パッケージは [Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) を通じて配布されています。専用 GPU が推奨されます。
 - **ディスク：** スタンドアロンインストールごとに最低 4.85 GB
 - **RAM：** 最低 8 GB、推奨 16 GB
 </Accordion>
@@ -40,7 +40,7 @@ Comfy Desktop は複数のインストール方法の一つです。**Portable�
 **Windows** のスタンドアロンインストールは管理者権限を必要としません。**macOS** は、システム全体への初回インストール時に管理者権限が必要です。**Linux** では `.deb` パッケージのインストールに `sudo` が必要です。AppImage は管理者権限なしでユーザースペースで実行できます。
 </Accordion>
 <Accordion title="Comfy Desktop をダウンロードするには？">
-公式 [ComfyUI ダウンロードページ](https://comfy.org/download) から最新ビルドをダウンロードしてください。Linux 用インストーラー（`.deb` と AppImage）も同じページにあります。ソースから実行する場合は [Linux インストールガイド](/ja/installation/desktop/linux) を参照してください。
+公式 [ComfyUI ダウンロードページ](https://comfy.org/download) から最新の Windows または macOS ビルドをダウンロードしてください。Linux では [Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) の[ユニバーサルダウンロードリンク](https://dl.todesktop.com/241130tqe9q3y)から `.deb` または AppImage を入手できます。ソースから実行する場合は [Linux インストールガイド](/ja/installation/desktop/linux) を参照してください。
 </Accordion>
 <Accordion title="Legacy Desktop と Comfy Desktop の両方をインストールできますか？">
 はい、共存できます。ただし、インストール済みの環境を新しい Comfy Desktop に移行し、最終的に Legacy Desktop をアンインストールすることを推奨します。[移行ガイド](/ja/installation/desktop/usage/migrate) を参照してください。

--- a/ja/installation/desktop/faq.mdx
+++ b/ja/installation/desktop/faq.mdx
@@ -2,13 +2,13 @@
 title: "Comfy Desktop FAQ"
 description: "Comfy Desktop に関するよくある質問とトラブルシューティング"
 sidebarTitle: "FAQ"
-translationSourceHash: 63620620
+translationSourceHash: a124f5aa
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
   "Installation & Setup": b5578878
   "Usage": b5abdafd
-  "Troubleshooting": 890673f8
+  "Troubleshooting": 9bcd69c3
 ---
 
 ## 一般質問
@@ -108,7 +108,7 @@ Desktop アプリはローテーションする `app.log` ファイルに書き�
 
 - **Windows:** `%APPDATA%\Comfy Desktop\logs`
 - **macOS:** `~/Library/Logs/Comfy Desktop`
-- **Linux:** `~/.config/comfyui-desktop-2/logs`
+- **Linux:** `~/.config/Comfy Desktop/logs`
 
 `app.log` を探してください。以前のセッションはタイムスタンプ付きの `app.log_*.log` ファイルにローテーションされます。
 

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -3,19 +3,19 @@ title: "Linux 版 Comfy Desktop"
 description: "Linux 版 Comfy Desktop：公式の .deb または AppImage でインストールするか、リポジトリをクローンしてソースから実行します。ソースビルドには Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b8ccb49d
+translationSourceHash: bcc51bea
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": d98a6de1
+  "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 2603fe88
+  "Install the official package": 89c30b2e
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop** は Linux で動作します。[ダウンロードページ](https://comfy.org/download) では公式の `.deb` パッケージ（Debian/Ubuntu）と AppImage が配布されています。ほとんどのユーザーはこれらの利用を推奨します。ソースから実行したい場合は、[Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) をクローンしてください。
+**Comfy Desktop** は Linux で動作します。公式の `.deb` パッケージ（Debian/Ubuntu）と AppImage は [Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) を通じて配布されています。[ユニバーサルダウンロードリンク](https://dl.todesktop.com/241130tqe9q3y)（プラットフォームを自動判別）からダウンロードしてください。ほとんどのユーザーはこれらのパッケージの利用を推奨します。ソースから実行したい場合は、リポジトリをクローンして以下の手順に従ってください。
 
 ## システム要件
 
@@ -29,7 +29,7 @@ translationBlockHashes:
 
 ## 公式パッケージのインストール
 
-[ダウンロードページ](https://comfy.org/download) から `.deb` または AppImage をダウンロードしてインストールします:
+[ユニバーサルダウンロードリンク](https://dl.todesktop.com/241130tqe9q3y)（プラットフォームを自動判別）から Linux パッケージをダウンロードしてインストールします:
 
 ```bash
 sudo apt install ./*.deb

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux 版 Comfy Desktop"
 description: "Linux 版 Comfy Desktop：公式の .deb または AppImage でインストールするか、リポジトリをクローンしてソースから実行します。ソースビルドには Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 75f31979
+translationSourceHash: b8ccb49d
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": d98a6de1
   "System Requirements": 409b2af2
-  "Install the official package": 135f26e2
+  "Install the official package": 2603fe88
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,10 +39,10 @@ AppImage の場合:
 
 ```bash
 chmod +x ./*.AppImage
-./*.AppImage --no-sandbox
+./<name>.AppImage
 ```
 
-`--no-sandbox` フラグが必要なのは、追加設定なしでは Linux で Electron のサンドボックスが失敗しやすいためです。このフラグはすべてのプロセスで Electron のサンドボックスを無効にします。
+起動に失敗する場合、ディストリビューションが Electron のサンドボックスをブロックしている可能性があります（Ubuntu 24.04 以降は AppArmor が非特権ユーザー名前空間を制限します）。その場合は `--no-sandbox` を付けて再試行してください。このフラグはすべてのプロセスで Electron のサンドボックスを無効にするため、サンドボックス有効の起動が失敗する場合のみ使ってください。
 
 ## ソースからビルドして実行
 

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -3,7 +3,7 @@ title: "Linux 版 Comfy Desktop"
 description: "Linux 版 Comfy Desktop：公式の .deb または AppImage でインストールするか、リポジトリをクローンしてソースから実行します。ソースビルドには Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 9a0099dd
+translationSourceHash: e5b27cc1
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
@@ -12,7 +12,7 @@ translationBlockHashes:
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
-  "Removing leftover data": a2df8410
+  "Removing leftover data": a42f3904
 ---
 
 **Comfy Desktop** は Linux で動作します。公式の `.deb` パッケージ（Debian/Ubuntu）と AppImage は [Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) を通じて配布されています。[ユニバーサルダウンロードリンク](https://dl.todesktop.com/241130tqe9q3y)（プラットフォームを自動判別）からダウンロードしてください。ほとんどのユーザーはこれらのパッケージの利用を推奨します。ソースから実行したい場合は、リポジトリをクローンして以下の手順に従ってください。
@@ -128,3 +128,5 @@ pnpm run build:linux
 3. **データ、キャッシュ、状態フォルダーを削除**: `~/.local/share/comfyui-desktop-2`、`~/.cache/comfyui-desktop-2`、`~/.local/state/comfyui-desktop-2`
 4. **個々のインストールを削除**: アプリ内から削除するか、`~/ComfyUI-Installs` と設定したカスタムインストールディレクトリを手動で削除します
 5. **共有モデルライブラリを削除**: `~/ComfyUI-Shared`の共有モデルライブラリを削除（これらのファイルが不要な場合のみ）
+
+`.deb` または AppImage でインストールした場合、アプリのプロファイルとログは `~/.config/Comfy Desktop` にも保存されます。リポジトリの [reset-linux.sh](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/scripts/reset-linux.sh) を実行すると、既知のアプリデータをすべて削除できます（`~/ComfyUI-Installs` はそのまま残ります）。

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -1,29 +1,48 @@
 ---
 title: "Linux 版 Comfy Desktop"
-description: "Linux 版 Comfy Desktop：公式インストーラーは存在しないため、リポジトリをクローンしてソースから実行します。Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
+description: "Linux 版 Comfy Desktop：公式の .deb または AppImage でインストールするか、リポジトリをクローンしてソースから実行します。ソースビルドには Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b42848c3
+translationSourceHash: 75f31979
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": e92746cf
-  "System Requirements": a66d549d
-  "Build and run from source": ec8a8f51
+  "_intro": d98a6de1
+  "System Requirements": 409b2af2
+  "Install the official package": 135f26e2
+  "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop** は Linux で動作しますが、公式の Linux インストーラーはまだ公開されていません。[ダウンロードページ](https://comfy.org/download) は Windows と macOS のみです。Linux では [Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) をクローンしてソースから実行してください。
+**Comfy Desktop** は Linux で動作します。[ダウンロードページ](https://comfy.org/download) では公式の `.deb` パッケージ（Debian/Ubuntu）と AppImage が配布されています。ほとんどのユーザーはこれらの利用を推奨します。ソースから実行したい場合は、[Comfy Desktop リポジトリ](https://github.com/Comfy-Org/Comfy-Desktop) をクローンしてください。
 
 ## システム要件
 
 - **OS:** Linux（Ubuntu 22.04 以降を推奨）
 - **アーキテクチャ:** x64
-- **Node.js:** v22 LTS 以降
-- **pnpm:** v10 以降（Corepack で有効化）
+- **Node.js:** v22 LTS 以降（ソースビルドのみ）
+- **pnpm:** v10 以降、Corepack で有効化（ソースビルドのみ）
+- **ビルドツール:** `build-essential` と `git`（ソースビルドのみ）
 - **GPU:** 専用 GPU（NVIDIA / AMD）を推奨しますが、必須ではありません
 - **ディスク容量:** ComfyUI インストールごとに少なくとも 4.85 GB を推奨
+
+## 公式パッケージのインストール
+
+[ダウンロードページ](https://comfy.org/download) から `.deb` または AppImage をダウンロードしてインストールします:
+
+```bash
+sudo apt install ./*.deb
+```
+
+AppImage の場合:
+
+```bash
+chmod +x ./*.AppImage
+./*.AppImage --no-sandbox
+```
+
+`--no-sandbox` フラグが必要なのは、追加設定なしでは Linux で Electron のサンドボックスが失敗しやすいためです。このフラグはすべてのプロセスで Electron のサンドボックスを無効にします。
 
 ## ソースからビルドして実行
 
@@ -31,7 +50,13 @@ translationBlockHashes:
 
 ### 前提条件
 
-Node.js 22 をインストールし、pnpm を有効にします:
+まずビルドツールと git をインストールします。新規インストールした Ubuntu にはこれらが含まれておらず、`pnpm run init` は `node-pty` などのネイティブモジュールをコンパイルするため、`build-essential` がないと `Error: not found: make` で失敗します:
+
+```bash
+sudo apt install build-essential git
+```
+
+次に Node.js 22 をインストールし、pnpm を有効にします:
 
 ```bash
 nvm install 22 && nvm use 22

--- a/ja/installation/desktop/linux.mdx
+++ b/ja/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux 版 Comfy Desktop"
 description: "Linux 版 Comfy Desktop：公式の .deb または AppImage でインストールするか、リポジトリをクローンしてソースから実行します。ソースビルドには Ubuntu 22.04+、x64、Node.js v22 LTS が必要です。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: bcc51bea
+translationSourceHash: 9a0099dd
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 89c30b2e
+  "Install the official package": c9a03f09
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,7 +39,7 @@ AppImage の場合:
 
 ```bash
 chmod +x ./*.AppImage
-./<name>.AppImage
+./*.AppImage
 ```
 
 起動に失敗する場合、ディストリビューションが Electron のサンドボックスをブロックしている可能性があります（Ubuntu 24.04 以降は AppArmor が非特権ユーザー名前空間を制限します）。その場合は `--no-sandbox` を付けて再試行してください。このフラグはすべてのプロセスで Electron のサンドボックスを無効にするため、サンドボックス有効の起動が失敗する場合のみ使ってください。

--- a/ja/installation/desktop/overview.mdx
+++ b/ja/installation/desktop/overview.mdx
@@ -3,7 +3,7 @@ title: "Comfy Desktop 概要"
 description: "Comfy Desktop の概要：生成 AI 向けノードベースエンジンである ComfyUI の複数インスタンスをインストール・管理・起動するデスクトップアプリ。"
 icon: "desktop"
 sidebarTitle: "概要"
-translationSourceHash: 7ad9cbf9
+translationSourceHash: f1e6d02d
 translationFrom: installation/desktop/overview.mdx
 ---
 
@@ -13,7 +13,7 @@ translationFrom: installation/desktop/overview.mdx
 
 ![Comfy Desktop スクリーンショット](/images/desktop/usage/01-homepage.png)
 
-Comfy Desktop は **Windows 10+** と **macOS 13+（Apple Silicon）** に対応しています。Linux には公式インストーラーがまだなく、[ソースからビルド](/ja/installation/desktop/linux)できます。各スタンドアロンインストールには少なくとも **4.85 GB** のディスク容量と **8 GB RAM（推奨 16 GB）** が必要です。詳細は各プラットフォームのインストールページをご覧ください。
+Comfy Desktop は **Windows 10+**、**macOS 13+（Apple Silicon）**、**Linux**（公式の `.deb` および AppImage パッケージ）に対応しています。各スタンドアロンインストールには少なくとも **4.85 GB** のディスク容量と **8 GB RAM（推奨 16 GB）** が必要です。詳細は各プラットフォームのインストールページをご覧ください。
 
 ## はじめる
 
@@ -29,7 +29,7 @@ Comfy Desktop は **Windows 10+** と **macOS 13+（Apple Silicon）** に対応
   </Card>
 
   <Card title="Linux" icon="linux" href="/ja/installation/desktop/linux">
-    ソースからビルドして実行します。公式 Linux インストーラーはまだありません。
+    公式の `.deb` または AppImage をインストールするか、ソースからビルドします。
   </Card>
 </CardGroup>
 

--- a/ko/installation/desktop/faq.mdx
+++ b/ko/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop 자주 묻는 질문"
 description: "Comfy Desktop에 대한 일반적인 질문과 문제 해결 팁"
 sidebarTitle: "자주 묻는 질문"
-translationSourceHash: 140c8d7c
+translationSourceHash: 4bd257d6
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": 99b8522c
+  "Installation & Setup": a8b07570
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,15 +32,15 @@ Comfy Desktop은 여러 설치 옵션 중 하나입니다. 필요에 따라 **Po
 
 - **Windows:** Windows 10 이상, x64 또는 ARM64. 전용 GPU (NVIDIA / AMD)가 권장되지만 필수는 아닙니다.
 - **macOS:** macOS 13 이상 (Ventura), Apple Silicon (M1 이상)
-- **Linux:** 아직 공식 설치 프로그램이 없습니다. [소스에서 빌드](/ko/installation/desktop/linux)하세요. 전용 GPU가 권장됩니다.
+- **Linux:** 공식 `.deb` 및 AppImage 패키지는 [다운로드 페이지](https://comfy.org/download)에 있습니다. 전용 GPU가 권장됩니다.
 - **디스크:** 독립형 설치당 최소 4.85 GB
 - **RAM:** 최소 8 GB, 16 GB 권장
 </Accordion>
 <Accordion title="관리자 권한 없이 Comfy Desktop을 설치할 수 있나요?">
-**Windows**에서는 독립형 설치에 관리자 권한이 필요하지 않습니다. **macOS**에서는 초기 시스템 전체 설치에 관리자 권한이 필요합니다. **Linux**에서는 소스에서 사용자 공간으로 실행합니다. Node.js 같은 시스템 패키지를 설치할 때만 관리자 권한이 필요할 수 있습니다.
+**Windows**에서는 독립형 설치에 관리자 권한이 필요하지 않습니다. **macOS**에서는 초기 시스템 전체 설치에 관리자 권한이 필요합니다. **Linux**에서는 `.deb` 패키지 설치에 `sudo`가 필요합니다. AppImage는 관리자 권한 없이 사용자 공간에서 실행됩니다.
 </Accordion>
 <Accordion title="Comfy Desktop은 어떻게 다운로드하나요?">
-공식 [ComfyUI 다운로드 페이지](https://comfy.org/download)에서 최신 Windows 또는 macOS 빌드를 다운로드하세요. Linux에는 공개 설치 프로그램이 없으며 [소스에서 빌드](/ko/installation/desktop/linux)하세요.
+공식 [ComfyUI 다운로드 페이지](https://comfy.org/download)에서 최신 빌드를 다운로드하세요. Linux용 설치 프로그램(`.deb` 및 AppImage)도 같은 페이지에서 제공됩니다. 소스에서 실행하려면 [Linux 설치 가이드](/ko/installation/desktop/linux)를 참조하세요.
 </Accordion>
 <Accordion title="레거시 데스크톱과 Comfy Desktop을 모두 설치할 수 있나요?">
 네, 공존할 수 있습니다. 하지만 설치된 프로그램을 새로운 Comfy Desktop으로 이전하고 최종적으로 레거시 데스크톱을 제거하는 것이 좋습니다. [마이그레이션 가이드](/ko/installation/desktop/usage/migrate)를 참조하세요.

--- a/ko/installation/desktop/faq.mdx
+++ b/ko/installation/desktop/faq.mdx
@@ -2,13 +2,13 @@
 title: "Comfy Desktop 자주 묻는 질문"
 description: "Comfy Desktop에 대한 일반적인 질문과 문제 해결 팁"
 sidebarTitle: "자주 묻는 질문"
-translationSourceHash: 63620620
+translationSourceHash: a124f5aa
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
   "Installation & Setup": b5578878
   "Usage": b5abdafd
-  "Troubleshooting": 890673f8
+  "Troubleshooting": 9bcd69c3
 ---
 
 ## 일반 질문
@@ -107,7 +107,7 @@ Desktop 앱은 순환되는 `app.log` 파일에 기록합니다. 가장 빠른 �
 
 - **Windows:** `%APPDATA%\Comfy Desktop\logs`
 - **macOS:** `~/Library/Logs/Comfy Desktop`
-- **Linux:** `~/.config/comfyui-desktop-2/logs`
+- **Linux:** `~/.config/Comfy Desktop/logs`
 
 `app.log`를 찾으세요. 이전 세션은 타임스탬프가 붙은 `app.log_*.log` 파일로 순환됩니다.
 

--- a/ko/installation/desktop/faq.mdx
+++ b/ko/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop 자주 묻는 질문"
 description: "Comfy Desktop에 대한 일반적인 질문과 문제 해결 팁"
 sidebarTitle: "자주 묻는 질문"
-translationSourceHash: 4bd257d6
+translationSourceHash: 63620620
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": a8b07570
+  "Installation & Setup": b5578878
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,7 +32,7 @@ Comfy Desktop은 여러 설치 옵션 중 하나입니다. 필요에 따라 **Po
 
 - **Windows:** Windows 10 이상, x64 또는 ARM64. 전용 GPU (NVIDIA / AMD)가 권장되지만 필수는 아닙니다.
 - **macOS:** macOS 13 이상 (Ventura), Apple Silicon (M1 이상)
-- **Linux:** 공식 `.deb` 및 AppImage 패키지는 [다운로드 페이지](https://comfy.org/download)에 있습니다. 전용 GPU가 권장됩니다.
+- **Linux:** 공식 `.deb` 및 AppImage 패키지는 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 통해 배포됩니다. 전용 GPU가 권장됩니다.
 - **디스크:** 독립형 설치당 최소 4.85 GB
 - **RAM:** 최소 8 GB, 16 GB 권장
 </Accordion>
@@ -40,7 +40,7 @@ Comfy Desktop은 여러 설치 옵션 중 하나입니다. 필요에 따라 **Po
 **Windows**에서는 독립형 설치에 관리자 권한이 필요하지 않습니다. **macOS**에서는 초기 시스템 전체 설치에 관리자 권한이 필요합니다. **Linux**에서는 `.deb` 패키지 설치에 `sudo`가 필요합니다. AppImage는 관리자 권한 없이 사용자 공간에서 실행됩니다.
 </Accordion>
 <Accordion title="Comfy Desktop은 어떻게 다운로드하나요?">
-공식 [ComfyUI 다운로드 페이지](https://comfy.org/download)에서 최신 빌드를 다운로드하세요. Linux용 설치 프로그램(`.deb` 및 AppImage)도 같은 페이지에서 제공됩니다. 소스에서 실행하려면 [Linux 설치 가이드](/ko/installation/desktop/linux)를 참조하세요.
+공식 [ComfyUI 다운로드 페이지](https://comfy.org/download)에서 최신 Windows 또는 macOS 빌드를 다운로드하세요. Linux에서는 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)의 [범용 다운로드 링크](https://dl.todesktop.com/241130tqe9q3y)에서 `.deb` 또는 AppImage를 받을 수 있습니다. 소스에서 실행하려면 [Linux 설치 가이드](/ko/installation/desktop/linux)를 참조하세요.
 </Accordion>
 <Accordion title="레거시 데스크톱과 Comfy Desktop을 모두 설치할 수 있나요?">
 네, 공존할 수 있습니다. 하지만 설치된 프로그램을 새로운 Comfy Desktop으로 이전하고 최종적으로 레거시 데스크톱을 제거하는 것이 좋습니다. [마이그레이션 가이드](/ko/installation/desktop/usage/migrate)를 참조하세요.

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux용 Comfy Desktop"
 description: "Linux용 Comfy Desktop: 공식 .deb 또는 AppImage로 설치하거나, 저장소를 클론하여 소스에서 실행합니다. 소스 빌드에는 Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: bcc51bea
+translationSourceHash: 9a0099dd
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 89c30b2e
+  "Install the official package": c9a03f09
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,7 +39,7 @@ AppImage 사용 방법:
 
 ```bash
 chmod +x ./*.AppImage
-./<name>.AppImage
+./*.AppImage
 ```
 
 앱이 실행되지 않으면 배포판이 Electron 샌드박스를 차단하고 있을 수 있습니다(Ubuntu 24.04+는 AppArmor로 비특권 user namespace를 제한합니다). 이 경우 `--no-sandbox`를 붙여 다시 시도하세요. 이 플래그는 모든 프로세스의 Electron 샌드박스를 끄므로 샌드박스 실행이 실패할 때만 사용하세요.

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -3,19 +3,19 @@ title: "Linux용 Comfy Desktop"
 description: "Linux용 Comfy Desktop: 공식 .deb 또는 AppImage로 설치하거나, 저장소를 클론하여 소스에서 실행합니다. 소스 빌드에는 Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b8ccb49d
+translationSourceHash: bcc51bea
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": d98a6de1
+  "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 2603fe88
+  "Install the official package": 89c30b2e
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop**은 Linux에서 실행할 수 있습니다. [다운로드 페이지](https://comfy.org/download)에서 공식 `.deb` 패키지(Debian/Ubuntu)와 AppImage를 제공합니다. 대부분의 사용자는 이 중 하나를 사용하는 것을 권장합니다. 소스에서 앱을 실행하려면 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 클론하세요.
+**Comfy Desktop**은 Linux에서 실행할 수 있습니다. 공식 `.deb` 패키지(Debian/Ubuntu)와 AppImage는 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 통해 배포됩니다. [범용 다운로드 링크](https://dl.todesktop.com/241130tqe9q3y)에서 다운로드하세요(플랫폼을 자동으로 감지합니다). 대부분의 사용자는 이 패키지 중 하나를 사용하는 것을 권장합니다. 소스에서 앱을 실행하려면 저장소를 클론하고 아래 단계를 따르세요.
 
 ## 시스템 요구 사항
 
@@ -29,7 +29,7 @@ translationBlockHashes:
 
 ## 공식 패키지 설치
 
-[다운로드 페이지](https://comfy.org/download)에서 `.deb` 또는 AppImage를 다운로드해 설치하세요:
+[범용 다운로드 링크](https://dl.todesktop.com/241130tqe9q3y)로 Linux 패키지를 다운로드한 뒤 설치하세요(플랫폼을 자동으로 감지합니다):
 
 ```bash
 sudo apt install ./*.deb

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux용 Comfy Desktop"
 description: "Linux용 Comfy Desktop: 공식 .deb 또는 AppImage로 설치하거나, 저장소를 클론하여 소스에서 실행합니다. 소스 빌드에는 Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 75f31979
+translationSourceHash: b8ccb49d
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": d98a6de1
   "System Requirements": 409b2af2
-  "Install the official package": 135f26e2
+  "Install the official package": 2603fe88
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,10 +39,10 @@ AppImage 사용 방법:
 
 ```bash
 chmod +x ./*.AppImage
-./*.AppImage --no-sandbox
+./<name>.AppImage
 ```
 
-`--no-sandbox` 플래그가 필요한 이유는 추가 설정 없이는 Linux에서 Electron 샌드박스가 자주 실패하기 때문입니다. 이 플래그는 모든 프로세스의 Electron 샌드박스를 끕니다.
+앱이 실행되지 않으면 배포판이 Electron 샌드박스를 차단하고 있을 수 있습니다(Ubuntu 24.04+는 AppArmor로 비특권 user namespace를 제한합니다). 이 경우 `--no-sandbox`를 붙여 다시 시도하세요. 이 플래그는 모든 프로세스의 Electron 샌드박스를 끄므로 샌드박스 실행이 실패할 때만 사용하세요.
 
 ## 소스에서 빌드하고 실행
 

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -1,29 +1,48 @@
 ---
 title: "Linux용 Comfy Desktop"
-description: "Linux용 Comfy Desktop: 공식 설치 프로그램이 없으므로 리포지토리를 클론하여 소스에서 실행합니다. Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
+description: "Linux용 Comfy Desktop: 공식 .deb 또는 AppImage로 설치하거나, 저장소를 클론하여 소스에서 실행합니다. 소스 빌드에는 Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b42848c3
+translationSourceHash: 75f31979
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": e92746cf
-  "System Requirements": a66d549d
-  "Build and run from source": ec8a8f51
+  "_intro": d98a6de1
+  "System Requirements": 409b2af2
+  "Install the official package": 135f26e2
+  "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop**은 Linux에서 실행할 수 있지만, 아직 공식 Linux 설치 프로그램은 없습니다. [다운로드 페이지](https://comfy.org/download)는 Windows와 macOS만 제공합니다. Linux에서는 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 클론한 뒤 소스에서 실행하세요.
+**Comfy Desktop**은 Linux에서 실행할 수 있습니다. [다운로드 페이지](https://comfy.org/download)에서 공식 `.deb` 패키지(Debian/Ubuntu)와 AppImage를 제공합니다. 대부분의 사용자는 이 중 하나를 사용하는 것을 권장합니다. 소스에서 앱을 실행하려면 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 클론하세요.
 
 ## 시스템 요구 사항
 
 - **OS:** Linux (Ubuntu 22.04 이상 권장)
 - **아키텍처:** x64
-- **Node.js:** v22 LTS 이상
-- **pnpm:** v10 이상 (Corepack으로 활성화)
+- **Node.js:** v22 LTS 이상 (소스 빌드만)
+- **pnpm:** v10 이상, Corepack으로 활성화 (소스 빌드만)
+- **빌드 도구:** `build-essential` 및 `git` (소스 빌드만)
 - **GPU:** 전용 GPU(NVIDIA / AMD)를 권장하지만 필수는 아닙니다
 - **디스크 공간:** ComfyUI 설치마다 최소 4.85 GB 권장
+
+## 공식 패키지 설치
+
+[다운로드 페이지](https://comfy.org/download)에서 `.deb` 또는 AppImage를 다운로드해 설치하세요:
+
+```bash
+sudo apt install ./*.deb
+```
+
+AppImage 사용 방법:
+
+```bash
+chmod +x ./*.AppImage
+./*.AppImage --no-sandbox
+```
+
+`--no-sandbox` 플래그가 필요한 이유는 추가 설정 없이는 Linux에서 Electron 샌드박스가 자주 실패하기 때문입니다. 이 플래그는 모든 프로세스의 Electron 샌드박스를 끕니다.
 
 ## 소스에서 빌드하고 실행
 
@@ -31,7 +50,13 @@ translationBlockHashes:
 
 ### 사전 요구 사항
 
-Node.js 22를 설치한 다음 pnpm을 활성화하세요:
+먼저 빌드 도구와 git을 설치하세요. 새로 설치한 Ubuntu에는 기본으로 포함되어 있지 않으며, `pnpm run init`은 `node-pty` 같은 네이티브 모듈을 컴파일하므로 `build-essential`이 없으면 `Error: not found: make`로 실패합니다:
+
+```bash
+sudo apt install build-essential git
+```
+
+그다음 Node.js 22를 설치하고 pnpm을 활성화하세요:
 
 ```bash
 nvm install 22 && nvm use 22

--- a/ko/installation/desktop/linux.mdx
+++ b/ko/installation/desktop/linux.mdx
@@ -3,7 +3,7 @@ title: "Linux용 Comfy Desktop"
 description: "Linux용 Comfy Desktop: 공식 .deb 또는 AppImage로 설치하거나, 저장소를 클론하여 소스에서 실행합니다. 소스 빌드에는 Ubuntu 22.04+, x64, Node.js v22 LTS가 필요합니다."
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 9a0099dd
+translationSourceHash: e5b27cc1
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
@@ -12,7 +12,7 @@ translationBlockHashes:
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
-  "Removing leftover data": a2df8410
+  "Removing leftover data": a42f3904
 ---
 
 **Comfy Desktop**은 Linux에서 실행할 수 있습니다. 공식 `.deb` 패키지(Debian/Ubuntu)와 AppImage는 [Comfy Desktop 저장소](https://github.com/Comfy-Org/Comfy-Desktop)를 통해 배포됩니다. [범용 다운로드 링크](https://dl.todesktop.com/241130tqe9q3y)에서 다운로드하세요(플랫폼을 자동으로 감지합니다). 대부분의 사용자는 이 패키지 중 하나를 사용하는 것을 권장합니다. 소스에서 앱을 실행하려면 저장소를 클론하고 아래 단계를 따르세요.
@@ -128,3 +128,5 @@ pnpm run build:linux
 3. **데이터, 캐시, 상태 폴더 삭제**: `~/.local/share/comfyui-desktop-2`, `~/.cache/comfyui-desktop-2`, `~/.local/state/comfyui-desktop-2`
 4. **개별 설치 삭제**: 앱 내에서 삭제하거나 `~/ComfyUI-Installs`와 직접 설정한 사용자 지정 설치 디렉토리를 수동으로 삭제하세요.
 5. **공유 모델 라이브러리 삭제**: `~/ComfyUI-Shared`를 삭제하세요(해당 파일이 더 이상 필요하지 않은 경우).
+
+`.deb` 또는 AppImage로 설치한 경우, 앱 프로필과 로그는 `~/.config/Comfy Desktop`에도 저장됩니다. 저장소의 [reset-linux.sh](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/scripts/reset-linux.sh) 스크립트를 실행하면 알려진 모든 앱 데이터를 정리하며, `~/ComfyUI-Installs`는 그대로 유지됩니다.

--- a/ko/installation/desktop/overview.mdx
+++ b/ko/installation/desktop/overview.mdx
@@ -3,7 +3,7 @@ title: "Comfy Desktop 개요"
 description: "Comfy Desktop 개요: 생성형 AI를 위한 노드 기반 엔진인 ComfyUI의 여러 인스턴스를 설치, 관리, 실행하는 데스크톱 앱."
 icon: "desktop"
 sidebarTitle: "개요"
-translationSourceHash: 7ad9cbf9
+translationSourceHash: f1e6d02d
 translationFrom: installation/desktop/overview.mdx
 ---
 
@@ -13,7 +13,7 @@ translationFrom: installation/desktop/overview.mdx
 
 ![Comfy Desktop 스크린샷](/images/desktop/usage/01-homepage.png)
 
-Comfy Desktop은 **Windows 10 이상**, **macOS 13 이상 (Apple Silicon)**에서 실행됩니다. Linux에는 아직 공식 설치 프로그램이 없으며 [소스에서 빌드](/ko/installation/desktop/linux)할 수 있습니다. 각 독립형 설치는 최소 **4.85 GB**의 디스크 공간과 **8 GB RAM (16 GB 권장)** 이 필요합니다. 자세한 내용은 플랫폼별 페이지를 확인하세요.
+Comfy Desktop은 **Windows 10 이상**, **macOS 13 이상 (Apple Silicon)**, **Linux**(공식 `.deb` 및 AppImage 패키지)에서 실행됩니다. 각 독립형 설치는 최소 **4.85 GB**의 디스크 공간과 **8 GB RAM (16 GB 권장)** 이 필요합니다. 자세한 내용은 플랫폼별 페이지를 확인하세요.
 
 ## 시작하기
 
@@ -29,7 +29,7 @@ Comfy Desktop은 **Windows 10 이상**, **macOS 13 이상 (Apple Silicon)**에�
   </Card>
 
   <Card title="Linux" icon="linux" href="/ko/installation/desktop/linux">
-    소스에서 빌드하고 실행합니다. 아직 공식 Linux 설치 프로그램은 없습니다.
+    공식 `.deb` 또는 AppImage를 설치하거나 소스에서 빌드하세요.
   </Card>
 </CardGroup>
 

--- a/snippets/install/install-link.mdx
+++ b/snippets/install/install-link.mdx
@@ -1,6 +1,6 @@
 <AccordionGroup>
   <Accordion title="Comfy Desktop">
-    Comfy Desktop supports standalone installation on **Windows** and **macOS (Apple Silicon)**. Linux is from source only (no official installer yet).
+    Comfy Desktop supports standalone installation on **Windows**, **macOS (Apple Silicon)**, and **Linux** (AppImage and `.deb`).
     - Source is on [GitHub](https://github.com/Comfy-Org/Comfy-Desktop)
     <Tip>
     Desktop installs track the **stable** ComfyUI release by default. If you want every latest commit, use the portable version or a manual git install, or switch the instance update channel to **Latest on GitHub**.
@@ -19,7 +19,7 @@
       </Tab>
       <Tab title="Linux">
         <Card title="Comfy Desktop (Linux) Installation Guide" icon="link" href="/installation/desktop/linux">
-          Build and run from source. No official Linux installer yet.
+          Install the AppImage or `.deb`, or build and run from source.
         </Card>
       </Tab>
     </Tabs>

--- a/snippets/ja/install/install-link.mdx
+++ b/snippets/ja/install/install-link.mdx
@@ -1,7 +1,7 @@
-{/* translationSourceHash: c8296cc1 */}
+{/* translationSourceHash: 72fc9164 */}
 <AccordionGroup>
   <Accordion title="Comfy デスクトップ版">
-    Comfy Desktop は **Windows** と **macOS（Apple Silicon）** でのスタンドアロンインストールに対応しています。Linux はソースからのみです（公式インストーラーはまだありません）。
+    Comfy Desktop は **Windows**、**macOS（Apple Silicon）**、**Linux**（AppImage と `.deb`）でのスタンドアロンインストールに対応しています。
     - ソースは [GitHub](https://github.com/Comfy-Org/Comfy-Desktop) にあります
     <Tip>
     Desktop インストールはデフォルトで ComfyUI の **安定版** を追跡します。常に最新のコミットが必要な場合は、ポータブル版か手動 git インストールを使うか、インスタンスの更新チャネルを **Latest on GitHub** に切り替えてください。
@@ -20,7 +20,7 @@
       </Tab>
       <Tab title="Linux">
         <Card title="Comfy Desktop（Linux）インストールガイド" icon="link" href="/ja/installation/desktop/linux">
-          ソースからビルドして実行します。公式 Linux インストーラーはまだありません。
+          AppImage または `.deb` をインストールするか、ソースからビルドして実行します。
         </Card>
       </Tab>
     </Tabs>

--- a/snippets/ko/install/install-link.mdx
+++ b/snippets/ko/install/install-link.mdx
@@ -1,7 +1,7 @@
-{/* translationSourceHash: c8296cc1 */}
+{/* translationSourceHash: 72fc9164 */}
 <AccordionGroup>
   <Accordion title="Comfy 데스크톱">
-    Comfy Desktop은 **Windows**, **macOS(Apple Silicon)**에서 독립형 설치를 지원합니다. Linux는 소스에서만 실행할 수 있습니다(아직 공식 설치 프로그램 없음).
+    Comfy Desktop은 **Windows**, **macOS(Apple Silicon)**, **Linux**(AppImage 및 `.deb`)에서 독립형 설치를 지원합니다.
     - 소스는 [GitHub](https://github.com/Comfy-Org/Comfy-Desktop)에 있습니다
     <Tip>
     Desktop 설치는 기본적으로 ComfyUI **안정 릴리스**를 따릅니다. 항상 최신 커밋을 쓰려면 휴대용 버전이나 수동 git 설치를 사용하거나, 인스턴스 업데이트 채널을 **Latest on GitHub**로 바꾸세요.
@@ -20,7 +20,7 @@
       </Tab>
       <Tab title="Linux">
         <Card title="Comfy Desktop (Linux) 설치 가이드" icon="link" href="/ko/installation/desktop/linux">
-          소스에서 빌드하고 실행합니다. 아직 공식 Linux 설치 프로그램은 없습니다.
+          AppImage 또는 `.deb`를 설치하거나 소스에서 빌드해 실행하세요.
         </Card>
       </Tab>
     </Tabs>

--- a/snippets/zh/install/install-link.mdx
+++ b/snippets/zh/install/install-link.mdx
@@ -1,7 +1,7 @@
-{/* translationSourceHash: c8296cc1 */}
+{/* translationSourceHash: 72fc9164 */}
 <AccordionGroup>
   <Accordion title="Comfy 桌面版">
-    Comfy Desktop 支持在 **Windows** 和 **macOS（Apple Silicon）** 上进行独立安装。Linux 只能从源码运行（目前没有正式安装包）。
+    Comfy Desktop 支持在 **Windows**、**macOS（Apple Silicon）** 和 **Linux**（AppImage 和 `.deb`）上进行独立安装。
     - 源码在 [GitHub](https://github.com/Comfy-Org/Comfy-Desktop)
     <Tip>
     Desktop 安装默认跟踪 ComfyUI 的 **稳定版**。如果想始终使用最新提交，请使用便携版或手动 git 安装，或把实例更新通道改为 **Latest on GitHub**。
@@ -20,7 +20,7 @@
       </Tab>
       <Tab title="Linux">
         <Card title="Comfy Desktop（Linux）安装指南" icon="link" href="/zh/installation/desktop/linux">
-          从源码构建并运行。目前没有正式的 Linux 安装包。
+          安装 AppImage 或 `.deb`，或从源码构建并运行。
         </Card>
       </Tab>
     </Tabs>

--- a/zh/installation/desktop/faq.mdx
+++ b/zh/installation/desktop/faq.mdx
@@ -2,13 +2,13 @@
 title: "Comfy Desktop 常见问题"
 description: "Comfy Desktop 的常见问题与故障排除"
 sidebarTitle: "常见问题"
-translationSourceHash: 63620620
+translationSourceHash: a124f5aa
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
   "Installation & Setup": b5578878
   "Usage": b5abdafd
-  "Troubleshooting": 890673f8
+  "Troubleshooting": 9bcd69c3
 ---
 
 ## 常规问题
@@ -107,7 +107,7 @@ Desktop 应用会写入轮转的 `app.log` 文件。最快的查找方式是 **�
 
 - **Windows:** `%APPDATA%\Comfy Desktop\logs`
 - **macOS:** `~/Library/Logs/Comfy Desktop`
-- **Linux:** `~/.config/comfyui-desktop-2/logs`
+- **Linux:** `~/.config/Comfy Desktop/logs`
 
 查找 `app.log`。之前的会话会轮转为带时间戳的 `app.log_*.log` 文件。
 

--- a/zh/installation/desktop/faq.mdx
+++ b/zh/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop 常见问题"
 description: "Comfy Desktop 的常见问题与故障排除"
 sidebarTitle: "常见问题"
-translationSourceHash: 140c8d7c
+translationSourceHash: 4bd257d6
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": 99b8522c
+  "Installation & Setup": a8b07570
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,15 +32,15 @@ Comfy桌面版是多种安装方式之一。你仍然可以根据需要选择**�
 
 - **Windows：** Windows 10+，x64 或 ARM64。推荐使用独立 GPU（NVIDIA / AMD），但并非必需。
 - **macOS：** macOS 13+ (Ventura)，Apple Silicon (M1+)
-- **Linux：** 目前没有正式安装包。[从源码构建](/zh/installation/desktop/linux)。推荐使用独立 GPU。
+- **Linux：** 官方 `.deb` 和 AppImage 安装包见[下载页](https://comfy.org/download)。推荐使用独立 GPU。
 - **磁盘：** 每个独立安装至少 4.85 GB
 - **内存：** 最低 8 GB，推荐 16 GB
 </Accordion>
 <Accordion title="没有管理员权限可以安装 Comfy Desktop 吗？">
-**Windows** 上独立安装不需要管理员权限。**macOS** 上首次进行系统级安装时需要管理员权限。**Linux** 从源码在用户空间运行。只有安装 Node.js 等系统软件包时才可能需要管理员权限。
+**Windows** 上独立安装不需要管理员权限。**macOS** 上首次进行系统级安装时需要管理员权限。**Linux** 上安装 `.deb` 包需要 `sudo`；AppImage 在用户空间运行，无需管理员权限。
 </Accordion>
 <Accordion title="如何下载 Comfy Desktop？">
-从官方 [ComfyUI 下载页面](https://comfy.org/download) 下载最新的 Windows 或 macOS 构建。Linux 没有已发布的安装包，请[从源码构建](/zh/installation/desktop/linux)。
+从官方 [ComfyUI 下载页面](https://comfy.org/download) 下载最新构建。Linux 安装包（`.deb` 和 AppImage）也在该页面提供。如需从源码运行，参见 [Linux 安装指南](/zh/installation/desktop/linux)。
 </Accordion>
 <Accordion title="可以同时安装 Legacy Desktop 和 Comfy Desktop 吗？">
 可以共存。但我们建议将您的安装迁移到新的 Comfy Desktop，并最终卸载 Legacy Desktop。请参阅[迁移指南](/zh/installation/desktop/usage/migrate)。

--- a/zh/installation/desktop/faq.mdx
+++ b/zh/installation/desktop/faq.mdx
@@ -2,11 +2,11 @@
 title: "Comfy Desktop 常见问题"
 description: "Comfy Desktop 的常见问题与故障排除"
 sidebarTitle: "常见问题"
-translationSourceHash: 4bd257d6
+translationSourceHash: 63620620
 translationFrom: installation/desktop/faq.mdx
 translationBlockHashes:
   "General Questions": 3de4ef1d
-  "Installation & Setup": a8b07570
+  "Installation & Setup": b5578878
   "Usage": b5abdafd
   "Troubleshooting": 890673f8
 ---
@@ -32,7 +32,7 @@ Comfy桌面版是多种安装方式之一。你仍然可以根据需要选择**�
 
 - **Windows：** Windows 10+，x64 或 ARM64。推荐使用独立 GPU（NVIDIA / AMD），但并非必需。
 - **macOS：** macOS 13+ (Ventura)，Apple Silicon (M1+)
-- **Linux：** 官方 `.deb` 和 AppImage 安装包见[下载页](https://comfy.org/download)。推荐使用独立 GPU。
+- **Linux：** 官方 `.deb` 和 AppImage 安装包通过 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop) 分发。推荐使用独立 GPU。
 - **磁盘：** 每个独立安装至少 4.85 GB
 - **内存：** 最低 8 GB，推荐 16 GB
 </Accordion>
@@ -40,7 +40,7 @@ Comfy桌面版是多种安装方式之一。你仍然可以根据需要选择**�
 **Windows** 上独立安装不需要管理员权限。**macOS** 上首次进行系统级安装时需要管理员权限。**Linux** 上安装 `.deb` 包需要 `sudo`；AppImage 在用户空间运行，无需管理员权限。
 </Accordion>
 <Accordion title="如何下载 Comfy Desktop？">
-从官方 [ComfyUI 下载页面](https://comfy.org/download) 下载最新构建。Linux 安装包（`.deb` 和 AppImage）也在该页面提供。如需从源码运行，参见 [Linux 安装指南](/zh/installation/desktop/linux)。
+请从官方 [ComfyUI 下载页面](https://comfy.org/download) 下载最新的 Windows 或 macOS 构建。Linux 用户请使用 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop) 中的[通用下载链接](https://dl.todesktop.com/241130tqe9q3y)获取 `.deb` 或 AppImage。如需从源码运行，参见 [Linux 安装指南](/zh/installation/desktop/linux)。
 </Accordion>
 <Accordion title="可以同时安装 Legacy Desktop 和 Comfy Desktop 吗？">
 可以共存。但我们建议将您的安装迁移到新的 Comfy Desktop，并最终卸载 Legacy Desktop。请参阅[迁移指南](/zh/installation/desktop/usage/migrate)。

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -3,7 +3,7 @@ title: "Linux 上的 Comfy Desktop"
 description: "Linux 上的 Comfy Desktop：安装官方 .deb 或 AppImage，或克隆仓库从源码运行。源码构建要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 9a0099dd
+translationSourceHash: e5b27cc1
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
@@ -12,7 +12,7 @@ translationBlockHashes:
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
-  "Removing leftover data": a2df8410
+  "Removing leftover data": a42f3904
 ---
 
 **Comfy Desktop** 可以在 Linux 上运行。官方 `.deb` 包（Debian/Ubuntu）和 AppImage 通过 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop) 分发，请使用[通用下载链接](https://dl.todesktop.com/241130tqe9q3y)下载（会自动识别你的平台）。大多数用户建议使用其中一种安装包。如果想从源码运行应用，请克隆仓库并按照以下步骤操作。
@@ -128,3 +128,5 @@ pnpm run build:linux
 3. **删除数据、缓存和状态文件夹**：`~/.local/share/comfyui-desktop-2`、`~/.cache/comfyui-desktop-2` 和 `~/.local/state/comfyui-desktop-2`
 4. **删除各个安装**：在应用内删除，或手动删除 `~/ComfyUI-Installs` 以及你配置过的自定义安装目录
 5. **删除共享模型库**：`~/ComfyUI-Shared`（仅在你不再需要这些文件时）
+
+如果你是通过 `.deb` 或 AppImage 安装的，应用还会把配置文件和日志保存在 `~/.config/Comfy Desktop`。可以运行仓库里的 [reset-linux.sh](https://github.com/Comfy-Org/Comfy-Desktop/blob/main/scripts/reset-linux.sh) 脚本清理这些内容：它会删除所有已知的应用数据，但不会影响 `~/ComfyUI-Installs`。

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -1,29 +1,48 @@
 ---
 title: "Linux 上的 Comfy Desktop"
-description: "Linux 上的 Comfy Desktop：没有官方安装程序，需要克隆仓库并从源码运行。要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
+description: "Linux 上的 Comfy Desktop：安装官方 .deb 或 AppImage，或克隆仓库从源码运行。源码构建要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b42848c3
+translationSourceHash: 75f31979
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": e92746cf
-  "System Requirements": a66d549d
-  "Build and run from source": ec8a8f51
+  "_intro": d98a6de1
+  "System Requirements": 409b2af2
+  "Install the official package": 135f26e2
+  "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop** 可以在 Linux 上运行，但目前还没有正式发布的 Linux 安装包。[下载页](https://comfy.org/download) 只提供 Windows 和 macOS。在 Linux 上，请克隆 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop) 并从源码运行。
+**Comfy Desktop** 可以在 Linux 上运行。[下载页](https://comfy.org/download) 提供官方 `.deb` 包（Debian/Ubuntu）和 AppImage。大多数用户建议直接使用其中一种。如果想从源码运行应用，请克隆 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop)。
 
 ## 系统要求
 
 - **操作系统：** Linux（推荐 Ubuntu 22.04 或更高版本）
 - **架构：** x64
-- **Node.js：** v22 LTS 或更高版本
-- **pnpm：** v10 或更高版本（用 Corepack 启用）
+- **Node.js：** v22 LTS 或更高版本（仅源码构建需要）
+- **pnpm：** v10 或更高版本，用 Corepack 启用（仅源码构建需要）
+- **编译工具：** `build-essential` 和 `git`（仅源码构建需要）
 - **GPU：** 推荐独立 GPU（NVIDIA / AMD），但不是必须
 - **磁盘空间：** 每个 ComfyUI 安装建议至少 4.85 GB
+
+## 安装官方安装包
+
+从[下载页](https://comfy.org/download)下载 `.deb` 或 AppImage 并安装：
+
+```bash
+sudo apt install ./*.deb
+```
+
+AppImage 的使用方式：
+
+```bash
+chmod +x ./*.AppImage
+./*.AppImage --no-sandbox
+```
+
+需要 `--no-sandbox` 参数是因为在 Linux 上不额外配置时 Electron 沙箱经常无法启动。该参数会关闭所有进程的 Electron 沙箱。
 
 ## 从源码构建并运行
 
@@ -31,7 +50,13 @@ translationBlockHashes:
 
 ### 前置条件
 
-安装 Node.js 22，然后启用 pnpm：
+先安装编译工具和 git。新装的 Ubuntu 默认没有这些，而 `pnpm run init` 会编译 `node-pty` 等原生模块，缺少 `build-essential` 时会报 `Error: not found: make`：
+
+```bash
+sudo apt install build-essential git
+```
+
+然后安装 Node.js 22 并启用 pnpm：
 
 ```bash
 nvm install 22 && nvm use 22

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux 上的 Comfy Desktop"
 description: "Linux 上的 Comfy Desktop：安装官方 .deb 或 AppImage，或克隆仓库从源码运行。源码构建要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: bcc51bea
+translationSourceHash: 9a0099dd
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 89c30b2e
+  "Install the official package": c9a03f09
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,7 +39,7 @@ AppImage 的使用方式：
 
 ```bash
 chmod +x ./*.AppImage
-./<name>.AppImage
+./*.AppImage
 ```
 
 如果应用无法启动，可能是发行版阻止了 Electron 沙箱（Ubuntu 24.04+ 会通过 AppArmor 限制非特权 user namespace）。此时再用 `--no-sandbox` 重试。注意该参数会关闭所有进程的 Electron 沙箱，只在沙箱启动失败时使用。

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -3,12 +3,12 @@ title: "Linux 上的 Comfy Desktop"
 description: "Linux 上的 Comfy Desktop：安装官方 .deb 或 AppImage，或克隆仓库从源码运行。源码构建要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: 75f31979
+translationSourceHash: b8ccb49d
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
   "_intro": d98a6de1
   "System Requirements": 409b2af2
-  "Install the official package": 135f26e2
+  "Install the official package": 2603fe88
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
@@ -39,10 +39,10 @@ AppImage 的使用方式：
 
 ```bash
 chmod +x ./*.AppImage
-./*.AppImage --no-sandbox
+./<name>.AppImage
 ```
 
-需要 `--no-sandbox` 参数是因为在 Linux 上不额外配置时 Electron 沙箱经常无法启动。该参数会关闭所有进程的 Electron 沙箱。
+如果应用无法启动，可能是发行版阻止了 Electron 沙箱（Ubuntu 24.04+ 会通过 AppArmor 限制非特权 user namespace）。此时再用 `--no-sandbox` 重试。注意该参数会关闭所有进程的 Electron 沙箱，只在沙箱启动失败时使用。
 
 ## 从源码构建并运行
 

--- a/zh/installation/desktop/linux.mdx
+++ b/zh/installation/desktop/linux.mdx
@@ -3,19 +3,19 @@ title: "Linux 上的 Comfy Desktop"
 description: "Linux 上的 Comfy Desktop：安装官方 .deb 或 AppImage，或克隆仓库从源码运行。源码构建要求 Ubuntu 22.04+、x64 和 Node.js v22 LTS。"
 icon: "linux"
 sidebarTitle: "Linux"
-translationSourceHash: b8ccb49d
+translationSourceHash: bcc51bea
 translationFrom: installation/desktop/linux.mdx
 translationBlockHashes:
-  "_intro": d98a6de1
+  "_intro": 0534da4a
   "System Requirements": 409b2af2
-  "Install the official package": 2603fe88
+  "Install the official package": 89c30b2e
   "Build and run from source": f0c9dcb4
   "Updating": cdc9a557
   "Optional: local package": 47dfdddc
   "Removing leftover data": a2df8410
 ---
 
-**Comfy Desktop** 可以在 Linux 上运行。[下载页](https://comfy.org/download) 提供官方 `.deb` 包（Debian/Ubuntu）和 AppImage。大多数用户建议直接使用其中一种。如果想从源码运行应用，请克隆 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop)。
+**Comfy Desktop** 可以在 Linux 上运行。官方 `.deb` 包（Debian/Ubuntu）和 AppImage 通过 [Comfy Desktop 仓库](https://github.com/Comfy-Org/Comfy-Desktop) 分发，请使用[通用下载链接](https://dl.todesktop.com/241130tqe9q3y)下载（会自动识别你的平台）。大多数用户建议使用其中一种安装包。如果想从源码运行应用，请克隆仓库并按照以下步骤操作。
 
 ## 系统要求
 
@@ -29,7 +29,7 @@ translationBlockHashes:
 
 ## 安装官方安装包
 
-从[下载页](https://comfy.org/download)下载 `.deb` 或 AppImage 并安装：
+通过[通用下载链接](https://dl.todesktop.com/241130tqe9q3y)下载 Linux 安装包（会自动识别你的平台），然后安装：
 
 ```bash
 sudo apt install ./*.deb

--- a/zh/installation/desktop/overview.mdx
+++ b/zh/installation/desktop/overview.mdx
@@ -3,7 +3,7 @@ title: "Comfy Desktop 概览"
 description: "Comfy Desktop 概览：一个安装、管理和启动多个 ComfyUI 实例的桌面应用，ComfyUI 是生成式 AI 的基于节点的引擎。"
 icon: "desktop"
 sidebarTitle: "概览"
-translationSourceHash: 7ad9cbf9
+translationSourceHash: f1e6d02d
 translationFrom: installation/desktop/overview.mdx
 ---
 
@@ -13,7 +13,7 @@ translationFrom: installation/desktop/overview.mdx
 
 ![Desktop 截图](/images/desktop/usage/01-homepage.png)
 
-Comfy Desktop 支持 **Windows 10+** 和 **macOS 13+（Apple Silicon）**。Linux 目前没有正式安装包，可以从[源码构建](/zh/installation/desktop/linux)。每个独立安装需要至少 **4.85 GB** 磁盘空间和 **8 GB 内存（推荐 16 GB）**。详细要求请查看各平台安装页面。
+Comfy Desktop 支持 **Windows 10+**、**macOS 13+（Apple Silicon）** 和 **Linux**（官方 `.deb` 和 AppImage 安装包）。每个独立安装需要至少 **4.85 GB** 磁盘空间和 **8 GB 内存（推荐 16 GB）**。详细要求请查看各平台安装页面。
 
 ## 开始使用
 
@@ -29,7 +29,7 @@ Comfy Desktop 支持 **Windows 10+** 和 **macOS 13+（Apple Silicon）**。Linu
   </Card>
 
   <Card title="Linux" icon="linux" href="/zh/installation/desktop/linux">
-    从源码构建并运行。目前没有正式的 Linux 安装包。
+    安装官方 `.deb` 或 AppImage，或从源码构建。
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Supersedes #1632 (same commits, plus the updates below). Opened from a Comfy-Org branch so the Mintlify preview runs.

A user on a fresh Ubuntu 26.04 install reported that about half the commands on `installation/desktop/linux` fail, and `pnpm run init` dies while building `node-pty`:

```
gyp ERR! stack Error: not found: make
```

Verified cause: `node-pty` has no prebuilt binary for that environment, so node-gyp compiles it from source. A fresh Ubuntu image has no compiler toolchain, and the page's prerequisites never mentioned `build-essential`.

Changes (EN/JA/KO/ZH):

1. **Add missing build prerequisites**: `sudo apt install build-essential git` before Node.js/pnpm, with the `not found: make` failure mode called out explicitly.
2. **Document the official Linux packages**: Linux builds are distributed through the [Comfy Desktop repository](https://github.com/Comfy-Org/Comfy-Desktop) and its universal download link (verified live: the link returns `comfyui-desktop-2-1.0.47x86_64.AppImage` on Linux). Linux is not listed on comfy.org/download, so the references to the Downloads page were replaced with the Comfy Desktop download link.
3. **Scope source-build-only requirements**: Node.js / pnpm / build tools are now marked as needed for a source build only.
4. **Fix the `install-link` snippet** (EN/JA/KO/ZH): it still said Linux had no official installer; it now lists Linux (AppImage / `.deb`).
5. **Fix the Linux log path for packaged installs**: packaged builds take their app name from `productName` (`Comfy Desktop`), so the app log lives at `~/.config/Comfy Desktop/logs`; `~/.config/comfyui-desktop-2/logs` applies to source runs only. The Linux cleanup section now also notes that packaged installs keep the app profile there and points to the repository's `reset-linux.sh` for a full cleanup.

Translation hashes synced via `pnpm translate:sync-hash`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation guides and translations; no application or runtime behavior is modified.
> 
> **Overview**
> Updates Comfy Desktop installation docs (EN/JA/KO/ZH) so **Linux is documented with official `.deb` and AppImage** packages from the Comfy Desktop repo and universal download link, instead of describing Linux as source-only with no published installer.
> 
> The **Linux guide** adds an “Install the official package” section (`.deb` via `apt`, AppImage, and optional `--no-sandbox` when Electron sandboxing is blocked). **Source-build** steps now require `build-essential` and `git` up front, with the `pnpm run init` / `node-pty` `not found: make` failure called out; Node.js, pnpm, and build tools are labeled source-build-only.
> 
> **FAQ, overview, and install-link snippets** are aligned: Linux download/admin rights, packaged log path `~/.config/Comfy Desktop/logs`, and packaged cleanup via `reset-linux.sh`. Translation source hashes are synced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f98488a1ffbd3ca868aa44c06a88a2653ea320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->