### PR TITLE
Clarify API-only concurrency and per-member limits

### DIFF
--- a/development/api-development/sdks.mdx
+++ b/development/api-development/sdks.mdx
@@ -119,7 +119,7 @@ const client = new Comfy({ apiKey: "comfyui-..." });
 Works out of the box. Create an [API key](/development/api-development/getting-an-api-key) and pass it to the client.
 
 <Note>
-  API access requires a paid Comfy Cloud subscription. The free tier does not include it. How many jobs you can run at once depends on your tier. See [Parallel Execution](/development/deploy/cloud#parallel-execution-concurrent-jobs).
+  API access requires a paid Comfy Cloud subscription. The free tier does not include it. How many jobs you can run at once depends on your tier. See [Concurrency Limits](/development/deploy/cloud#concurrency-limits).
 </Note>
 
 ### Serverless deployment

--- a/development/cloud/api-reference.mdx
+++ b/development/cloud/api-reference.mdx
@@ -261,7 +261,7 @@ def upload_mask(file_path: str, original_ref: dict) -> dict:
 Submit a workflow for execution.
 
 <Info>
-  **Concurrent submissions supported:** Depending on your subscription tier, you can submit multiple workflows without waiting for previous jobs to complete. Jobs run in parallel up to your tier's limit. Additional jobs queue automatically. See [Parallel Execution](/development/deploy/cloud#parallel-execution-concurrent-jobs) for details and concurrency limits.
+  **Concurrent submissions supported:** Depending on your subscription tier, you can submit multiple workflows without waiting for previous jobs to complete. Jobs run in parallel up to your tier's limit. Additional jobs queue automatically. See [Concurrency Limits](/development/deploy/cloud#concurrency-limits) for details.
 </Info>
 
 ### Submit Workflow

--- a/development/comfy-router/quickstart.mdx
+++ b/development/comfy-router/quickstart.mdx
@@ -10,7 +10,7 @@ Comfy Router lets you call partner models through `https://api.comfy.org` with o
 
 <Steps>
   <Step title="Create an API key">
-    Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys). In a Bash-compatible terminal, set:
+    Create a key in the [Developer Platform](https://platform.comfy.org/profile/api-keys). In a Bash-compatible terminal, set:
 
     ```bash
     export COMFY_API_KEY="comfyui-..."

--- a/development/deploy/cloud.mdx
+++ b/development/deploy/cloud.mdx
@@ -71,15 +71,17 @@ See [Running Workflows](/development/run-workflows/overview) for how the same co
 
 API requests draw from the same monthly credit allocation as the Comfy Cloud web UI. There is no separate API credit pool. Each tier's included credits, top-up options, and per-workflow runtime caps apply to API jobs in exactly the same way as UI jobs. See the [pricing page](https://www.comfy.org/cloud/pricing?utm_source=docs&utm_campaign=cloud-api) for the monthly credit amounts on each tier. If you run out of credits mid-month, top-ups can be purchased from your account dashboard.
 
-## Parallel Execution (Concurrent Jobs)
+## Concurrency Limits
 
-API users can submit multiple workflows concurrently without waiting for previous jobs to complete. Submission returns as soon as the job is accepted, so you can keep several in flight. The dispatcher runs them in parallel up to your subscription tier's limit; check [platform.comfy.org](https://platform.comfy.org) for your current concurrency.
+Running multiple jobs in parallel is only supported when you submit workflows through the API. API users can submit multiple workflows concurrently without waiting for previous jobs to complete. Submission returns as soon as the job is accepted, so you can keep several in flight. The dispatcher runs them in parallel up to your subscription tier's limit; check [platform.comfy.org](https://platform.comfy.org) for your current concurrency.
 
 Jobs submitted beyond your concurrency limit queue normally and execute automatically as slots free up. If the queue itself is full, the SDKs retry for you within a bounded budget before raising `QueueFull`.
 
 <Info>
-  Parallel execution is currently available via the API only. See [pricing plans](https://www.comfy.org/cloud/pricing?utm_source=docs&utm_campaign=cloud-api) for subscription details.
+  The Comfy Cloud UI does not support running more than one job per person. Workflows queued in the editor run one at a time, in order. Only API submissions run in parallel. See [pricing plans](https://www.comfy.org/cloud/pricing?utm_source=docs&utm_campaign=cloud-api) for subscription details.
 </Info>
+
+On Team and Enterprise plans, concurrency is per member: everyone in the workspace has their own concurrency limit, so one member's running jobs never block another's.
 
 ## Existing v1 integrations
 

--- a/development/deploy/cloud.mdx
+++ b/development/deploy/cloud.mdx
@@ -19,7 +19,7 @@ Comfy Cloud works with the [Comfy SDKs](/development/api-development/sdks) out o
 
 <Steps>
   <Step title="Create an API key">
-    Log in at [platform.comfy.org](https://platform.comfy.org) and create a key. See [Getting an API Key](/development/api-development/getting-an-api-key) for step-by-step instructions.
+    Log in to the [Developer Platform](https://platform.comfy.org) and create a key. See [Getting an API Key](/development/api-development/getting-an-api-key) for step-by-step instructions.
   </Step>
   <Step title="Install the SDK">
     <CodeGroup>

--- a/get_started/cloud.mdx
+++ b/get_started/cloud.mdx
@@ -55,6 +55,14 @@ ComfyUI offers both an official cloud version, [Comfy Cloud](https://comfy.org/c
   View pricing and subscription options for Comfy Cloud
 </Card>
 
+### Concurrency limits
+
+The Comfy Cloud UI does not support running more than one workflow at a time. Each person can run one workflow at a time in the editor; additional workflows wait in the queue and run one after another.
+
+Running multiple jobs in parallel is only supported when you submit workflows through the API, which requires a paid subscription. See [Concurrency Limits](/development/deploy/cloud#concurrency-limits) in the developer docs for details.
+
+On Team and Enterprise plans, concurrency is per member: everyone in the workspace has their own concurrency, so one member's running workflows never block another's.
+
 
 ## How to use ComfyUI Cloud
 


### PR DESCRIPTION
## Summary
Updated documentation to clarify that parallel job execution is an API-only feature and to explain per-member concurrency limits on Team and Enterprise plans.

## Key Changes
- Renamed "Parallel Execution (Concurrent Jobs)" section to "Concurrency Limits" for clarity
- Added explicit statement that parallel execution is only supported via the API, not the web UI
- Updated info box to clarify that the Comfy Cloud UI runs one workflow at a time per person, with additional workflows queuing sequentially
- Added new paragraph explaining that on Team and Enterprise plans, concurrency limits are per member, so team members don't block each other
- Added new "Concurrency limits" section to the getting started guide with user-friendly explanation
- Updated cross-references to use the new section name "Concurrency Limits" throughout the docs

## Notable Details
- Changes maintain consistency across multiple documentation files (cloud deployment guide, getting started guide, SDK guide, and API reference)
- The clarification distinguishes between UI behavior (sequential) and API behavior (parallel up to tier limit)
- Emphasizes that API access requires a paid subscription to use concurrency features

https://claude.ai/code/session_01MpPuwjxKzAXSqRQ7UdjEd9