### PR TITLE
docs: add runnable request examples to the Router wan video model pages

### DIFF
--- a/.github/scripts/snippets/gen-code-pages.ts
+++ b/.github/scripts/snippets/gen-code-pages.ts
@@ -775,7 +775,7 @@ function renderDerivedPage(model: string, s: ModelSchema): string {
   const apiDocs = PROVIDER_API_DOCS[providerOf(model)];
   const input = s.authored && s.input
     ? `${schemaFields(s.input, s.components, "param", docBase)}\n\nGenerated from the schema Router serves at \`GET ${ROUTE}/${model}/openapi.json\`, the same document it validates a call against before the request reaches the provider.`
-    : `<Note>\nRouter has not published an authored input schema for this model yet: \`GET ${ROUTE}/${model}/openapi.json\` returns an open object with \`x-comfy-input-schema-authored: false\`. Router forwards the body to ${provider} unchanged, so ${apiDocs ? `[${provider}'s own API reference](${apiDocs})` : `${provider}'s own API documentation`} is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.\n</Note>`;
+    : `<Note>\nRouter has not published an authored input schema for this model yet: \`GET ${ROUTE}/${model}/openapi.json\` returns an open object with \`x-comfy-input-schema-authored: false\`. Router forwards the body to ${provider} unchanged, so ${apiDocs ? `[${possessive(provider)} own API reference](${apiDocs})` : `${possessive(provider)} own API documentation`} is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.\n</Note>`;
   const output = s.output
     ? schemaFields(s.output, s.components, "response", docBase)
     : `Router does not publish an output schema for this model.`;
@@ -783,9 +783,14 @@ function renderDerivedPage(model: string, s: ModelSchema): string {
   const examples = s.inputExample !== undefined || s.outputExample !== undefined
     ? `\n\n## Examples\n${s.inputExample !== undefined ? `\n### Input\n\n\`\`\`json\n${JSON.stringify(s.inputExample, null, 2)}\n\`\`\`\n` : ""}${s.outputExample !== undefined ? `\n### Output\n\n\`\`\`json\n${JSON.stringify(outputExample, null, 2)}\n\`\`\`\n` : ""}`
     : "";
-  const requestSetup = requestExample
-    ? derivedSnippets(model, requestExample)
-    : `<Note>\nThis model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).\n</Note>`;
+  // Say WHY there is no snippet, not just that there isn't one. A model whose
+  // input schema is unauthored has no documented fields on this page either, so
+  // "build the body from the input documentation below" points the reader at a
+  // section that only forwards them to the provider; name that provider instead.
+  const noExample = s.authored
+    ? `This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).`
+    : `Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to ${provider} unchanged: build it from ${apiDocs ? `[${possessive(provider)} own API reference](${apiDocs})` : `${possessive(provider)} own API documentation`}, then send it with the [Router quickstart](/development/comfy-router/quickstart).`;
+  const requestSetup = requestExample ? derivedSnippets(model, requestExample) : `<Note>\n${noExample}\n</Note>`;
   const title = modelTitle(model);
   return `---
 title: ${JSON.stringify(`Use ${title} with Comfy Router`)}

--- a/development/comfy-router/models.mdx
+++ b/development/comfy-router/models.mdx
@@ -256,13 +256,13 @@ Every model below is served by the same route, `POST /v2/models/{provider}/{mode
 
 ## Wan
 
-- [Happyhorse 1.0 I2V](/development/comfy-router/models/wan/happyhorse-1-0-i2v/code): `wan/happyhorse-1.0-i2v`
-- [Happyhorse 1.0 R2V](/development/comfy-router/models/wan/happyhorse-1-0-r2v/code): `wan/happyhorse-1.0-r2v`
-- [Happyhorse 1.0 T2V](/development/comfy-router/models/wan/happyhorse-1-0-t2v/code): `wan/happyhorse-1.0-t2v`
-- [Happyhorse 1.0 Video Edit](/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code): `wan/happyhorse-1.0-video-edit`
-- [Happyhorse 1.1 I2V](/development/comfy-router/models/wan/happyhorse-1-1-i2v/code): `wan/happyhorse-1.1-i2v`
-- [Happyhorse 1.1 R2V](/development/comfy-router/models/wan/happyhorse-1-1-r2v/code): `wan/happyhorse-1.1-r2v`
-- [Happyhorse 1.1 T2V](/development/comfy-router/models/wan/happyhorse-1-1-t2v/code): `wan/happyhorse-1.1-t2v`
+- [HappyHorse 1.0 I2V](/development/comfy-router/models/wan/happyhorse-1-0-i2v/code): `wan/happyhorse-1.0-i2v`
+- [HappyHorse 1.0 R2V](/development/comfy-router/models/wan/happyhorse-1-0-r2v/code): `wan/happyhorse-1.0-r2v`
+- [HappyHorse 1.0 T2V](/development/comfy-router/models/wan/happyhorse-1-0-t2v/code): `wan/happyhorse-1.0-t2v`
+- [HappyHorse 1.0 Video Edit](/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code): `wan/happyhorse-1.0-video-edit`
+- [HappyHorse 1.1 I2V](/development/comfy-router/models/wan/happyhorse-1-1-i2v/code): `wan/happyhorse-1.1-i2v`
+- [HappyHorse 1.1 R2V](/development/comfy-router/models/wan/happyhorse-1-1-r2v/code): `wan/happyhorse-1.1-r2v`
+- [HappyHorse 1.1 T2V](/development/comfy-router/models/wan/happyhorse-1-1-t2v/code): `wan/happyhorse-1.1-t2v`
 - [Wan 2.5 I2I Preview](/development/comfy-router/models/wan/wan2-5-i2i-preview/code): `wan/wan2.5-i2i-preview`
 - [Wan 2.5 I2V Preview](/development/comfy-router/models/wan/wan2-5-i2v-preview/code): `wan/wan2.5-i2v-preview`
 - [Wan 2.5 T2I Preview](/development/comfy-router/models/wan/wan2-5-t2i-preview/code): `wan/wan2.5-t2i-preview`

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-1-1-flash/code.mdx
@@ -19,7 +19,7 @@ Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-ke
 **Endpoint:** `POST https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-1.1-flash`
 
 <Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
+Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to Gemini Interactions unchanged: build it from [Gemini Interactions' own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference), then send it with the [Router quickstart](/development/comfy-router/quickstart).
 </Note>
 
 ## Schema
@@ -27,7 +27,7 @@ This model has no runnable request example. Build the body from the input docume
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-1.1-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.
+Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-1.1-flash/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions' own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
+++ b/development/comfy-router/models/gemini-interactions/gemini-omni-flash-preview/code.mdx
@@ -19,7 +19,7 @@ Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-ke
 **Endpoint:** `POST https://api.comfy.org/v2/models/gemini-interactions/gemini-omni-flash-preview`
 
 <Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
+Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to Gemini Interactions unchanged: build it from [Gemini Interactions' own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference), then send it with the [Router quickstart](/development/comfy-router/quickstart).
 </Note>
 
 ## Schema
@@ -27,7 +27,7 @@ This model has no runnable request example. Build the body from the input docume
 ### Input
 
 <Note>
-Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-flash-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions's own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.
+Router has not published an authored input schema for this model yet: `GET /v2/models/gemini-interactions/gemini-omni-flash-preview/openapi.json` returns an open object with `x-comfy-input-schema-authored: false`. Router forwards the body to Gemini Interactions unchanged, so [Gemini Interactions' own API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) is authoritative for the request fields, and Router does not perform model-specific input validation. Provider validation still applies.
 </Note>
 
 ### Output

--- a/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-fast/code.mdx
@@ -19,7 +19,7 @@ Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-ke
 **Endpoint:** `POST https://api.comfy.org/v2/models/ltx/ltx-2-5-fast`
 
 <Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
+Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to LTX unchanged: build it from LTX's own API documentation, then send it with the [Router quickstart](/development/comfy-router/quickstart).
 </Note>
 
 ## Schema

--- a/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
+++ b/development/comfy-router/models/ltx/ltx-2-5-pro/code.mdx
@@ -19,7 +19,7 @@ Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-ke
 **Endpoint:** `POST https://api.comfy.org/v2/models/ltx/ltx-2-5-pro`
 
 <Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
+Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to LTX unchanged: build it from LTX's own API documentation, then send it with the [Router quickstart](/development/comfy-router/quickstart).
 </Note>
 
 ## Schema

--- a/development/comfy-router/models/minimax/minimax-h3/code.mdx
+++ b/development/comfy-router/models/minimax/minimax-h3/code.mdx
@@ -19,7 +19,7 @@ Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-ke
 **Endpoint:** `POST https://api.comfy.org/v2/models/minimax/minimax-h3`
 
 <Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
+Router has not published an authored input schema for this model, so there is no request example to generate a snippet from. Router forwards the body to MiniMax unchanged: build it from [MiniMax's own API reference](https://platform.minimax.io/docs/api-reference), then send it with the [Router quickstart](/development/comfy-router/quickstart).
 </Note>
 
 ## Schema

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
@@ -1,26 +1,75 @@
 ---
 title: "Use Happyhorse 1.0 I2V with Comfy Router"
-description: "Call wan/happyhorse-1.0-i2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.0 I2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-i2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-i2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.0 I2V. HappyHorse 1.0 image-to-video animates a still first frame and renders synchronized audio in the same pass.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.0-i2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.0-i2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.0-i2v",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.0-i2v", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-i2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"img_url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +383,34 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-i2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +420,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-i2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.0 I2V with Comfy Router"
+title: "Use HappyHorse 1.0 I2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.0 I2V"
+sidebarTitle: "HappyHorse 1.0 I2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.0 I2V. HappyHorse 1.0 image-to-video animates a still first frame and renders synchronized audio in the same pass.
+API Reference for HappyHorse 1.0 I2V. HappyHorse 1.0 image-to-video animates a still first frame and renders synchronized audio in the same pass.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.0-i2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.0 I2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-i2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.0 image-to-video animates a still first frame and renders synchronized audio in the same pass.
+variants:
+- title: Happyhorse 1.0 I2V
+  model: wan/happyhorse-1.0-i2v
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-i2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.0-i2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.0 I2V
+name: HappyHorse 1.0 I2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-i2v over HTTP through Comfy Router, plus
@@ -10,7 +10,7 @@ description: >-
 summary: >-
   HappyHorse 1.0 image-to-video animates a still first frame and renders synchronized audio in the same pass.
 variants:
-- title: Happyhorse 1.0 I2V
+- title: HappyHorse 1.0 I2V
   model: wan/happyhorse-1.0-i2v
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Happyhorse 1.0 R2V with Comfy Router"
-description: "Call wan/happyhorse-1.0-r2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.0 R2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-r2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-r2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.0 R2V. HappyHorse 1.0 reference-to-video keeps the subjects of one or more reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.0-r2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.0-r2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.0-r2v",
+        {
+            "input": {
+                "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+                "media": [
+                    {
+                        "type": "reference_image",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.0-r2v", {
+  input: {
+    prompt: "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    media: [
+      {
+        type: "reference_image",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-r2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"character1 walks in from the left, turns to the camera and waves, plain orange backdrop\",\"media\":[{\"type\":\"reference_image\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-r2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "media": [
+      {
+        "type": "reference_image",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "actual_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-r2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.0 R2V with Comfy Router"
+title: "Use HappyHorse 1.0 R2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.0 R2V"
+sidebarTitle: "HappyHorse 1.0 R2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.0 R2V. HappyHorse 1.0 reference-to-video keeps the subjects of one or more reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
+API Reference for HappyHorse 1.0 R2V. HappyHorse 1.0 reference-to-video keeps the subjects of one or more reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.yaml
@@ -1,0 +1,42 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.0-r2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.0 R2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-r2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.0 reference-to-video keeps the subjects of one or more reference images consistent across a new
+  scene, addressed in the prompt as character1, character2 and so on.
+variants:
+- title: Happyhorse 1.0 R2V
+  model: wan/happyhorse-1.0-r2v
+example:
+  input:
+    prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+    media:
+      - type: reference_image
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+      actual_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-r2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.0-r2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.0 R2V
+name: HappyHorse 1.0 R2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-r2v over HTTP through Comfy Router, plus
@@ -11,7 +11,7 @@ summary: >-
   HappyHorse 1.0 reference-to-video keeps the subjects of one or more reference images consistent across a new
   scene, addressed in the prompt as character1, character2 and so on.
 variants:
-- title: Happyhorse 1.0 R2V
+- title: HappyHorse 1.0 R2V
   model: wan/happyhorse-1.0-r2v
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-t2
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Happyhorse 1.0 T2V with Comfy Router"
-description: "Call wan/happyhorse-1.0-t2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.0 T2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-t2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-t2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.0 T2V. HappyHorse 1.0 text-to-video builds a short video with synchronized audio from a prompt alone.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.0-t2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.0-t2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.0-t2v",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.0-t2v", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-t2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +381,33 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-t2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan2.6-t2v/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -357,5 +418,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-t2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.0 T2V with Comfy Router"
+title: "Use HappyHorse 1.0 T2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.0 T2V"
+sidebarTitle: "HappyHorse 1.0 T2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.0 T2V. HappyHorse 1.0 text-to-video builds a short video with synchronized audio from a prompt alone.
+API Reference for HappyHorse 1.0 T2V. HappyHorse 1.0 text-to-video builds a short video with synchronized audio from a prompt alone.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.0-t2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.0 T2V
+name: HappyHorse 1.0 T2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-t2v over HTTP through Comfy Router, plus
@@ -10,7 +10,7 @@ description: >-
 summary: >-
   HappyHorse 1.0 text-to-video builds a short video with synchronized audio from a prompt alone.
 variants:
-- title: Happyhorse 1.0 T2V
+- title: HappyHorse 1.0 T2V
   model: wan/happyhorse-1.0-t2v
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.0-t2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.0 T2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-t2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.0 text-to-video builds a short video with synchronized audio from a prompt alone.
+variants:
+- title: Happyhorse 1.0 T2V
+  model: wan/happyhorse-1.0-t2v
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-t2v/code.yaml
@@ -35,5 +35,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
@@ -1,26 +1,83 @@
 ---
 title: "Use Happyhorse 1.0 Video Edit with Comfy Router"
-description: "Call wan/happyhorse-1.0-video-edit through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-video-edit over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.0 Video Edit"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.0-video-edit.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.0-video-edit`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.0 Video Edit. HappyHorse 1.0 video edit rewrites an existing clip from a text instruction, optionally guided by reference images.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.0-video-edit`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.0-video-edit`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.0-video-edit",
+        {
+            "input": {
+                "prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+                "media": [
+                    {
+                        "type": "video",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.0-video-edit", {
+  input: {
+    prompt: "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    media: [
+      {
+        type: "video",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.0-video-edit \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged\",\"media\":[{\"type\":\"video\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4\"}]}, \"parameters\": {\"resolution\":\"720P\"}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +391,38 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-vi
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    "media": [
+      {
+        "type": "video",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P"
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    "actual_prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged, monochrome linework on paper texture",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +432,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.0-vi
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.0 Video Edit with Comfy Router"
+title: "Use HappyHorse 1.0 Video Edit with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-video-edit over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.0 Video Edit"
+sidebarTitle: "HappyHorse 1.0 Video Edit"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.0 Video Edit. HappyHorse 1.0 video edit rewrites an existing clip from a text instruction, optionally guided by reference images.
+API Reference for HappyHorse 1.0 Video Edit. HappyHorse 1.0 video edit rewrites an existing clip from a text instruction, optionally guided by reference images.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.yaml
@@ -1,0 +1,41 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.0-video-edit.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.0 Video Edit
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-video-edit over HTTP through Comfy Router,
+  plus the request fields and the result shape
+summary: >-
+  HappyHorse 1.0 video edit rewrites an existing clip from a text instruction, optionally guided by reference
+  images.
+variants:
+- title: Happyhorse 1.0 Video Edit
+  model: wan/happyhorse-1.0-video-edit
+example:
+  input:
+    prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged
+    media:
+      - type: video
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+  parameters:
+    resolution: 720P
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged
+      actual_prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged, monochrome linework on paper texture
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-0-video-edit/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.0-video-edit.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.0 Video Edit
+name: HappyHorse 1.0 Video Edit
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.0-video-edit over HTTP through Comfy Router,
@@ -11,7 +11,7 @@ summary: >-
   HappyHorse 1.0 video edit rewrites an existing clip from a text instruction, optionally guided by reference
   images.
 variants:
-- title: Happyhorse 1.0 Video Edit
+- title: HappyHorse 1.0 Video Edit
   model: wan/happyhorse-1.0-video-edit
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
@@ -1,26 +1,75 @@
 ---
 title: "Use Happyhorse 1.1 I2V with Comfy Router"
-description: "Call wan/happyhorse-1.1-i2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.1 I2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-i2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-i2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.1 I2V. HappyHorse 1.1 image-to-video animates a still first frame and renders synchronized dialogue, effects and music in the same pass.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.1-i2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.1-i2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.1-i2v",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.1-i2v", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-i2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"img_url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +383,34 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-i2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +420,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-i2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.1 I2V with Comfy Router"
+title: "Use HappyHorse 1.1 I2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.1 I2V"
+sidebarTitle: "HappyHorse 1.1 I2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.1 I2V. HappyHorse 1.1 image-to-video animates a still first frame and renders synchronized dialogue, effects and music in the same pass.
+API Reference for HappyHorse 1.1 I2V. HappyHorse 1.1 image-to-video animates a still first frame and renders synchronized dialogue, effects and music in the same pass.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.1-i2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.1 I2V
+name: HappyHorse 1.1 I2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-i2v over HTTP through Comfy Router, plus
@@ -11,7 +11,7 @@ summary: >-
   HappyHorse 1.1 image-to-video animates a still first frame and renders synchronized dialogue, effects and
   music in the same pass.
 variants:
-- title: Happyhorse 1.1 I2V
+- title: HappyHorse 1.1 I2V
   model: wan/happyhorse-1.1-i2v
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-i2v/code.yaml
@@ -1,0 +1,40 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.1-i2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.1 I2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-i2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.1 image-to-video animates a still first frame and renders synchronized dialogue, effects and
+  music in the same pass.
+variants:
+- title: Happyhorse 1.1 I2V
+  model: wan/happyhorse-1.1-i2v
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Happyhorse 1.1 R2V with Comfy Router"
-description: "Call wan/happyhorse-1.1-r2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.1 R2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-r2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-r2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.1 R2V. HappyHorse 1.1 reference-to-video keeps the subjects of up to nine reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.1-r2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.1-r2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.1-r2v",
+        {
+            "input": {
+                "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+                "media": [
+                    {
+                        "type": "reference_image",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.1-r2v", {
+  input: {
+    prompt: "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    media: [
+      {
+        type: "reference_image",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-r2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"character1 walks in from the left, turns to the camera and waves, plain orange backdrop\",\"media\":[{\"type\":\"reference_image\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-r2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "media": [
+      {
+        "type": "reference_image",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "actual_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-r2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.1 R2V with Comfy Router"
+title: "Use HappyHorse 1.1 R2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.1 R2V"
+sidebarTitle: "HappyHorse 1.1 R2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.1 R2V. HappyHorse 1.1 reference-to-video keeps the subjects of up to nine reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
+API Reference for HappyHorse 1.1 R2V. HappyHorse 1.1 reference-to-video keeps the subjects of up to nine reference images consistent across a new scene, addressed in the prompt as character1, character2 and so on.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.yaml
@@ -1,0 +1,42 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.1-r2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.1 R2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-r2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.1 reference-to-video keeps the subjects of up to nine reference images consistent across a new
+  scene, addressed in the prompt as character1, character2 and so on.
+variants:
+- title: Happyhorse 1.1 R2V
+  model: wan/happyhorse-1.1-r2v
+example:
+  input:
+    prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+    media:
+      - type: reference_image
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+      actual_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-r2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.1-r2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.1 R2V
+name: HappyHorse 1.1 R2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-r2v over HTTP through Comfy Router, plus
@@ -11,7 +11,7 @@ summary: >-
   HappyHorse 1.1 reference-to-video keeps the subjects of up to nine reference images consistent across a new
   scene, addressed in the prompt as character1, character2 and so on.
 variants:
-- title: Happyhorse 1.1 R2V
+- title: HappyHorse 1.1 R2V
   model: wan/happyhorse-1.1-r2v
 example:
   input:

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-t2
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use Happyhorse 1.1 T2V with Comfy Router"
+title: "Use HappyHorse 1.1 T2V with Comfy Router"
 description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
-sidebarTitle: "Happyhorse 1.1 T2V"
+sidebarTitle: "HappyHorse 1.1 T2V"
 ---
 
 {/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Happyhorse 1.1 T2V. HappyHorse 1.1 text-to-video builds a short video with synchronized dialogue, effects and music from a prompt alone.
+API Reference for HappyHorse 1.1 T2V. HappyHorse 1.1 text-to-video builds a short video with synchronized dialogue, effects and music from a prompt alone.
 
 ## Quick start
 

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Happyhorse 1.1 T2V with Comfy Router"
-description: "Call wan/happyhorse-1.1-t2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Happyhorse 1.1 T2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/happyhorse-1.1-t2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/happyhorse-1.1-t2v`, served by Comfy Router from Wan.
+API Reference for Happyhorse 1.1 T2V. HappyHorse 1.1 text-to-video builds a short video with synchronized dialogue, effects and music from a prompt alone.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/happyhorse-1.1-t2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/happyhorse-1.1-t2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/happyhorse-1.1-t2v",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/happyhorse-1.1-t2v", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/happyhorse-1.1-t2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +381,33 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-t2
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan2.6-t2v/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -357,5 +418,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/happyhorse-1.1-t2
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
@@ -1,0 +1,40 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/happyhorse-1.1-t2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Happyhorse 1.1 T2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-t2v over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  HappyHorse 1.1 text-to-video builds a short video with synchronized dialogue, effects and music from a prompt
+  alone.
+variants:
+- title: Happyhorse 1.1 T2V
+  model: wan/happyhorse-1.1-t2v
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
@@ -36,5 +36,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
+++ b/development/comfy-router/models/wan/happyhorse-1-1-t2v/code.yaml
@@ -2,7 +2,7 @@
 # `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
 # The request fields render from router-schemas/wan/happyhorse-1.1-t2v.json,
 # the schema Router validates a call against. Only the example body lives here.
-name: Happyhorse 1.1 T2V
+name: HappyHorse 1.1 T2V
 provider: Wan
 description: >-
   Python, TypeScript and cURL snippets for calling wan/happyhorse-1.1-t2v over HTTP through Comfy Router, plus
@@ -11,7 +11,7 @@ summary: >-
   HappyHorse 1.1 text-to-video builds a short video with synchronized dialogue, effects and music from a prompt
   alone.
 variants:
-- title: Happyhorse 1.1 T2V
+- title: HappyHorse 1.1 T2V
   model: wan/happyhorse-1.1-t2v
 example:
   input:

--- a/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-i2v-preview/code.mdx
@@ -1,26 +1,75 @@
 ---
 title: "Use Wan 2.5 I2V Preview with Comfy Router"
-description: "Call wan/wan2.5-i2v-preview through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.5-i2v-preview over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.5 I2V Preview"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-i2v-preview.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-i2v-preview`, served by Comfy Router from Wan.
+API Reference for Wan 2.5 I2V Preview. Wan 2.5 image-to-video turns a still first frame into a short video, with the motion and the camera move described by the prompt.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.5-i2v-preview`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.5-i2v-preview`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.5-i2v-preview",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.5-i2v-preview", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.5-i2v-preview \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"img_url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +383,34 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.5-i2v-previe
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +420,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.5-i2v-previe
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-5-i2v-preview/code.yaml
+++ b/development/comfy-router/models/wan/wan2-5-i2v-preview/code.yaml
@@ -1,0 +1,40 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.5-i2v-preview.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.5 I2V Preview
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.5-i2v-preview over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  Wan 2.5 image-to-video turns a still first frame into a short video, with the motion and the camera move
+  described by the prompt.
+variants:
+- title: Wan 2.5 I2V Preview
+  model: wan/wan2.5-i2v-preview
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.5-t2v-previe
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Wan 2.5 T2V Preview with Comfy Router"
-description: "Call wan/wan2.5-t2v-preview through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.5-t2v-preview over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.5 T2V Preview"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.5-t2v-preview.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.5-t2v-preview`, served by Comfy Router from Wan.
+API Reference for Wan 2.5 T2V Preview. Wan 2.5 text-to-video builds a short video from a prompt alone, with no reference image or video.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.5-t2v-preview`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.5-t2v-preview`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.5-t2v-preview",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.5-t2v-preview", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.5-t2v-preview \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +381,33 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.5-t2v-previe
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan2.6-t2v/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -357,5 +418,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.5-t2v-previe
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.yaml
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.5-t2v-preview.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.5 T2V Preview
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.5-t2v-preview over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  Wan 2.5 text-to-video builds a short video from a prompt alone, with no reference image or video.
+variants:
+- title: Wan 2.5 T2V Preview
+  model: wan/wan2.5-t2v-preview
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-5-t2v-preview/code.yaml
+++ b/development/comfy-router/models/wan/wan2-5-t2v-preview/code.yaml
@@ -35,5 +35,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-i2v/code.mdx
@@ -1,26 +1,75 @@
 ---
 title: "Use Wan 2.6 I2V with Comfy Router"
-description: "Call wan/wan2.6-i2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.6-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.6 I2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-i2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-i2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.6 I2V. Wan 2.6 image-to-video animates a still first frame, at 720P or 1080P and up to 15 seconds.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.6-i2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.6-i2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.6-i2v",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.6-i2v", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.6-i2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"img_url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +383,34 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-i2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "img_url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +420,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-i2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-6-i2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-6-i2v/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.6-i2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.6 I2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.6-i2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.6 image-to-video animates a still first frame, at 720P or 1080P and up to 15 seconds.
+variants:
+- title: Wan 2.6 I2V
+  model: wan/wan2.6-i2v
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    img_url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-r2v/code.mdx
@@ -1,26 +1,75 @@
 ---
 title: "Use Wan 2.6 R2V with Comfy Router"
-description: "Call wan/wan2.6-r2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.6-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.6 R2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-r2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-r2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.6 R2V. Wan 2.6 reference-to-video carries the subjects of one to three reference videos into a new scene, addressed in the prompt as character1, character2 and so on.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.6-r2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.6-r2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.6-r2v",
+        {
+            "input": {
+                "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+                "reference_video_urls": ["https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.6-r2v", {
+  input: {
+    prompt: "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    reference_video_urls: ["https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.6-r2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"character1 walks in from the left, turns to the camera and waves, plain orange backdrop\",\"reference_video_urls\":[\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4\"]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +383,36 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-r2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "reference_video_urls": [
+      "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "actual_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +422,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-r2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-6-r2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-6-r2v/code.yaml
@@ -1,0 +1,41 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.6-r2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.6 R2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.6-r2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.6 reference-to-video carries the subjects of one to three reference videos into a new scene, addressed
+  in the prompt as character1, character2 and so on.
+variants:
+- title: Wan 2.6 R2V
+  model: wan/wan2.6-r2v
+example:
+  input:
+    prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+    reference_video_urls:
+      - "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+      actual_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-t2v/openap
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Wan 2.6 T2V with Comfy Router"
-description: "Call wan/wan2.6-t2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.6-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.6 T2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.6-t2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.6-t2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.6 T2V. Wan 2.6 text-to-video builds a short video from a prompt alone, at 720P or 1080P and up to 15 seconds.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.6-t2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.6-t2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.6-t2v",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.6-t2v", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.6-t2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +381,33 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-t2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan2.6-t2v/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -357,5 +418,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.6-t2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.yaml
@@ -35,5 +35,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-6-t2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-6-t2v/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.6-t2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.6 T2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.6-t2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.6 text-to-video builds a short video from a prompt alone, at 720P or 1080P and up to 15 seconds.
+variants:
+- title: Wan 2.6 T2V
+  model: wan/wan2.6-t2v
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-i2v/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Wan 2.7 I2V with Comfy Router"
-description: "Call wan/wan2.7-i2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.7-i2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.7 I2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-i2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-i2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.7 I2V. Wan 2.7 image-to-video animates a first frame supplied through the media list, which also accepts a last frame, a driving audio track and an opening clip.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.7-i2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.7-i2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.7-i2v",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "media": [
+                    {
+                        "type": "first_frame",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.7-i2v", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    media: [
+      {
+        type: "first_frame",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.7-i2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"media\":[{\"type\":\"first_frame\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-i2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "media": [
+      {
+        "type": "first_frame",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-i2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-7-i2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-7-i2v/code.yaml
@@ -1,0 +1,42 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.7-i2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.7 I2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.7-i2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.7 image-to-video animates a first frame supplied through the media list, which also accepts a last
+  frame, a driving audio track and an opening clip.
+variants:
+- title: Wan 2.7 I2V
+  model: wan/wan2.7-i2v
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    media:
+      - type: first_frame
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-r2v/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Wan 2.7 R2V with Comfy Router"
-description: "Call wan/wan2.7-r2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.7-r2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.7 R2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-r2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-r2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.7 R2V. Wan 2.7 reference-to-video carries subjects from reference images and reference videos into a new scene, addressed in the prompt as character1, character2 and so on.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.7-r2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.7-r2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.7-r2v",
+        {
+            "input": {
+                "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+                "media": [
+                    {
+                        "type": "reference_image",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.7-r2v", {
+  input: {
+    prompt: "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    media: [
+      {
+        type: "reference_image",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.7-r2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"character1 walks in from the left, turns to the camera and waves, plain orange backdrop\",\"media\":[{\"type\":\"reference_image\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-r2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "media": [
+      {
+        "type": "reference_image",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop",
+    "actual_prompt": "character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-r2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-7-r2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-7-r2v/code.yaml
@@ -1,0 +1,42 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.7-r2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.7 R2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.7-r2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.7 reference-to-video carries subjects from reference images and reference videos into a new scene,
+  addressed in the prompt as character1, character2 and so on.
+variants:
+- title: Wan 2.7 R2V
+  model: wan/wan2.7-r2v
+example:
+  input:
+    prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+    media:
+      - type: reference_image
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop
+      actual_prompt: character1 walks in from the left, turns to the camera and waves, plain orange backdrop, even studio lighting, steady medium shot
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Wan 2.7 T2V with Comfy Router"
-description: "Call wan/wan2.7-t2v through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.7-t2v over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.7 T2V"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-t2v.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-t2v`, served by Comfy Router from Wan.
+API Reference for Wan 2.7 T2V. Wan 2.7 text-to-video builds a short video from a prompt alone, at 720P or 1080P and 2 to 15 seconds.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.7-t2v`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.7-t2v`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.7-t2v",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.7-t2v", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.7-t2v \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +381,33 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-t2v/openap
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan2.6-t2v/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -357,5 +418,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-t2v/openap
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.mdx
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-t2v/openap
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.yaml
@@ -35,5 +35,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-7-t2v/code.yaml
+++ b/development/comfy-router/models/wan/wan2-7-t2v/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.7-t2v.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.7 T2V
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.7-t2v over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.7 text-to-video builds a short video from a prompt alone, at 720P or 1080P and 2 to 15 seconds.
+variants:
+- title: Wan 2.7 T2V
+  model: wan/wan2.7-t2v
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
+++ b/development/comfy-router/models/wan/wan2-7-videoedit/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Wan 2.7 Video Edit with Comfy Router"
-description: "Call wan/wan2.7-videoedit through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan2.7-videoedit over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 2.7 Video Edit"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan2.7-videoedit.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan2.7-videoedit`, served by Comfy Router from Wan.
+API Reference for Wan 2.7 Video Edit. Wan 2.7 video edit rewrites an existing clip from a text instruction, optionally guided by reference images.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan2.7-videoedit`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan2.7-videoedit`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan2.7-videoedit",
+        {
+            "input": {
+                "prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+                "media": [
+                    {
+                        "type": "video",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "audio_setting": "origin",
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan2.7-videoedit", {
+  input: {
+    prompt: "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    media: [
+      {
+        type: "video",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    audio_setting: "origin",
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan2.7-videoedit \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged\",\"media\":[{\"type\":\"video\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4\"}]}, \"parameters\": {\"resolution\":\"720P\",\"audio_setting\":\"origin\"}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-videoedit/
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    "media": [
+      {
+        "type": "video",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "audio_setting": "origin"
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged",
+    "actual_prompt": "restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged, monochrome linework on paper texture",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan2.7-videoedit/
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan2-7-videoedit/code.yaml
+++ b/development/comfy-router/models/wan/wan2-7-videoedit/code.yaml
@@ -1,0 +1,41 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan2.7-videoedit.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 2.7 Video Edit
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan2.7-videoedit over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 2.7 video edit rewrites an existing clip from a text instruction, optionally guided by reference images.
+variants:
+- title: Wan 2.7 Video Edit
+  model: wan/wan2.7-videoedit
+example:
+  input:
+    prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged
+    media:
+      - type: video
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/street_dancer.mp4"
+  parameters:
+    resolution: 720P
+    audio_setting: origin
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged
+      actual_prompt: restyle the clip as a hand-drawn ink sketch, keep the dancer's movement unchanged, monochrome linework on paper texture
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
@@ -8,7 +8,7 @@ sidebarTitle: "Wan 3.0 Video Prime"
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for Wan 3.0 Video Prime. Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, taking the same prompt and media list.
+API Reference for Wan 3.0 Video Prime. Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, validated against the same Router prompt and media schema.
 
 ## Quick start
 
@@ -413,7 +413,7 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan3.0-video-prim
   "usage": {
     "video_count": 1,
     "video_duration": 5,
-    "video_ratio": "1920*1080"
+    "video_ratio": "1280*720"
   }
 }
 ```

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.mdx
@@ -1,26 +1,73 @@
 ---
 title: "Use Wan 3.0 Video Prime with Comfy Router"
-description: "Call wan/wan3.0-video-prime through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan3.0-video-prime over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 3.0 Video Prime"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan3.0-video-prime.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan3.0-video-prime`, served by Comfy Router from Wan.
+API Reference for Wan 3.0 Video Prime. Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, taking the same prompt and media list.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan3.0-video-prime`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan3.0-video-prime`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan3.0-video-prime",
+        {
+            "input": {
+                "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan3.0-video-prime", {
+  input: {
+    prompt: "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan3.0-video-prime \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"a single red maple leaf falling onto still water, slow motion, shallow depth of field\"}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,27 +381,43 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan3.0-video-prim
 
 ## Examples
 
-### Output
+### Input
 
 ```json
 {
-  "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
-    "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
-    "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+  "input": {
+    "prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field"
   },
-  "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
-  "usage": {
-    "SR": 720,
+  "parameters": {
+    "resolution": "720P",
     "duration": 5
   }
 }
 ```
 
+### Output
+
+```json
+{
+  "output": {
+    "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
+    "task_status": "SUCCEEDED",
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
+    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward",
+    "video_url": "https://.../generated.mp4"
+  },
+  "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
+  "usage": {
+    "video_count": 1,
+    "video_duration": 5,
+    "video_ratio": "1920*1080"
+  }
+}
+```
+
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.yaml
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.yaml
@@ -8,7 +8,7 @@ description: >-
   Python, TypeScript and cURL snippets for calling wan/wan3.0-video-prime over HTTP through Comfy Router, plus
   the request fields and the result shape
 summary: >-
-  Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, taking the same prompt and media list.
+  Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, validated against the same Router prompt and media schema.
 variants:
 - title: Wan 3.0 Video Prime
   model: wan/wan3.0-video-prime
@@ -35,5 +35,5 @@ result:
     usage:
       video_count: 1
       video_duration: 5
-      video_ratio: 1920*1080
+      video_ratio: 1280*720
   note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan3-0-video-prime/code.yaml
+++ b/development/comfy-router/models/wan/wan3-0-video-prime/code.yaml
@@ -1,0 +1,39 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan3.0-video-prime.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 3.0 Video Prime
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan3.0-video-prime over HTTP through Comfy Router, plus
+  the request fields and the result shape
+summary: >-
+  Wan 3.0 Video Prime is the higher-quality tier of Wan 3.0 Video, taking the same prompt and media list.
+variants:
+- title: Wan 3.0 Video Prime
+  model: wan/wan3.0-video-prime
+example:
+  input:
+    prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field
+      actual_prompt: a single red maple leaf falling onto still water, slow motion, shallow depth of field, soft morning light, gentle ripples spreading outward
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      video_count: 1
+      video_duration: 5
+      video_ratio: 1920*1080
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.

--- a/development/comfy-router/models/wan/wan3-0-video/code.mdx
+++ b/development/comfy-router/models/wan/wan3-0-video/code.mdx
@@ -1,26 +1,85 @@
 ---
 title: "Use Wan 3.0 Video with Comfy Router"
-description: "Call wan/wan3.0-video through Comfy Router: endpoint, request shape and the response Router returns."
+description: "Python, TypeScript and cURL snippets for calling wan/wan3.0-video over HTTP through Comfy Router, plus the request fields and the result shape"
 sidebarTitle: "Wan 3.0 Video"
 ---
 
-{/* GENERATED FILE. Generated from router-schemas/wan/wan3.0-video.json by `pnpm code-pages:gen`. */}
+{/* GENERATED FILE. Edit code.yaml in this directory and run `pnpm code-pages:gen`. */}
 
 import RouterCodeFooter from "/snippets/comfy-router/model-code-footer.mdx";
 
-API Reference for `wan/wan3.0-video`, served by Comfy Router from Wan.
+API Reference for Wan 3.0 Video. Wan 3.0 Video generates from a prompt alone or from a media list of first and last frames, reference images, videos and audio, addressed in the prompt as Image 1, Video 1 and Audio 1.
 
-## Request setup
+## Quick start
 
-Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. For Python, run `pip install comfy-sdk`. For TypeScript, run `npm install @comfyorg/sdk`. cURL uses raw HTTP.
+Create a key in [your Comfy workspace](https://platform.comfy.org/profile/api-keys) and export it as `COMFY_API_KEY`. The Python and TypeScript snippets use the Comfy SDKs (`pip install comfy-sdk`, `npm install @comfyorg/sdk`); the cURL snippet is the same call over raw HTTP.
 
 **Model ID:** `wan/wan3.0-video`
 
 **Endpoint:** `POST https://api.comfy.org/v2/models/wan/wan3.0-video`
 
-<Note>
-This model has no runnable request example. Build the body from the input documentation below, then use it with the [Router quickstart](/development/comfy-router/quickstart).
-</Note>
+<CodeGroup>
+```python Python
+from comfy_sdk import Comfy
+
+# Reads COMFY_API_KEY from the environment.
+# The SDK automatically creates an idempotency key and reuses it for automatic retries.
+with Comfy() as client:
+    result = client.models.run(
+        "wan/wan3.0-video",
+        {
+            "input": {
+                "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+                "media": [
+                    {
+                        "type": "first_frame",
+                        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+                    },
+                ],
+            },
+            "parameters": {
+                "resolution": "720P",
+                "duration": 5,
+            },
+        },
+    )
+
+print("video:", result["output"]["video_url"])
+```
+
+```typescript TypeScript
+import { comfy } from "@comfyorg/sdk";
+
+// Reads COMFY_API_KEY from the environment.
+// The SDK automatically creates an idempotency key and reuses it for automatic retries.
+type Result = { output: { video_url: string } };
+const { data } = await comfy.models.run<Result>("wan/wan3.0-video", {
+  input: {
+    prompt: "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    media: [
+      {
+        type: "first_frame",
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png",
+      },
+    ],
+  },
+  parameters: {
+    resolution: "720P",
+    duration: 5,
+  },
+});
+
+console.log("video:", data.output.video_url);
+```
+
+```bash cURL
+curl https://api.comfy.org/v2/models/wan/wan3.0-video \
+  -H "X-API-Key: $COMFY_API_KEY" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d "{\"input\": {\"prompt\":\"the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady\",\"media\":[{\"type\":\"first_frame\",\"url\":\"https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png\"}]}, \"parameters\": {\"resolution\":\"720P\",\"duration\":5}}"
+```
+</CodeGroup>
 
 ## Schema
 
@@ -334,19 +393,39 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan3.0-video/open
 
 ## Examples
 
+### Input
+
+```json
+{
+  "input": {
+    "prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "media": [
+      {
+        "type": "first_frame",
+        "url": "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+      }
+    ]
+  },
+  "parameters": {
+    "resolution": "720P",
+    "duration": 5
+  }
+}
+```
+
 ### Output
 
 ```json
 {
   "output": {
-    "actual_prompt": "a single red maple leaf falling onto still water, slow motion, shallow depth of field",
-    "end_time": "2027-01-01T00:01:04.000Z",
-    "orig_prompt": "a single red maple leaf falling onto still water",
-    "scheduled_time": "2027-01-01T00:00:01.000Z",
-    "submit_time": "2027-01-01T00:00:00.000Z",
     "task_id": "0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60",
     "task_status": "SUCCEEDED",
-    "video_url": "https://example.invalid/wan/wan3.0-video/generated.mp4"
+    "submit_time": "2027-01-01T00:00:00.000Z",
+    "scheduled_time": "2027-01-01T00:00:01.000Z",
+    "end_time": "2027-01-01T00:01:04.000Z",
+    "orig_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady",
+    "actual_prompt": "the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in",
+    "video_url": "https://.../generated.mp4"
   },
   "request_id": "7574ee8f-38a3-4b1e-9280-11c33ab46e51",
   "usage": {
@@ -356,5 +435,6 @@ Generated from the schema Router serves at `GET /v2/models/wan/wan3.0-video/open
 }
 ```
 
+The video URL is valid for 24 hours. Download the video promptly if you need to keep it.
 
 <RouterCodeFooter />

--- a/development/comfy-router/models/wan/wan3-0-video/code.yaml
+++ b/development/comfy-router/models/wan/wan3-0-video/code.yaml
@@ -1,0 +1,42 @@
+# Source of truth for code.mdx in this directory. Edit this file, then run
+# `pnpm code-pages:gen`; never edit code.mdx by hand (CI checks it is fresh).
+# The request fields render from router-schemas/wan/wan3.0-video.json,
+# the schema Router validates a call against. Only the example body lives here.
+name: Wan 3.0 Video
+provider: Wan
+description: >-
+  Python, TypeScript and cURL snippets for calling wan/wan3.0-video over HTTP through Comfy Router, plus the
+  request fields and the result shape
+summary: >-
+  Wan 3.0 Video generates from a prompt alone or from a media list of first and last frames, reference images,
+  videos and audio, addressed in the prompt as Image 1, Video 1 and Audio 1.
+variants:
+- title: Wan 3.0 Video
+  model: wan/wan3.0-video
+example:
+  input:
+    prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+    media:
+      - type: first_frame
+        url: "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/input/pink_robot_front.png"
+  parameters:
+    resolution: 720P
+    duration: 5
+result:
+  path: output.video_url
+  label: video
+  example:
+    output:
+      task_id: 0385dc79-5ff8-4d82-bcb6-7c1a9f2e4d60
+      task_status: SUCCEEDED
+      submit_time: "2027-01-01T00:00:00.000Z"
+      scheduled_time: "2027-01-01T00:00:01.000Z"
+      end_time: "2027-01-01T00:01:04.000Z"
+      orig_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady
+      actual_prompt: the robot lowers its raised arm and steps toward the camera, the flat orange backdrop holds steady, smooth studio lighting, subtle camera push in
+      video_url: "https://.../generated.mp4"
+    request_id: 7574ee8f-38a3-4b1e-9280-11c33ab46e51
+    usage:
+      SR: 720
+      duration: 5
+  note: The video URL is valid for 24 hours. Download the video promptly if you need to keep it.


### PR DESCRIPTION
## ELI-5

Every Comfy Router model page builds its Python, TypeScript and cURL snippets out of one shared example request body. 23 of the 198 generated pages had no such body, so instead of copy-pasteable code they showed a note telling the reader to assemble the request themselves. This adds the missing bodies for the 18 wan video models, and for the five pages that genuinely have nothing to build one from, it makes the note say *why* and point somewhere useful.

## What changed

**18 new `code.yaml` specs** under `development/comfy-router/models/wan/`, one per wan video model: `wan2.5-i2v-preview`, `wan2.5-t2v-preview`, `wan2.6-i2v`, `wan2.6-t2v`, `wan2.6-r2v`, `wan2.7-i2v`, `wan2.7-t2v`, `wan2.7-r2v`, `wan2.7-videoedit`, `wan3.0-video`, `wan3.0-video-prime`, and the seven HappyHorse 1.0 / 1.1 models. Each carries a display name, a one-sentence summary, the request body, and the result path so the snippets print `output.video_url` rather than the whole envelope.

**Why `code.yaml` and not `router-schemas/`.** The example could also live at `paths.<route>.post.requestBody.content['application/json'].schema.example` in the synced schema document, which is where the two wan image models carry theirs. Those files are not an authoring surface: `.github/scripts/snippets/README.md` says the spec-sync bot drops them in and not to hand write them, and every one of the last nine commits touching `router-schemas/` is a wholesale bot sync. An example added there would be reverted on the next sync. `code.yaml` is the documented surface for a hand-written body and it survives the sync. The schema still renders the Input and Output field tables on every one of these pages exactly as before; only the example body moved into the repo.

**Assets in the request examples** are first-party files in `Comfy-Org/workflow_templates`, both re-checked HTTP 200 while writing this:

- `input/pink_robot_front.png`, 1232x928 PNG, 1.2 MB. Inside the `input.img_url` bounds the schema documents (JPEG/JPG/PNG/BMP/WEBP, 360 to 2000 pixels, max 10 MB), verified with `ffprobe`.
- `input/street_dancer.mp4`, 720x1280, 5.0 s, 2.6 MB. Inside the `input.reference_video_urls` bounds (mp4/mov, 2 to 30 s, max 30 MB), verified with `ffprobe`.

No `example.invalid` placeholder appears anywhere in the added request examples.

**Generator change, one branch.** The no-example fallback note now has two wordings. A model with an authored input schema keeps the existing text. A model that publishes `x-comfy-input-schema-authored: false` gets a note that says Router has not published a schema for it, so there is nothing to generate an example from, and sends the reader to that provider's own API reference. The old text told those readers to "build the body from the input documentation below" when the section below has no fields in it at all, only a pointer to the provider. Same edit switches `${provider}'s` to the file's existing `possessive()` helper, which fixes `Gemini Interactions's` to `Gemini Interactions'` on the two pages where the label ends in `s`.

**HappyHorse casing**, in a separate commit. The auto-derived title rule produced `Happyhorse`; the tutorials, the built-in node pages and the product spell it `HappyHorse`. Now that these pages carry a hand-written spec, the name is set there. This changes the seven sidebar labels and their rows in the generated catalog index. `docs.json` is untouched.

## Coverage, measured

| | before | after |
|---|---|---|
| generated model pages | 198 | 198 |
| pages rendering a `<CodeGroup>` | 175 | 193 |
| pages showing a no-example note | 23 | 5 |

The five remaining are `ltx/ltx-2-5-fast`, `ltx/ltx-2-5-pro`, `gemini-interactions/gemini-omni-1-1-flash`, `gemini-interactions/gemini-omni-flash-preview` and `minimax/minimax-h3`. Their notes now explain the reason instead of stating the absence.

I pointed the same sweep at the portion this PR does **not** fix and the numbers are under `## Residual`.

## Where the bodies came from, and what that does not prove

Every field and value is taken from the model's own published input schema in `router-schemas/wan/*.json`, which is the document Router validates a call against, plus this repo's own HappyHorse node pages (`built-in-nodes/HappyHorse*.mdx`) for the HappyHorse resolution and duration ranges. `resolution: 720P` and `duration: 5` are enum-valid and inside the documented per-model range for every one of the 18.

They were **not** lifted from the Router end-to-end case table. That table is not in this repo and I did not have access to it, so no example here is backed by a request that has actually been sent. Nothing in this PR was run against a live billed generation either. The bodies are schema-valid; provider acceptance is a separate thing, and the schema says so itself: "Schema acceptance alone does not imply provider acceptance."

## Falsifying the "no example exists" claim

The five remaining notes assert that no request example is available, so I went looking for one through every path I could reach rather than asserting it:

- All 198 synced schema documents parsed for `requestBody.content['application/json'].example` and `.schema.example`: exactly 23 had neither, and those 23 are the pages in this ticket. No other source of a request example exists in `router-schemas/`.
- No `code.yaml` existed for any of the 23.
- `GET https://api.comfy.org/v2/models/<provider>/<model>/openapi.json`, the live endpoint these snapshots are synced from, answers **401** without an API key for all seven models I tried, so it could neither confirm nor refute a newer upstream example. This is recorded as an unexercised artifact below.
- `openapi-v2.yaml` in this repo is the generic Router API spec and carries no per-model request bodies.

The note is also a redirect rather than a dead end: it names the provider whose API reference does document the body, and links the Router quickstart for sending it.

## Residual

**The three HappyHorse bodies with the weakest documentary support.** `wan/happyhorse-1.0-r2v`, `wan/happyhorse-1.1-r2v` and `wan/happyhorse-1.0-video-edit` pass their reference image or input video through `input.media[]` with `type: reference_image` / `type: video`. Those values are in the enum the shared schema publishes for these three models, and the sibling `wan2.7-r2v` and `wan2.7-videoedit` models use exactly those types. But the field's own description reads "Media asset list for wan2.7 and wan3.0 models" and its per-model type list does not mention HappyHorse at all, and the schema carries no other field that could hold a reference image. So the shape is a reading of the schema, not a shape anyone has confirmed HappyHorse accepts, and the page contains a sentence that arguably contradicts its own example. Confirming these three against the Router case table, or getting the `media` description amended to name HappyHorse, is the follow-up.

**Five model pages still have no request example**: `ltx/ltx-2-5-fast`, `ltx/ltx-2-5-pro`, `gemini-interactions/gemini-omni-1-1-flash`, `gemini-interactions/gemini-omni-flash-preview`, `minimax/minimax-h3`. All five publish `x-comfy-input-schema-authored: false` and document zero request fields, so there is no in-repo material to build a verifiable body from. Authoring an input schema for them upstream is what unblocks this; once that lands, the sync gives these pages both a schema and an example with no change here.

**Four pages still ship a request example that reads as runnable and cannot run**, because their body points at a non-resolving `example.invalid` host: `kling/kling-v1-5`, `kling/kling-v2-1`, `kling/videos-avatar-image2video`, `wan/wan2-5-i2i-preview`. That is a different defect from this one and has its own ticket, so I left it alone. Recording the count here because I had the sweep built: `example.invalid` also appears in the **response** fixtures of 103 of the 198 pages, which is cosmetic rather than a broken copy-paste, and is untouched.

**Unexercised artifacts.** `GET /v2/models/<provider>/<model>/openapi.json` answered 401 from this environment, so I could not check whether the live spec is ahead of the committed snapshot for any of the 23 models. The Router end-to-end case table the acceptance criteria name is not in this repo and I could not read it, so no body here is cross-checked against a request that has been sent. No example was verified against a live generation, by design.

**A durability note the follow-up should carry.** For a curated page the generator resolves the example as `variant.example ?? spec.example` and never falls back to the schema example, so if upstream later publishes a request example for one of these 18 models, the `code.yaml` body will shadow it silently. Deleting the `code.yaml` at that point is all it takes, but nothing warns you.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `bun run code-pages:check` (198 pages fresh, 27 curated / 171 derived; `--validate` syntax-checks every emitted Python, TypeScript and bash snippet): pass. `bun test ./.github/scripts/snippets/`: 16 pass, 0 fail. `bun run code-pages:check-providers`: 0 errors, 281 pre-existing warnings, 18 skipped (the new specs declare no `provider_spec`). `python3 .github/scripts/validate-links.py --check`: pass. `python3 .github/scripts/check-anchors.py --only-changed`: 23 files, pass. `curl -sI` on both asset URLs: HTTP 200. `ffprobe` on both assets for the dimension, duration and size bounds.
- **Deviations:** the acceptance criterion asking for bodies lifted from the Router end-to-end case table is not met, because that table is not reachable from this repo; bodies come from the published per-model schema instead, and the three weakest are named under `## Residual`. The criterion asking for `@file:` or a resolvable URL is met with resolvable URLs: `@file:` only reaches top-level keys of the example (`fileInputs()` filters `Object.entries(example)` and the literal emitters only consult the file list at depth 0), and every wan asset sits nested under `input`, so using it would have meant changing generator behaviour that the ticket puts out of scope. The response fixtures I authored use the elided `https://.../generated.mp4` placeholder that the existing curated specs use for the same purpose, rather than a resolvable URL, on the grounds that a response fixture is not something a reader sends.
