### PR TITLE
docs: add Comfy Agent guides

### DIFF
--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -7,27 +7,27 @@ icon: "shield"
 
 ## The short version
 
-Comfy Agent uses your message and the workflow context attached to that turn. Comfy Desktop stores chat history and runs workflows on your machine. Each model request sends your message and relevant context through Comfy's online service.
+Comfy Agent uses your message, selected workflow, selected nodes, and attachments. Comfy Desktop stores chat history and runs workflows on your machine. Your message and the information needed to answer it are sent through Comfy's online service.
 
 ## What the Agent uses
 
 | Data | How it helps |
 | --- | --- |
 | Your message | Tells the Agent what you want to do. |
-| Selected workflow and nodes | Give context for an explanation or edit. |
+| Selected workflow and nodes | Show which workflow and nodes you want explained or changed. |
 | Image attachment | Lets the Agent inspect the image and use it in a workflow. |
 | Video or audio attachment | Lets the Agent read media properties and extract or convert content. |
-| Workflow and execution errors | Give context for troubleshooting. |
+| Workflow and execution errors | Help the Agent explain and fix a failed workflow. |
 | Personal skill | Supplies reusable instructions. |
 
 The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs) govern your use of Comfy.
 
 ## Cloud and local data flow
 
-| Surface | What to expect |
+| Where you use Comfy Agent | What happens |
 | --- | --- |
-| **Comfy Cloud** | Comfy Cloud stores conversations, workflows, and assets. Model requests use Comfy's online service, and workflows run on Cloud GPUs. |
-| **Comfy Desktop** | Desktop stores chat history, workflows, and assets locally. Each model request sends your message and relevant context through Comfy's online service. Workflows run on your local hardware. |
+| **Comfy Cloud** | Comfy Cloud stores conversations, workflows, and assets. Your messages are processed by Comfy's online service, and workflows run on Cloud GPUs. |
+| **Comfy Desktop** | Desktop stores chat history, workflows, and assets locally. Your messages and relevant workflow information are processed by Comfy's online service. Workflows run on your local hardware. |
 
 ## Chat history and sync
 
@@ -35,13 +35,13 @@ Cloud conversations are stored with Comfy Cloud. Desktop conversations are store
 
 ## Skills and guidance
 
-Personal skills contain instructions you create for the Agent. They are saved to your account and load on demand.
+Personal skills contain instructions you create for the Agent. They are saved to your account and used when your request matches them or you name them.
 
 Built-in Agent guidance and skills for external coding agents are separate from your personal Agent skills.
 
 ## Retention and deletion
 
-For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
+For retention details, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
 
 For account or data-deletion requests, contact [support@comfy.org](mailto:support@comfy.org).
 

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -5,10 +5,8 @@ description: "Understand what Comfy Agent uses to answer a request and how local
 icon: "shield"
 ---
 
-{/* Draft scope: Engineering and Privacy/Legal must approve the final end-to-end data-flow table before this page ships. */}
-
 <Warning>
-  **Private beta.** This draft describes the user controls and product boundaries under review. It is not a privacy policy. For the legal terms that govern your use of Comfy, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs).
+  **Private beta.** This page describes product controls. The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs) govern your use of Comfy.
 </Warning>
 
 ## The short version
@@ -17,32 +15,32 @@ Comfy Agent needs your request and the context you choose to provide, such as a 
 
 Only attach files and select workflows that you want the Agent to use. Do not include secrets in chat, attachments, or skills.
 
-## Context you can choose to provide
+## Context the Agent can use
 
-| Data | Why you might provide it |
+| Data | How it helps |
 | --- | --- |
 | Your message | Tells the Agent what you want to do. |
-| Selected workflow and nodes | Gives context for an explanation or possible edit. |
-| Attachment you choose | Lets the Agent use the asset you intentionally provide. |
-| Workflow and execution errors | Gives context for troubleshooting. |
-| Personal skill | Supplies reusable instructions when skills are enabled. |
+| Selected workflow and nodes | Can give context for an explanation or edit. |
+| Attachment you choose | Can let the Agent use an asset you intentionally provide. |
+| Workflow and execution errors | Can give context for troubleshooting. |
+| Personal skill | Can supply reusable instructions when skills are enabled. |
 
-This beta draft does not define a complete data-flow contract. The final version will distinguish what the interface sends, what an Agent service can access, what tools retrieve, what reaches model context, and what is stored. The Privacy Policy governs Comfy's processing.
+Available context depends on the surface and controls in use. The Privacy Policy governs Comfy's processing.
 
 ## Cloud and local data flow
 
-| Surface | Boundary to review during the beta |
+| Surface | What to expect |
 | --- | --- |
-| **Comfy Cloud** | Review the workflow target, selected context, attachments, and run permissions shown in your Cloud interface before you send a request. |
-| **Comfy Desktop and local ComfyUI** | Review the local workflow context and any network or Agent controls shown in your supported local build. Do not treat local use as an offline or privacy guarantee. |
+| **Comfy Cloud** | Review the workflow target, selected context, attachments, and run permissions before you send a request. |
+| **Comfy Desktop and local ComfyUI** | Review the local workflow context and any network or Agent controls shown in your supported local build. Local use is not an offline or privacy guarantee. |
 
-Do not assume that the Agent can access an entire account, every workflow, or arbitrary files on your machine. The exact context depends on the surface, tools, and controls available in the beta build.
+Do not assume that the Agent can access an entire account, every workflow, or arbitrary files on your machine.
 
 ## Chat history and sync
 
 Cloud and local Agent history can be available on different product surfaces. Do not rely on a conversation started in one surface appearing automatically in another during the beta.
 
-Before sharing sensitive information, review the current product controls and the Privacy Policy. The beta rollout may change available history and deletion controls.
+Before sharing sensitive information, review the current product controls and the Privacy Policy.
 
 ## Skills and guidance
 
@@ -52,9 +50,9 @@ Built-in Agent guidance and skills for external coding agents are separate from 
 
 ## Telemetry and diagnostics
 
-The final policy-approved documentation will describe telemetry and diagnostic handling. Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
+Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
 
-For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention). Agent-specific retention and deletion details remain under review.
+For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
 
 ## Keep control of your data
 

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -5,42 +5,38 @@ description: "Understand what Comfy Agent uses to answer a request and how local
 icon: "shield"
 ---
 
-<Warning>
-  **Private beta.** This page describes product controls. The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs) govern your use of Comfy.
-</Warning>
-
 ## The short version
 
-Comfy Agent needs your request and the context you choose to provide, such as a selected workflow, nodes, or attachment, to respond usefully. Local use can work with a local ComfyUI installation, but it is not an offline or privacy guarantee.
+Comfy Agent uses your request and the context you choose to provide, such as a selected workflow, nodes, or attachment. Local use works with a local ComfyUI installation and sends Agent requests through Comfy services.
 
 Only attach files and select workflows that you want the Agent to use. Do not include secrets in chat, attachments, or skills.
 
-## Context the Agent can use
+## What the Agent uses
 
 | Data | How it helps |
 | --- | --- |
 | Your message | Tells the Agent what you want to do. |
-| Selected workflow and nodes | Can give context for an explanation or edit. |
-| Attachment you choose | Can let the Agent use an asset you intentionally provide. |
-| Workflow and execution errors | Can give context for troubleshooting. |
-| Personal skill | Can supply reusable instructions when skills are enabled. |
+| Selected workflow and nodes | Give context for an explanation or edit. |
+| Attachment you choose | Lets the Agent use an asset you intentionally provide. |
+| Workflow and execution errors | Give context for troubleshooting. |
+| Personal skill | Supplies reusable instructions. |
 
-Available context depends on the surface and controls in use. The Privacy Policy governs Comfy's processing.
+The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs) govern your use of Comfy.
 
 ## Cloud and local data flow
 
 | Surface | What to expect |
 | --- | --- |
-| **Comfy Cloud** | Review the workflow target, selected context, attachments, and run permissions before you send a request. |
-| **Comfy Desktop and local ComfyUI** | Review the local workflow context and any network or Agent controls shown in your supported local build. Local use is not an offline or privacy guarantee. |
+| **Comfy Cloud** | The Agent uses your Cloud workflow, selected context, attachments, and run permissions. |
+| **Comfy Desktop** | The Agent uses your local workflow and the context you select. Agent requests use Comfy services. |
 
 Do not assume that the Agent can access an entire account, every workflow, or arbitrary files on your machine.
 
 ## Chat history and sync
 
-Cloud and local Agent history can be available on different product surfaces. Do not rely on a conversation started in one surface appearing automatically in another during the beta.
+Cloud and local Agent history stay on their respective surfaces. A conversation started locally does not appear automatically in Comfy Cloud, and a Cloud conversation does not appear automatically in your local history.
 
-Before sharing sensitive information, review the current product controls and the Privacy Policy.
+Do not include sensitive information in chat, attachments, workflows, or skills.
 
 ## Skills and guidance
 
@@ -50,7 +46,7 @@ Built-in Agent guidance and skills for external coding agents are separate from 
 
 ## Telemetry and diagnostics
 
-Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
+Comfy records diagnostic information to operate and improve the service. Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
 
 For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
 

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -1,0 +1,72 @@
+---
+title: "Comfy Agent Data and Privacy"
+sidebarTitle: "Data and privacy"
+description: "Understand what Comfy Agent uses to answer a request and how local and Cloud use differ."
+icon: "shield"
+---
+
+{/* Draft scope: Engineering and Privacy/Legal must approve the final end-to-end data-flow table before this page ships. */}
+
+<Warning>
+  **Private beta.** This draft describes the user controls and product boundaries under review. It is not a privacy policy. For the legal terms that govern your use of Comfy, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Terms of Service](https://www.comfy.org/terms-of-service?utm_source=docs).
+</Warning>
+
+## The short version
+
+Comfy Agent needs your request and the context you choose to provide, such as a selected workflow, nodes, or attachment, to respond usefully. Local use can work with a local ComfyUI installation, but it is not an offline or privacy guarantee.
+
+Only attach files and select workflows that you want the Agent to use. Do not include secrets in chat, attachments, or skills.
+
+## Context you can choose to provide
+
+| Data | Why you might provide it |
+| --- | --- |
+| Your message | Tells the Agent what you want to do. |
+| Selected workflow and nodes | Gives context for an explanation or possible edit. |
+| Attachment you choose | Lets the Agent use the asset you intentionally provide. |
+| Workflow and execution errors | Gives context for troubleshooting. |
+| Personal skill | Supplies reusable instructions when skills are enabled. |
+
+This beta draft does not define a complete data-flow contract. The final version will distinguish what the interface sends, what an Agent service can access, what tools retrieve, what reaches model context, and what is stored. The Privacy Policy governs Comfy's processing.
+
+## Cloud and local data flow
+
+| Surface | Boundary to review during the beta |
+| --- | --- |
+| **Comfy Cloud** | Review the workflow target, selected context, attachments, and run permissions shown in your Cloud interface before you send a request. |
+| **Comfy Desktop and local ComfyUI** | Review the local workflow context and any network or Agent controls shown in your supported local build. Do not treat local use as an offline or privacy guarantee. |
+
+Do not assume that the Agent can access an entire account, every workflow, or arbitrary files on your machine. The exact context depends on the surface, tools, and controls available in the beta build.
+
+## Chat history and sync
+
+Cloud and local Agent history can be available on different product surfaces. Do not rely on a conversation started in one surface appearing automatically in another during the beta.
+
+Before sharing sensitive information, review the current product controls and the Privacy Policy. The beta rollout may change available history and deletion controls.
+
+## Skills and guidance
+
+Personal skills contain instructions you create for the Agent. They can influence how the Agent approaches work, but they do not grant new permissions.
+
+Built-in Agent guidance and skills for external coding agents are separate from your personal Agent skills. Do not paste secrets into any of them.
+
+## Telemetry and diagnostics
+
+The final policy-approved documentation will describe telemetry and diagnostic handling. Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
+
+For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention). Agent-specific retention and deletion details remain under review.
+
+## Keep control of your data
+
+- Attach only files you intend to share with the Agent.
+- Confirm the selected workflow before you send a request.
+- Do not include API keys, passwords, or access tokens.
+- Review imported workflows and skills before using them.
+- Inspect unfamiliar custom nodes, downloads, and external calls before running a workflow.
+- Contact [support@comfy.org](mailto:support@comfy.org) for account or data-deletion requests.
+
+## Related resources
+
+- [Comfy Agent overview](/agent-tools/in-app-agent)
+- [Get started with Comfy Agent](/agent-tools/in-app-agent-installation)
+- [Comfy Agent skills](/agent-tools/in-app-agent-skills)

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -7,7 +7,7 @@ icon: "shield"
 
 ## The short version
 
-Comfy Agent uses your request and the context you choose to provide, such as a selected workflow, nodes, or attachment. Local use works with a local ComfyUI installation and sends Agent requests through Comfy services.
+Comfy Agent uses your message and the workflow context attached to that turn. Comfy Desktop stores chat history and runs workflows on your machine. Each model request sends your message and relevant context through Comfy's online service.
 
 ## What the Agent uses
 
@@ -15,7 +15,8 @@ Comfy Agent uses your request and the context you choose to provide, such as a s
 | --- | --- |
 | Your message | Tells the Agent what you want to do. |
 | Selected workflow and nodes | Give context for an explanation or edit. |
-| Attachment you choose | Lets the Agent use an asset you intentionally provide. |
+| Image attachment | Lets the Agent inspect the image and use it in a workflow. |
+| Video or audio attachment | Lets the Agent read media properties and extract or convert content. |
 | Workflow and execution errors | Give context for troubleshooting. |
 | Personal skill | Supplies reusable instructions. |
 
@@ -25,16 +26,16 @@ The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [
 
 | Surface | What to expect |
 | --- | --- |
-| **Comfy Cloud** | The Agent uses your Cloud workflow, selected context, attachments, and run permissions. |
-| **Comfy Desktop** | The Agent uses your local workflow and the context you select. Agent requests use Comfy services. |
+| **Comfy Cloud** | Comfy Cloud stores conversations, workflows, and assets. Model requests use Comfy's online service, and workflows run on Cloud GPUs. |
+| **Comfy Desktop** | Desktop stores chat history, workflows, and assets locally. Each model request sends your message and relevant context through Comfy's online service. Workflows run on your local hardware. |
 
 ## Chat history and sync
 
-Cloud and local Agent history stay on their respective surfaces. A conversation started locally does not appear automatically in Comfy Cloud, and a Cloud conversation does not appear automatically in your local history.
+Cloud conversations are stored with Comfy Cloud. Desktop conversations are stored locally. The two histories do not sync.
 
 ## Skills and guidance
 
-Personal skills contain instructions you create for the Agent. They can influence how the Agent approaches work, but they do not grant new permissions.
+Personal skills contain instructions you create for the Agent. They are saved to your account and load on demand.
 
 Built-in Agent guidance and skills for external coding agents are separate from your personal Agent skills.
 

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -44,9 +44,3 @@ Built-in Agent guidance and skills for external coding agents are separate from 
 For retention details, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
 
 For account or data-deletion requests, contact [support@comfy.org](mailto:support@comfy.org).
-
-## Related resources
-
-- [Comfy Agent overview](/agent-tools/in-app-agent)
-- [Get started with Comfy Agent](/agent-tools/in-app-agent-installation)
-- [Comfy Agent skills](/agent-tools/in-app-agent-skills)

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -9,8 +9,6 @@ icon: "shield"
 
 Comfy Agent uses your request and the context you choose to provide, such as a selected workflow, nodes, or attachment. Local use works with a local ComfyUI installation and sends Agent requests through Comfy services.
 
-Only attach files and select workflows that you want the Agent to use. Do not include secrets in chat, attachments, or skills.
-
 ## What the Agent uses
 
 | Data | How it helps |
@@ -30,34 +28,21 @@ The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [
 | **Comfy Cloud** | The Agent uses your Cloud workflow, selected context, attachments, and run permissions. |
 | **Comfy Desktop** | The Agent uses your local workflow and the context you select. Agent requests use Comfy services. |
 
-Do not assume that the Agent can access an entire account, every workflow, or arbitrary files on your machine.
-
 ## Chat history and sync
 
 Cloud and local Agent history stay on their respective surfaces. A conversation started locally does not appear automatically in Comfy Cloud, and a Cloud conversation does not appear automatically in your local history.
-
-Do not include sensitive information in chat, attachments, workflows, or skills.
 
 ## Skills and guidance
 
 Personal skills contain instructions you create for the Agent. They can influence how the Agent approaches work, but they do not grant new permissions.
 
-Built-in Agent guidance and skills for external coding agents are separate from your personal Agent skills. Do not paste secrets into any of them.
+Built-in Agent guidance and skills for external coding agents are separate from your personal Agent skills.
 
-## Telemetry and diagnostics
-
-Comfy records diagnostic information to operate and improve the service. Do not rely on telemetry controls as a substitute for avoiding secrets in prompts, attachments, workflows, and skills.
+## Retention and deletion
 
 For general Comfy customer-content retention information and account-level requests, see the [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [Data Retention](/support/data-retention).
 
-## Keep control of your data
-
-- Attach only files you intend to share with the Agent.
-- Confirm the selected workflow before you send a request.
-- Do not include API keys, passwords, or access tokens.
-- Review imported workflows and skills before using them.
-- Inspect unfamiliar custom nodes, downloads, and external calls before running a workflow.
-- Contact [support@comfy.org](mailto:support@comfy.org) for account or data-deletion requests.
+For account or data-deletion requests, contact [support@comfy.org](mailto:support@comfy.org).
 
 ## Related resources
 

--- a/agent-tools/in-app-agent-data-privacy.mdx
+++ b/agent-tools/in-app-agent-data-privacy.mdx
@@ -7,7 +7,7 @@ icon: "shield"
 
 ## The short version
 
-Comfy Agent uses your message, selected workflow, selected nodes, and attachments. Comfy Desktop stores chat history and runs workflows on your machine. Your message and the information needed to answer it are sent through Comfy's online service.
+Comfy Agent uses your message, selected workflow, selected nodes, and attachments. When you work with a local ComfyUI installation, chat history is stored on that machine. Your message and the information needed to answer it are sent through Comfy's online service.
 
 ## What the Agent uses
 
@@ -27,11 +27,11 @@ The [Privacy Policy](https://www.comfy.org/privacy-policy?utm_source=docs) and [
 | Where you use Comfy Agent | What happens |
 | --- | --- |
 | **Comfy Cloud** | Comfy Cloud stores conversations, workflows, and assets. Your messages are processed by Comfy's online service, and workflows run on Cloud GPUs. |
-| **Comfy Desktop** | Desktop stores chat history, workflows, and assets locally. Your messages and relevant workflow information are processed by Comfy's online service. Workflows run on your local hardware. |
+| **Local ComfyUI in Desktop** | The local installation stores chat history, workflows, and files. Your messages and relevant workflow information are processed by Comfy's online service. Local workflow nodes run on your hardware; partner nodes use their online providers. |
 
 ## Chat history and sync
 
-Cloud conversations are stored with Comfy Cloud. Desktop conversations are stored locally. The two histories do not sync.
+Conversations with the Cloud Agent are stored with Comfy Cloud. Conversations with the local Agent are stored on the machine running ComfyUI. The two histories do not sync. This depends on whether you are using Cloud or a local installation, not which application window you open it in.
 
 ## Skills and guidance
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Get Started with Comfy Agent"
 sidebarTitle: "Get started"
-description: "Open Comfy Agent in Cloud, Desktop, or a local ComfyUI installation."
+description: "Open Comfy Agent in Comfy Cloud or Comfy Desktop."
 icon: "play"
 ---
 
@@ -23,7 +23,7 @@ import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 2. Open the workflow you want help with, or create a new workflow.
 3. Select the **Agent** control in the workflow bar.
 4. Accept the consent notice.
-5. Choose the workflow for the conversation.
+5. Select the workflow tab you want the Agent to use.
 6. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
 
 For your first generation, use **Ask** mode.
@@ -33,30 +33,26 @@ For your first generation, use **Ask** mode.
 1. Update Comfy Desktop.
 2. Sign in to your Comfy account.
 3. Open a workflow and select the **Agent** control.
-4. Accept the consent notice and choose the workflow.
+4. Accept the consent notice and select the workflow tab you want the Agent to use.
 5. Send a small request in **Ask** mode.
-
-## Start from a git-based ComfyUI install
-
-Git-based support is not included. Use Comfy Cloud or Comfy Desktop.
 
 ## Troubleshooting
 
-### I do not see the Agent button
+### The Agent button is missing
 
-Check that you are signed in and using a supported surface. Updating Comfy Desktop or ComfyUI does not by itself add Comfy Agent.
+Sign in to your Comfy account. In Comfy Desktop, update the application and restart it. If the button is still missing, Comfy Agent is not enabled for that account or installation.
 
 ### The Agent cannot edit the workflow I expected
 
-Select the workflow in the conversation before you send a message. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
+Select the workflow tab, then send your message again. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
 
-### The local Agent does not start
+### The Agent asks for an input
 
-Confirm that your distribution and version are supported.
+Attach the requested image, video, audio, or other file to the conversation, then ask the Agent to continue.
 
 ### I cannot find a local conversation in Cloud
 
-Local and Cloud history may not be synchronized. See [Data and privacy](/agent-tools/in-app-agent-data-privacy#chat-history-and-sync).
+Local and Cloud history are separate. See [Data and privacy](/agent-tools/in-app-agent-data-privacy#chat-history-and-sync).
 
 ## Next steps
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -7,10 +7,6 @@ icon: "play"
 
 import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 
-<Note>
-  **Private beta.** Comfy Agent availability varies by account, ComfyUI distribution, and version. If you do not see the Agent button, the feature is not enabled for your current setup yet.
-</Note>
-
 ## Choose your setup
 
 <CapabilitySummary />
@@ -19,34 +15,34 @@ import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 | --- | --- | --- |
 | **Comfy Cloud** | A Comfy account with Agent access | Open a workflow and look for the Agent control. |
 | **Comfy Desktop** | A supported Desktop release and a signed-in Comfy account | Update Desktop, then check the workflow bar for the Agent control. |
-| **Git-based ComfyUI** | A supported ComfyUI release and the separately released Agent package | Follow this page only after the local package and its installation command are announced. |
+| **Git-based ComfyUI** | Not included | Use Comfy Cloud or Comfy Desktop. |
 
 ## Start in Comfy Cloud
 
 1. Sign in to [Comfy Cloud](https://cloud.comfy.org).
 2. Open the workflow you want help with, or create a new workflow.
 3. Select the **Agent** control in the workflow bar.
-4. Read and accept the consent notice when it appears.
+4. Accept the consent notice.
 5. Confirm the workflow selected for the conversation.
 6. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
 
-For your first generation, use an approval-first run setting if your beta build offers one.
+For your first generation, use **Ask** mode.
 
 ## Start in Comfy Desktop
 
-Comfy Desktop support is released separately from Cloud. When Agent is available in your Desktop version:
+Comfy Desktop support is released separately from Cloud:
 
 1. Update Comfy Desktop to the supported release.
 2. Sign in to your Comfy account.
 3. Open a workflow and select the **Agent** control.
 4. Accept the consent notice and confirm the selected workflow.
-5. Send a small request using an approval-first run setting, if available.
+5. Send a small request in **Ask** mode.
 
 Do not use prototype or developer-only installation instructions to add it manually.
 
 ## Start from a git-based ComfyUI install
 
-Git-based support is not available in this beta. Use Comfy Cloud or Comfy Desktop if your account has access.
+Git-based support is not included. Use Comfy Cloud or Comfy Desktop.
 
 ## Keep your first run safe
 
@@ -62,7 +58,7 @@ Before approving a run:
 
 ### I do not see the Agent button
 
-Check that you are signed in, using a supported surface, and included in the current rollout. Updating Comfy Desktop or ComfyUI does not by itself guarantee access when the feature is still gated.
+Check that you are signed in and using a supported surface. Updating Comfy Desktop or ComfyUI does not by itself add Comfy Agent.
 
 ### The Agent cannot edit the workflow I expected
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -69,4 +69,4 @@ Local and Cloud history are separate. See [Data and privacy](/agent-tools/in-app
   </Card>
 </CardGroup>
 
-[Data and privacy](/agent-tools/in-app-agent-data-privacy)
+See [Data and privacy](/agent-tools/in-app-agent-data-privacy) to learn where messages, files, and conversations are stored.

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -23,36 +23,22 @@ import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 2. Open the workflow you want help with, or create a new workflow.
 3. Select the **Agent** control in the workflow bar.
 4. Accept the consent notice.
-5. Confirm the workflow selected for the conversation.
+5. Choose the workflow for the conversation.
 6. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
 
 For your first generation, use **Ask** mode.
 
 ## Start in Comfy Desktop
 
-Comfy Desktop support is released separately from Cloud:
-
-1. Update Comfy Desktop to the supported release.
+1. Update Comfy Desktop.
 2. Sign in to your Comfy account.
 3. Open a workflow and select the **Agent** control.
-4. Accept the consent notice and confirm the selected workflow.
+4. Accept the consent notice and choose the workflow.
 5. Send a small request in **Ask** mode.
-
-Do not use prototype or developer-only installation instructions to add it manually.
 
 ## Start from a git-based ComfyUI install
 
 Git-based support is not included. Use Comfy Cloud or Comfy Desktop.
-
-## Keep your first run safe
-
-Before approving a run:
-
-- Confirm the workflow selected for the conversation.
-- Review graph changes and unfamiliar nodes.
-- Check the run permission and, if you use a spending limit, the limit itself.
-- Do not paste API keys, passwords, or other secrets into chat or a skill.
-- Stop and inspect the workflow if a request produces an unexpected download, external call, or custom-node action.
 
 ## Troubleshooting
 
@@ -62,7 +48,7 @@ Check that you are signed in and using a supported surface. Updating Comfy Deskt
 
 ### The Agent cannot edit the workflow I expected
 
-Confirm the workflow context shown in the interface before you send a message. Do not assume that changing the visible tab changes the editable target. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
+Select the workflow in the conversation before you send a message. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
 
 ### The local Agent does not start
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -1,0 +1,85 @@
+---
+title: "Get Started with Comfy Agent"
+sidebarTitle: "Get started"
+description: "Open Comfy Agent in Cloud, Desktop, or a local ComfyUI installation."
+icon: "play"
+---
+
+import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
+
+<Note>
+  **Private beta.** Comfy Agent availability varies by account, ComfyUI distribution, and version. If you do not see the Agent button, the feature is not enabled for your current setup yet.
+</Note>
+
+## Choose your setup
+
+<CapabilitySummary />
+
+| Setup | What you need | Status check |
+| --- | --- | --- |
+| **Comfy Cloud** | A Comfy account with Agent access | Open a workflow and look for the Agent control. |
+| **Comfy Desktop** | A supported Desktop release and a signed-in Comfy account | Update Desktop, then check the workflow bar for the Agent control. |
+| **Git-based ComfyUI** | A supported ComfyUI release and the separately released Agent package | Follow this page only after the local package and its installation command are announced. |
+
+## Start in Comfy Cloud
+
+1. Sign in to [Comfy Cloud](https://cloud.comfy.org).
+2. Open the workflow you want help with, or create a new workflow.
+3. Select the **Agent** control in the workflow bar.
+4. Read and accept the consent notice when it appears.
+5. Confirm the workflow selected for the conversation.
+6. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
+
+For your first generation, use an approval-first run setting if your beta build offers one.
+
+## Start in Comfy Desktop
+
+Comfy Desktop support is released separately from Cloud. When it is available for your Desktop version:
+
+1. Update Comfy Desktop to the supported release.
+2. Sign in to your Comfy account.
+3. Open a workflow and select the **Agent** control.
+4. Accept the consent notice and confirm the selected workflow.
+5. Send a small request using an approval-first run setting, if available.
+
+The Agent package may be bundled with Desktop or installed by the release. Do not use prototype or developer-only installation instructions to add it manually.
+
+## Start from a git-based ComfyUI install
+
+Git-based support is planned as a separate optional package. The package name, supported ComfyUI version, and installation command are not published yet.
+
+When that release is available, this section will include the exact install, update, health-check, disable, and uninstall commands. Until then, use Comfy Cloud or Comfy Desktop if your account has access.
+
+## Keep your first run safe
+
+Before approving a run:
+
+- Confirm the workflow selected for the conversation.
+- Review graph changes and unfamiliar nodes.
+- Check the run permission and, if you use a spending limit, the limit itself.
+- Do not paste API keys, passwords, or other secrets into chat or a skill.
+- Stop and inspect the workflow if a request produces an unexpected download, external call, or custom-node action.
+
+## Troubleshooting
+
+### I do not see the Agent button
+
+Check that you are signed in, using a supported surface, and included in the current rollout. Updating Comfy Desktop or ComfyUI does not by itself guarantee access when the feature is still gated.
+
+### The Agent cannot edit the workflow I expected
+
+Confirm the workflow context shown in the interface before you send a message. Do not assume that changing the visible tab changes the editable target. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
+
+### The local Agent does not start
+
+Confirm that your distribution and version are supported. Local package requirements and recovery steps will be included with the released package documentation.
+
+### I cannot find a local conversation in Cloud
+
+Local and Cloud history may not be synchronized. See [Data and privacy](/agent-tools/in-app-agent-data-privacy#chat-history-and-sync).
+
+## Next steps
+
+- [Comfy Agent overview](/agent-tools/in-app-agent)
+- [Comfy Agent skills](/agent-tools/in-app-agent-skills)
+- [Data and privacy](/agent-tools/in-app-agent-data-privacy)

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -44,7 +44,7 @@ Sign in to your Comfy account. In Comfy Desktop, update the application and rest
 
 ### The Agent cannot edit the workflow I expected
 
-Select the workflow tab, then send your message again. See [Comfy Agent overview](/agent-tools/in-app-agent#workflow-targeting).
+Select the workflow tab, then send your message again. See [Choose which workflow to edit](/agent-tools/in-app-agent#choose-which-workflow-to-edit).
 
 ### The Agent asks for an input
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -60,6 +60,13 @@ Local and Cloud history are separate. See [Data and privacy](/agent-tools/in-app
 
 ## Next steps
 
-- [Comfy Agent overview](/agent-tools/in-app-agent)
-- [Comfy Agent skills](/agent-tools/in-app-agent-skills)
-- [Data and privacy](/agent-tools/in-app-agent-data-privacy)
+<CardGroup cols={2}>
+  <Card title="Edit an existing workflow" icon="pen" href="/agent-tools/in-app-agent#build-and-edit-workflows">
+    Change prompts, models, or processing steps.
+  </Card>
+  <Card title="Save a reusable skill" icon="wand-magic-sparkles" href="/agent-tools/in-app-agent-skills#create-a-skill-in-chat">
+    Remember instructions for future requests.
+  </Card>
+</CardGroup>
+
+[Data and privacy](/agent-tools/in-app-agent-data-privacy)

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -34,7 +34,7 @@ For your first generation, use an approval-first run setting if your beta build 
 
 ## Start in Comfy Desktop
 
-Comfy Desktop support is released separately from Cloud. When it is available for your Desktop version:
+Comfy Desktop support is released separately from Cloud. When Agent is available in your Desktop version:
 
 1. Update Comfy Desktop to the supported release.
 2. Sign in to your Comfy account.
@@ -42,13 +42,11 @@ Comfy Desktop support is released separately from Cloud. When it is available fo
 4. Accept the consent notice and confirm the selected workflow.
 5. Send a small request using an approval-first run setting, if available.
 
-The Agent package may be bundled with Desktop or installed by the release. Do not use prototype or developer-only installation instructions to add it manually.
+Do not use prototype or developer-only installation instructions to add it manually.
 
 ## Start from a git-based ComfyUI install
 
-Git-based support is planned as a separate optional package. The package name, supported ComfyUI version, and installation command are not published yet.
-
-When that release is available, this section will include the exact install, update, health-check, disable, and uninstall commands. Until then, use Comfy Cloud or Comfy Desktop if your account has access.
+Git-based support is not available in this beta. Use Comfy Cloud or Comfy Desktop if your account has access.
 
 ## Keep your first run safe
 
@@ -72,7 +70,7 @@ Confirm the workflow context shown in the interface before you send a message. D
 
 ### The local Agent does not start
 
-Confirm that your distribution and version are supported. Local package requirements and recovery steps will be included with the released package documentation.
+Confirm that your distribution and version are supported.
 
 ### I cannot find a local conversation in Cloud
 

--- a/agent-tools/in-app-agent-installation.mdx
+++ b/agent-tools/in-app-agent-installation.mdx
@@ -5,50 +5,54 @@ description: "Open Comfy Agent in Comfy Cloud or Comfy Desktop."
 icon: "play"
 ---
 
-import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
-
 ## Choose your setup
 
-<CapabilitySummary />
+You need a Comfy account with Agent access.
 
-| Setup | What you need | Status check |
-| --- | --- | --- |
-| **Comfy Cloud** | A Comfy account with Agent access | Open a workflow and look for the Agent control. |
-| **Comfy Desktop** | A supported Desktop release and a signed-in Comfy account | Update Desktop, then check the workflow bar for the Agent control. |
-| **Git-based ComfyUI** | Not included | Use Comfy Cloud or Comfy Desktop. |
+- **Comfy Cloud:** [Sign in to Cloud](https://cloud.comfy.org). No local installation is needed.
+- **Comfy Desktop:** Follow the [Desktop installation guide](/installation/desktop/overview), then sign in. For an existing installation, follow [Update ComfyUI](/installation/update_comfyui).
 
-## Start in Comfy Cloud
+## Make your first image
 
-1. Sign in to [Comfy Cloud](https://cloud.comfy.org).
-2. Open the workflow you want help with, or create a new workflow.
-3. Select the **Agent** control in the workflow bar.
-4. Accept the consent notice.
-5. Select the workflow tab you want the Agent to use.
-6. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
+### Open the Agent
 
-For your first generation, use **Ask** mode.
+Open a blank workflow, then select **Ask Comfy Agent** in the workflow bar. Read and accept the consent notice if prompted. Use **Choose a workflow** in the Agent panel to select the blank workflow.
 
-## Start in Comfy Desktop
+### Build a workflow
 
-1. Update Comfy Desktop.
-2. Sign in to your Comfy account.
-3. Open a workflow and select the **Agent** control.
-4. Accept the consent notice and select the workflow tab you want the Agent to use.
-5. Send a small request in **Ask** mode.
+Send this message:
+
+> Build a text-to-image workflow for a red sneaker on a neutral gray background. Use an available model and include a Save Image node. Check the workflow for errors, but don't run it yet.
+
+The Agent builds the workflow on the canvas, fills in the prompt and model settings, and checks the node connections and required inputs. You should see a connected workflow ending in a **Save Image** node.
+
+If the Agent reports a missing model or file, supply it or ask for an alternative available in your installation. Ask it to check the workflow again before continuing.
+
+### Generate the image
+
+Open **Run permissions** next to the message box, choose **Ask before a workflow runs**, and select **Save changes** if you changed the setting.
+
+Send “Run this workflow.” When the Agent asks for approval, select **Run**. Select **Cancel** instead if you do not want to start that run.
+
+When generation finishes, the Agent returns the output in the conversation. The image also appears in the **Save Image** node. Right-click the image there to save it to your computer.
+
+### Make a change
+
+Send “Change the background to white and keep the model and other settings.” The Agent updates the existing workflow. Ask it to run again to compare the result.
 
 ## Troubleshooting
 
 ### The Agent button is missing
 
-Sign in to your Comfy account. In Comfy Desktop, update the application and restart it. If the button is still missing, Comfy Agent is not enabled for that account or installation.
+Sign in to your Comfy account. In Comfy Desktop, [update the application](/installation/update_comfyui) and restart it. If the button is still missing, check your account's Agent access with [support](/support/contact-support).
 
 ### The Agent cannot edit the workflow I expected
 
-Select the workflow tab, then send your message again. See [Choose which workflow to edit](/agent-tools/in-app-agent#choose-which-workflow-to-edit).
+Choose the intended workflow in the Agent panel, then send your message again. See [Choose which workflow to edit](/agent-tools/in-app-agent#choose-which-workflow-to-edit).
 
 ### The Agent asks for an input
 
-Attach the requested image, video, audio, or other file to the conversation, then ask the Agent to continue.
+Select **Attach a file** or drag the requested file into the message box, then ask the Agent to continue.
 
 ### I cannot find a local conversation in Cloud
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -50,9 +50,3 @@ Comfy Agent includes guidance for building workflows and choosing models. Person
 [Skills for coding agents](/agent-tools/skills) are installed separately in tools such as Claude Code. Installing one there does not add it to Comfy Agent.
 
 Keep API keys, passwords, and access tokens out of skill instructions. For data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
-
-## Related resources
-
-- [Comfy Agent overview](/agent-tools/in-app-agent)
-- [Get started with Comfy Agent](/agent-tools/in-app-agent-installation)
-- [Skills for coding agents](/agent-tools/skills)

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -11,7 +11,7 @@ A personal skill is a reusable instruction pack for Comfy Agent. It includes a n
 
 For example, a skill can tell the Agent how you prefer to organize a workflow, how to name outputs, or which checks to perform before a run.
 
-When **Skills** is available in the Agent panel, matching skills load with your request. Use the skills control to choose one explicitly.
+Matching skills load with your request. Use the skills control to choose one explicitly.
 
 ## Three kinds of skills and guidance
 
@@ -25,7 +25,7 @@ These are separate systems. Installing a skill for a coding agent does not add i
 
 ## Use and manage skills
 
-If **Skills** appears in the Agent panel, select it to browse, create, update, or remove your personal skills. Review the instructions before you use a skill in a workflow.
+Select **Skills** in the Agent panel to browse, create, update, or remove your personal skills.
 
 ## Write a useful skill
 
@@ -43,14 +43,7 @@ Explain any assumption before changing the workflow.
 
 Keep instructions focused on the outcome and checks you want the Agent to perform.
 
-## Safety and privacy
-
-- Never include API keys, passwords, access tokens, or private credentials in a skill.
-- Treat imported skill text as untrusted. Review it before you save or use it.
-- A skill can guide Agent behavior, but it does not grant additional access to workflows, files, or accounts.
-- Review unfamiliar workflow changes, custom nodes, downloads, and external calls before running them.
-
-For information about skills and data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
+Keep API keys, passwords, and access tokens out of skill instructions. For data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
 
 ## Related resources
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -1,0 +1,67 @@
+---
+title: "Comfy Agent Skills"
+sidebarTitle: "Agent skills"
+description: "Use personal skills to give Comfy Agent reusable instructions for your work."
+icon: "wand-magic-sparkles"
+---
+
+{/* Draft scope: Product and Frontend must confirm the enabled skills UI before this page ships. */}
+
+<Note>
+  **Private beta.** Personal skills are being rolled out with Comfy Agent. The controls described below appear only when skills are enabled for your account.
+</Note>
+
+## What is a personal skill?
+
+A personal skill is a reusable instruction pack for Comfy Agent. It can include a name, a short description of when to use it, and instructions that guide the Agent for a specific kind of work.
+
+For example, a skill can tell the Agent how you prefer to organize a workflow, how to name outputs, or which checks to perform before a run.
+
+Personal-skill behavior and availability can vary during the beta. Check the skills controls in your Agent panel before relying on a skill for a workflow.
+
+## Three kinds of skills and guidance
+
+| Type | Where it works | What it is for |
+| --- | --- | --- |
+| **Personal Comfy Agent skills** | The Comfy Agent panel | Reusable instructions you create for your own Agent work. |
+| **Built-in Agent guidance** | Comfy Agent | Curated guidance that helps the Agent work with ComfyUI. |
+| **Skills for coding agents** | Claude Code and other external agents | Plugins and skills from the [Comfy Skills repository](https://github.com/Comfy-Org/comfy-skills). |
+
+These are separate systems. Installing a skill for a coding agent does not add it to the Comfy Agent panel.
+
+## Skills in the beta
+
+The beta may expose a skills control for some accounts. When it is available, use the actions shown in the Agent panel and review the resulting instructions before using them in a workflow.
+
+Creation, import, generation, automatic matching, explicit invocation, limits, storage, and sync are all release-dependent. This draft will document those procedures only after the launch UI and validation behavior are confirmed.
+
+## Drafting a useful skill
+
+A good skill is narrow and practical:
+
+```text
+Name: product-shot-check
+
+Use when preparing a product image workflow for review.
+
+Before running, check that the workflow has a clear subject, a clean background,
+an output size appropriate for the delivery channel, and a Save Image node.
+Explain any assumption before changing the workflow.
+```
+
+Keep instructions focused on the outcome and checks you want the Agent to perform. Avoid long, unrelated background material.
+
+## Safety and privacy
+
+- Never include API keys, passwords, access tokens, or private credentials in a skill.
+- Treat imported skill text as untrusted. Review it before you save or use it.
+- A skill can guide Agent behavior, but it does not grant additional access to workflows, files, or accounts.
+- Review unfamiliar workflow changes, custom nodes, downloads, and external calls before running them.
+
+For information about skills and data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
+
+## Related resources
+
+- [Comfy Agent overview](/agent-tools/in-app-agent)
+- [Get started with Comfy Agent](/agent-tools/in-app-agent-installation)
+- [Skills for coding agents](/agent-tools/skills)

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -7,11 +7,11 @@ icon: "wand-magic-sparkles"
 
 ## What is a personal skill?
 
-A personal skill is a reusable instruction pack for Comfy Agent. It includes a name, a short description of when to use it, and instructions that guide the Agent for a specific kind of work.
+A personal skill is a reusable set of instructions for Comfy Agent. It includes a name, a one-line description of when to use it, and the instructions themselves.
 
-For example, a skill can tell the Agent how you prefer to organize a workflow, how to name outputs, or which checks to perform before a run.
+Use personal skills for preferences and processes you want to repeat, such as a standard image size, a preferred workflow structure, or a validation checklist.
 
-Matching skills load with your request. Use the skills control to choose one explicitly.
+Personal skills are saved to your account. The Agent loads a skill when its description matches your request or when you ask for it by name.
 
 ## Three kinds of skills and guidance
 
@@ -23,25 +23,48 @@ Matching skills load with your request. Use the skills control to choose one exp
 
 These are separate systems. Installing a skill for a coding agent does not add it to the Comfy Agent panel.
 
-## Use and manage skills
+## Create a skill in chat
 
-Select **Skills** in the Agent panel to browse, create, update, or remove your personal skills.
+Tell the Agent what to save, what to call it, and when it should be used:
 
-## Write a useful skill
+> Save this as a skill called product-shot: When I ask for a product image, use a square 1024 × 1024 canvas, a neutral gray background, and a Save Image node. Validate the workflow before running it.
+
+The Agent saves the skill for future messages. A new or updated skill takes effect with your next message.
+
+You can also paste the contents of a `SKILL.md` file with `name` and `description` frontmatter and ask the Agent to save it.
+
+## Use a skill
+
+Ask for a skill by name:
+
+> Use my product-shot skill to create a studio photo workflow for a red sneaker.
+
+The Agent can also select a skill automatically when your request matches its description.
+
+## Update or delete a skill
+
+Use the same skill name to replace its instructions:
+
+> Update my product-shot skill to use a white background and a 1536 × 1536 canvas.
+
+Delete a skill by name:
+
+> Delete my product-shot skill.
+
+## Write clear instructions
 
 A good skill is narrow and practical:
 
 ```text
-Name: product-shot-check
+Name: product-shot
 
-Use when preparing a product image workflow for review.
+Use when creating a square product image.
 
-Before running, check that the workflow has a clear subject, a clean background,
-an output size appropriate for the delivery channel, and a Save Image node.
-Explain any assumption before changing the workflow.
+Set the output to 1024 × 1024. Use a neutral gray background.
+Add a Save Image node. Validate the workflow before running it.
 ```
 
-Keep instructions focused on the outcome and checks you want the Agent to perform.
+Keep each skill focused on one repeatable task. Put the trigger in the description and the procedure in the instructions.
 
 Keep API keys, passwords, and access tokens out of skill instructions. For data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -9,19 +9,9 @@ icon: "wand-magic-sparkles"
 
 A personal skill is a reusable set of instructions for Comfy Agent. It includes a name, a one-line description of when to use it, and the instructions themselves.
 
-Use personal skills for preferences and processes you want to repeat, such as a standard image size, a preferred workflow structure, or a validation checklist.
+Use personal skills to repeat instructions such as “make square images,” “use a white background,” or “check node connections before running.”
 
 Personal skills are saved to your account. The Agent loads a skill when its description matches your request or when you ask for it by name.
-
-## Three kinds of skills and guidance
-
-| Type | Where it works | What it is for |
-| --- | --- | --- |
-| **Personal Comfy Agent skills** | The Comfy Agent panel | Reusable instructions you create for your own Agent work. |
-| **Built-in Agent guidance** | Comfy Agent | Curated guidance that helps the Agent work with ComfyUI. |
-| **Skills for coding agents** | Claude Code and other external agents | Plugins and skills from the [Comfy Skills repository](https://github.com/Comfy-Org/comfy-skills). |
-
-These are separate systems. Installing a skill for a coding agent does not add it to the Comfy Agent panel.
 
 ## Create a skill in chat
 
@@ -30,8 +20,6 @@ Tell the Agent what to save, what to call it, and when it should be used:
 > Save this as a skill called product-shot: When I ask for a product image, use a square 1024 × 1024 canvas, a neutral gray background, and a Save Image node. Validate the workflow before running it.
 
 The Agent saves the skill for future messages. A new or updated skill takes effect with your next message.
-
-You can also paste the contents of a `SKILL.md` file. The Agent reads the name and description from the file's header.
 
 ## Use a skill
 
@@ -51,20 +39,15 @@ Delete a skill by name:
 
 > Delete my product-shot skill.
 
-## Write clear instructions
+## Save an existing skill file
 
-A good skill is narrow and practical:
+Paste the contents of your `SKILL.md` file into chat and ask the Agent to save it as a personal skill. The Agent reads its name and description from the header at the top of the file. The saved skill is available from your next message.
 
-```text
-Name: product-shot
+## Built-in guidance and coding-agent skills
 
-Use when creating a square product image.
+Comfy Agent includes guidance for building workflows and choosing models. Personal skills add your own instructions for repeated tasks.
 
-Set the output to 1024 × 1024. Use a neutral gray background.
-Add a Save Image node. Validate the workflow before running it.
-```
-
-Keep each skill focused on one repeatable task. Put the trigger in the description and the procedure in the instructions.
+[Skills for coding agents](/agent-tools/skills) are installed separately in tools such as Claude Code. Installing one there does not add it to Comfy Agent.
 
 Keep API keys, passwords, and access tokens out of skill instructions. For data handling, see [Data and privacy](/agent-tools/in-app-agent-data-privacy#skills-and-guidance).
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -5,17 +5,13 @@ description: "Use personal skills to give Comfy Agent reusable instructions for 
 icon: "wand-magic-sparkles"
 ---
 
-<Note>
-  **Private beta.** Skills appear in the Agent panel when they are available for your account.
-</Note>
-
 ## What is a personal skill?
 
-A personal skill is a reusable instruction pack for Comfy Agent. It can include a name, a short description of when to use it, and instructions that guide the Agent for a specific kind of work.
+A personal skill is a reusable instruction pack for Comfy Agent. It includes a name, a short description of when to use it, and instructions that guide the Agent for a specific kind of work.
 
 For example, a skill can tell the Agent how you prefer to organize a workflow, how to name outputs, or which checks to perform before a run.
 
-Check the skills controls in your Agent panel before relying on a skill for a workflow.
+When **Skills** is available in the Agent panel, matching skills load with your request. Use the skills control to choose one explicitly.
 
 ## Three kinds of skills and guidance
 
@@ -27,9 +23,9 @@ Check the skills controls in your Agent panel before relying on a skill for a wo
 
 These are separate systems. Installing a skill for a coding agent does not add it to the Comfy Agent panel.
 
-## Skills in the beta
+## Use and manage skills
 
-When skills are available, use the actions shown in the Agent panel and review the resulting instructions before using them in a workflow.
+If **Skills** appears in the Agent panel, select it to browse, create, update, or remove your personal skills. Review the instructions before you use a skill in a workflow.
 
 ## Write a useful skill
 
@@ -45,7 +41,7 @@ an output size appropriate for the delivery channel, and a Save Image node.
 Explain any assumption before changing the workflow.
 ```
 
-Keep instructions focused on the outcome and checks you want the Agent to perform. Avoid long, unrelated background material.
+Keep instructions focused on the outcome and checks you want the Agent to perform.
 
 ## Safety and privacy
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -5,10 +5,8 @@ description: "Use personal skills to give Comfy Agent reusable instructions for 
 icon: "wand-magic-sparkles"
 ---
 
-{/* Draft scope: Product and Frontend must confirm the enabled skills UI before this page ships. */}
-
 <Note>
-  **Private beta.** Personal skills are being rolled out with Comfy Agent. The controls described below appear only when skills are enabled for your account.
+  **Private beta.** Skills appear in the Agent panel when they are available for your account.
 </Note>
 
 ## What is a personal skill?
@@ -17,7 +15,7 @@ A personal skill is a reusable instruction pack for Comfy Agent. It can include 
 
 For example, a skill can tell the Agent how you prefer to organize a workflow, how to name outputs, or which checks to perform before a run.
 
-Personal-skill behavior and availability can vary during the beta. Check the skills controls in your Agent panel before relying on a skill for a workflow.
+Check the skills controls in your Agent panel before relying on a skill for a workflow.
 
 ## Three kinds of skills and guidance
 
@@ -31,11 +29,9 @@ These are separate systems. Installing a skill for a coding agent does not add i
 
 ## Skills in the beta
 
-The beta may expose a skills control for some accounts. When it is available, use the actions shown in the Agent panel and review the resulting instructions before using them in a workflow.
+When skills are available, use the actions shown in the Agent panel and review the resulting instructions before using them in a workflow.
 
-Creation, import, generation, automatic matching, explicit invocation, limits, storage, and sync are all release-dependent. This draft will document those procedures only after the launch UI and validation behavior are confirmed.
-
-## Drafting a useful skill
+## Write a useful skill
 
 A good skill is narrow and practical:
 

--- a/agent-tools/in-app-agent-skills.mdx
+++ b/agent-tools/in-app-agent-skills.mdx
@@ -31,7 +31,7 @@ Tell the Agent what to save, what to call it, and when it should be used:
 
 The Agent saves the skill for future messages. A new or updated skill takes effect with your next message.
 
-You can also paste the contents of a `SKILL.md` file with `name` and `description` frontmatter and ask the Agent to save it.
+You can also paste the contents of a `SKILL.md` file. The Agent reads the name and description from the file's header.
 
 ## Use a skill
 

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -7,7 +7,17 @@ icon: "comments"
 
 import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 
-Comfy Agent is the chat experience inside ComfyUI. Use it to explain a workflow, diagnose an error, make a focused graph change, or run a workflow.
+Comfy Agent is an assistant inside ComfyUI. It can build and edit workflows, explain nodes, inspect media, fix validation errors, and run the finished workflow.
+
+## What it can do
+
+- Find templates, models, and nodes available in your ComfyUI environment.
+- Build a workflow from a template and customize its prompts and settings.
+- Change part of the current workflow without rebuilding the rest.
+- Add, connect, configure, and remove nodes.
+- Validate a workflow before running it.
+- Inspect images and read video or audio properties.
+- Run workflows and return their outputs.
 
 ## Where you can use it
 
@@ -19,16 +29,42 @@ Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agen
 
 1. Open the workflow you want help with.
 2. Select **Agent** in the workflow bar.
-3. Choose the workflow for the conversation.
-4. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
-5. Inspect the response and graph changes.
-6. Keep the run permission set to **Ask** for your first workflow run.
+3. Select the workflow tab you want to edit.
+4. Ask for a specific change, such as “Change the prompt to a neon city at dusk and keep the rest of the workflow unchanged.”
+5. Inspect the graph changes.
+6. Run the workflow when it is ready.
 
 ## Workflow targeting
 
-Comfy Agent works in the workflow selected for the conversation.
+Each message captures the selected workflow tab when you send it. The Agent can edit only that workflow during the turn.
 
-Changing the visible tab does not change the workflow target. Select a different workflow when you want the Agent to work there.
+The Agent cannot create or switch tabs. To work in another tab, select it and send a new message.
+
+The Agent can read another open or saved workflow for comparison without loading it into the current tab. For example:
+
+> Compare this workflow with my portrait workflow and use the same sampler settings here.
+
+## Build and edit workflows
+
+For a new workflow, open a blank workflow tab, select it, and send your request from there. The Agent searches for a matching template before building from individual nodes. A template includes a connected graph and an output node.
+
+For changes to an existing workflow, name the part you want changed and what should stay the same:
+
+- “Change the prompt to a watercolor landscape. Keep the model and sampler settings.”
+- “Add an upscaling stage after image generation.”
+- “Switch this workflow to Flux using models installed here.”
+
+## Validate before running
+
+The Agent checks node connections, model names, required values, and output nodes before a run. It separates workflow errors from inputs that only you can provide.
+
+If the workflow is valid but still needs an image, video, or other input, attach the file and ask the Agent to continue.
+
+## Work with media
+
+The Agent can inspect the visible contents and dimensions of a still image. For video, it can read duration, resolution, frame rate, and codec details. For audio, it can read duration, codec, and stream details.
+
+It can also resize or trim media, extract a video frame, join video clips, and add audio to a video. These results are saved as assets that can be used in a workflow.
 
 ## Run permissions
 
@@ -36,57 +72,24 @@ Choose a run permission next to the message box:
 
 - **Ask** requests approval before each workflow run.
 - **Auto** runs workflows without asking for each run.
-- **Limited** requests approval when a run exceeds your credit limit.
 
-Run permissions control workflow execution. Graph edits remain visible in the workflow.
+Ask and Auto control workflow runs. The Agent can edit the selected workflow in either mode.
 
 ## What the Agent can use
 
-The Agent uses your message, selected workflow, selected nodes, attachments, and workflow errors.
+The Agent uses your message, selected workflow, selected nodes, attachments, and workflow errors. It can also read another workflow when you ask it to compare or reuse settings.
 
 For Cloud and local data flow, chat history, and privacy controls, see [Comfy Agent data and privacy](/agent-tools/in-app-agent-data-privacy).
 
-## FAQ
-
-### Can the Agent edit more than one workflow?
-
-The Agent edits the workflow selected for the conversation. Select another workflow to work there.
-
-### Does Auto mode let the Agent do anything automatically?
-
-Auto mode runs workflows without asking for each run. It does not change what the Agent can access.
-
-### Does local mean that no data leaves my computer?
-
-No. Local use works with your local ComfyUI installation, but Agent requests use Comfy services. See [Data and privacy](/agent-tools/in-app-agent-data-privacy).
-
-### Can I stop the Agent or a workflow run?
+## Stop or cancel
 
 Stop an Agent turn from the chat panel. Cancel queued and active workflows from the workflow controls.
-
-### Can I use my existing Agent skills from Claude Code?
-
-No. Skills for external coding agents are separate from personal Comfy Agent skills. See [Comfy Agent skills](/agent-tools/in-app-agent-skills).
-
-## Access and feedback
-
-<Card title="Request access" icon="list" href="https://links.comfy.org/agentalpha">
-  Request access to Comfy Agent.
-</Card>
-
-## Feedback
-
-Share bugs and impressions:
-
-<Card title="Send feedback" icon="message" href="https://links.comfy.org/agentalphafeedback">
-  Report bugs or share impressions.
-</Card>
 
 ## Related
 
 <CardGroup cols={3}>
   <Card title="Get started" icon="play" href="/agent-tools/in-app-agent-installation">
-    Set up Comfy Agent for your available surface.
+    Get started in Comfy Cloud or Comfy Desktop.
   </Card>
   <Card title="Agent skills" icon="wand-magic-sparkles" href="/agent-tools/in-app-agent-skills">
     Create and use reusable Agent instructions.

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -25,20 +25,13 @@ Comfy Agent is an assistant inside ComfyUI. It can build and edit workflows, exp
 
 Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agent-tools/cli). MCP connects an external AI client to Comfy. The CLI is for terminal and script workflows. Comfy Agent works in the ComfyUI interface.
 
-## Your first Agent task
-
-1. Open the workflow you want help with.
-2. Select **Agent** in the workflow bar.
-3. Select the workflow tab you want to edit.
-4. Ask for a specific change, such as “Change the prompt to a neon city at dusk and keep the rest of the workflow unchanged.”
-5. Inspect the graph changes.
-6. Run the workflow when it is ready.
+To make your first image, follow [Get started with Comfy Agent](/agent-tools/in-app-agent-installation#make-your-first-image).
 
 ## Choose which workflow to edit
 
-Select a workflow tab before sending your message. The Agent edits that workflow until it finishes responding.
+Use the workflow selector in the Agent panel to choose the workflow to edit, then send your message. Switching to another tab while the Agent is responding does not redirect its edits.
 
-The Agent cannot create or switch tabs. To work in another tab, select it and send a new message.
+The Agent cannot create or switch tabs itself. To work elsewhere, open the other workflow, choose it in the Agent panel, and send a new message.
 
 The Agent can read another open or saved workflow for comparison without loading it into the current tab. For example:
 
@@ -46,7 +39,7 @@ The Agent can read another open or saved workflow for comparison without loading
 
 ## Build and edit workflows
 
-For a new workflow, open a blank workflow tab, select it, and send your request from there. The Agent searches for a matching template before building from individual nodes. A template includes a connected graph and an output node.
+For a new workflow, open a blank workflow tab and choose it in the Agent panel. The Agent searches for a matching template before building from individual nodes. A template includes a connected graph and an output node.
 
 For changes to an existing workflow, name the part you want changed and what should stay the same:
 
@@ -64,7 +57,16 @@ If the workflow is valid but still needs an image, video, or other input, attach
 
 The Agent can inspect the visible contents and dimensions of a still image. For video, it can read the duration, dimensions, frame rate, and format. For audio, it can read the duration, format, and audio tracks.
 
-It can also resize or trim media, extract a video frame, join video clips, and add audio to a video. These results are saved as assets that can be used in a workflow.
+Use **Attach a file** in the message box to add an image or file. You can also drag media into the conversation.
+
+| Add to the conversation | Ask | Result |
+| --- | --- | --- |
+| An image | “Describe the lighting in this image.” | A description you can use to refine your prompt. |
+| A video | “Trim this to the first five seconds.” | A shortened video file. |
+| Two video clips | “Join clip A followed by clip B.” | One video containing both clips in that order. |
+| A video and an audio file | “Add this audio to the video.” | A video with the supplied audio. |
+
+Media editing requires the media tools to be available in your installation. In Cloud, edited files are saved to your asset library. The Agent returns a preview or file link in the conversation.
 
 ## Run permissions
 
@@ -72,6 +74,8 @@ Choose a run permission next to the message box:
 
 - **Ask** requests approval before each workflow run.
 - **Auto** runs workflows without asking for each run.
+
+Select **Save changes** to apply your choice. In Ask mode, select **Run** in the approval message to start the workflow, or **Cancel** to decline that run.
 
 Ask and Auto control workflow runs. The Agent can edit the selected workflow in either mode.
 
@@ -83,7 +87,7 @@ For Cloud and local data flow, chat history, and privacy controls, see [Comfy Ag
 
 ## Stop or cancel
 
-Stop a response from the chat panel. Cancel queued and running workflows from the workflow controls.
+Select **Stop** in the message box to stop the Agent's current response. Workflow execution has separate controls in the [run and queue area](/interface/overview); use those to manage a workflow that has already been submitted.
 
 ## Related
 

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -99,5 +99,3 @@ Select **Stop** in the message box to stop the Agent's current response. Workflo
     Create and use reusable Agent instructions.
   </Card>
 </CardGroup>
-
-For information about messages, files, and conversation storage, see [Data and privacy](/agent-tools/in-app-agent-data-privacy).

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -1,39 +1,116 @@
 ---
-title: "Comfy In-App Agent"
-sidebarTitle: "In-App Agent"
-description: "Join the private alpha waitlist for Comfy In-App Agent on Comfy Cloud."
+title: "Comfy Agent"
+sidebarTitle: "Overview"
+description: "Use Comfy Agent to understand, build, edit, and run ComfyUI workflows."
 icon: "comments"
 ---
 
+import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
+
+{/* Draft terminology: Product/Brand must confirm the public name before this page ships. */}
+
 <Note>
-  **Private alpha.** Comfy In-App Agent is rolling out to a limited set of users. Public docs and website pages are not available yet. Join the waitlist to request access.
+  **Private beta.** Comfy Agent is rolling out by account and installation. If you do not see the Agent control, it is not enabled for your current setup yet.
 </Note>
 
-**Comfy In-App Agent** is the agent experience inside Comfy Cloud: prompt in chat, and the agent can build or edit workflows on your graph.
+Comfy Agent is the chat experience inside ComfyUI. Ask it to explain a workflow, diagnose an error, make a focused graph change, or run a workflow after you review the request.
 
-## Join the waitlist
+## Where you can use it
 
-<Card title="Join the alpha waitlist" icon="list" href="https://links.comfy.org/agentalpha">
-  Request access to the Comfy In-App Agent private alpha.
+<CapabilitySummary />
+
+Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agent-tools/cli). MCP connects an external AI client to Comfy. The CLI is for terminal and script workflows. Comfy Agent works in the ComfyUI interface.
+
+## Your first Agent task
+
+1. Open the workflow you want help with.
+2. Select **Agent** in the workflow bar.
+3. Confirm the workflow selected for the conversation.
+4. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
+5. Review the response and any graph changes.
+6. Use an approval-first run setting, when that control is available.
+
+## Workflow targeting
+
+Comfy Agent can use workflow context for a conversation. Confirm the workflow target shown in the beta interface before you send a message, especially when you have multiple tabs open.
+
+Do not assume that changing the visible tab changes the workflow context or edit target. Use the controls displayed in your beta build to change context.
+
+Workflow-reference and editing behavior can vary during the beta. Treat only changes that the interface clearly identifies as editable as safe to approve.
+
+## Run permissions
+
+Current beta builds can show run permission controls near the message box:
+
+- **Ask** requests approval before a workflow runs.
+- **Auto** can allow a workflow to run without per-run approval.
+- **Limited** can add a credit limit to run approval.
+
+Review the controls and their description in your build before using them. Run permission controls are about workflow execution. They are not a substitute for reviewing workflow, file, or account access.
+
+## Stay in control
+
+- Review graph changes before you save or run the workflow.
+- Stop an Agent turn when you do not want it to continue.
+- Reject a run request if you do not want to spend credits or start execution.
+- Treat cancelling a chat turn, cancelling a queued run, and cancelling an active workflow as separate actions. Their availability and effects depend on the current surface.
+- Inspect unfamiliar nodes, custom nodes, downloads, and external calls before you run a workflow.
+- Do not paste API keys, passwords, or other secrets into chat, attachments, or skills.
+
+## What the Agent can use
+
+The exact context available during a beta turn depends on the interface, tools, and controls in your build. Check the workflow target, selected nodes, attachments, and permission controls before you send a request.
+
+This draft does not define the complete boundary between UI-sent context, Agent-service access, tool retrieval, model context, and stored data. That boundary is under review.
+
+For Cloud and local data flow, chat history, and privacy controls, see [Comfy Agent data and privacy](/agent-tools/in-app-agent-data-privacy).
+
+## FAQ
+
+### Can the Agent edit more than one workflow?
+
+Confirm the workflow context shown in the interface before you ask for an edit. Beta targeting rules can vary by release, so do not assume that a visible tab is the edit target.
+
+### Does Auto mode let the Agent do anything automatically?
+
+Auto mode is a run-permission control. Review its description in your beta build before using it, and continue to review workflow changes, files, and account actions yourself.
+
+### Does local mean that no data leaves my computer?
+
+No. Do not treat local use as an offline or privacy guarantee. Review the current controls in your build and [Data and privacy](/agent-tools/in-app-agent-data-privacy).
+
+### Can I stop the Agent or a workflow run?
+
+You can stop an Agent turn or reject a run request when the relevant control is available. Cancelling a queued or active workflow is a separate operation. Review the current workflow controls before starting a costly run.
+
+### Can I use my existing Agent skills from Claude Code?
+
+No. Skills for external coding agents are separate from personal Comfy Agent skills. See [Comfy Agent skills](/agent-tools/in-app-agent-skills).
+
+## Access and feedback
+
+<Card title="Request access" icon="list" href="https://links.comfy.org/agentalpha">
+  Request access to the Comfy Agent beta.
 </Card>
 
 ## Feedback
 
-Already in the alpha? Share bugs and impressions:
+Already in the beta? Share bugs and impressions:
 
 <Card title="Send feedback" icon="message" href="https://links.comfy.org/agentalphafeedback">
-  Report bugs or share impressions from the alpha.
+  Report bugs or share impressions from the beta.
 </Card>
 
 ## Related
 
-Looking for agent tools that work from Claude, Cursor, Codex, and other MCP clients (outside the ComfyUI canvas)?
-
-<CardGroup cols={2}>
-  <Card title="Comfy MCP" icon="bolt" href="/agent-tools/mcp">
-    Connect external MCP clients to ComfyUI for generation, search, and workflows.
+<CardGroup cols={3}>
+  <Card title="Get started" icon="play" href="/agent-tools/in-app-agent-installation">
+    Set up Comfy Agent for your available surface.
   </Card>
-  <Card title="Agent Tools overview" icon="robot" href="/agent-tools">
-    Compare the cloud connection, the local connection, and the In-App Agent.
+  <Card title="Agent skills" icon="wand-magic-sparkles" href="/agent-tools/in-app-agent-skills">
+    Create and use reusable Agent instructions when skills are enabled.
+  </Card>
+  <Card title="Data and privacy" icon="shield" href="/agent-tools/in-app-agent-data-privacy">
+    Understand context, remote processing, chat history, and controls.
   </Card>
 </CardGroup>

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -100,6 +100,12 @@ Select **Stop** in the message box to stop the Agent's current response. Workflo
   </Card>
 </CardGroup>
 
+## Access
+
+<Card title="Join the waitlist" icon="list" href="https://links.comfy.org/agentalpha">
+  Request access to Comfy Agent.
+</Card>
+
 ## Feedback
 
 Have a problem or an idea? [Send feedback](https://links.comfy.org/agentalphafeedback) about Comfy Agent.

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -7,7 +7,7 @@ icon: "comments"
 
 import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 
-Comfy Agent is the chat experience inside ComfyUI. Ask it to explain a workflow, diagnose an error, make a focused graph change, or run a workflow after you review the request.
+Comfy Agent is the chat experience inside ComfyUI. Use it to explain a workflow, diagnose an error, make a focused graph change, or run a workflow.
 
 ## Where you can use it
 
@@ -19,18 +19,16 @@ Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agen
 
 1. Open the workflow you want help with.
 2. Select **Agent** in the workflow bar.
-3. Confirm the workflow selected for the conversation.
+3. Choose the workflow for the conversation.
 4. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
-5. Review the response and any graph changes.
+5. Inspect the response and graph changes.
 6. Keep the run permission set to **Ask** for your first workflow run.
 
 ## Workflow targeting
 
-Comfy Agent works in the workflow selected for the conversation. Confirm the target before you send a message, especially when you have multiple tabs open.
+Comfy Agent works in the workflow selected for the conversation.
 
 Changing the visible tab does not change the workflow target. Select a different workflow when you want the Agent to work there.
-
-Only approve changes that the interface identifies as editable.
 
 ## Run permissions
 
@@ -40,20 +38,11 @@ Choose a run permission next to the message box:
 - **Auto** runs workflows without asking for each run.
 - **Limited** requests approval when a run exceeds your credit limit.
 
-Run permissions apply to workflow execution. They do not replace careful review of workflow, file, or account access.
-
-## Stay in control
-
-- Review graph changes before you save or run the workflow.
-- Stop an Agent turn when you do not want it to continue.
-- Reject a run request if you do not want to spend credits or start execution.
-- Treat cancelling a chat turn, cancelling a queued run, and cancelling an active workflow as separate actions. Their availability and effects depend on the current surface.
-- Inspect unfamiliar nodes, custom nodes, downloads, and external calls before you run a workflow.
-- Do not paste API keys, passwords, or other secrets into chat, attachments, or skills.
+Run permissions control workflow execution. Graph edits remain visible in the workflow.
 
 ## What the Agent can use
 
-The Agent uses your message, selected workflow, selected nodes, attachments, and workflow errors. Check that context before you send a message.
+The Agent uses your message, selected workflow, selected nodes, attachments, and workflow errors.
 
 For Cloud and local data flow, chat history, and privacy controls, see [Comfy Agent data and privacy](/agent-tools/in-app-agent-data-privacy).
 
@@ -61,7 +50,7 @@ For Cloud and local data flow, chat history, and privacy controls, see [Comfy Ag
 
 ### Can the Agent edit more than one workflow?
 
-Confirm the workflow context shown in the interface before you ask for an edit. Do not assume that a visible tab is the edit target.
+The Agent edits the workflow selected for the conversation. Select another workflow to work there.
 
 ### Does Auto mode let the Agent do anything automatically?
 
@@ -73,7 +62,7 @@ No. Local use works with your local ComfyUI installation, but Agent requests use
 
 ### Can I stop the Agent or a workflow run?
 
-You can stop an Agent turn or reject a run request when the relevant control is available. Cancelling a queued or active workflow is a separate operation. Review the current workflow controls before starting a costly run.
+Stop an Agent turn from the chat panel. Cancel queued and active workflows from the workflow controls.
 
 ### Can I use my existing Agent skills from Claude Code?
 
@@ -100,7 +89,7 @@ Share bugs and impressions:
     Set up Comfy Agent for your available surface.
   </Card>
   <Card title="Agent skills" icon="wand-magic-sparkles" href="/agent-tools/in-app-agent-skills">
-    Create and use reusable Agent instructions when skills are enabled.
+    Create and use reusable Agent instructions.
   </Card>
   <Card title="Data and privacy" icon="shield" href="/agent-tools/in-app-agent-data-privacy">
     Understand context, chat history, and controls.

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -99,3 +99,7 @@ Select **Stop** in the message box to stop the Agent's current response. Workflo
     Create and use reusable Agent instructions.
   </Card>
 </CardGroup>
+
+## Feedback
+
+Have a problem or an idea? [Send feedback](https://links.comfy.org/agentalphafeedback) about Comfy Agent.

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -7,10 +7,6 @@ icon: "comments"
 
 import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 
-<Note>
-  **Private beta.** Comfy Agent is rolling out by account and installation. If you do not see the Agent control, it is not enabled for your current setup yet.
-</Note>
-
 Comfy Agent is the chat experience inside ComfyUI. Ask it to explain a workflow, diagnose an error, make a focused graph change, or run a workflow after you review the request.
 
 ## Where you can use it
@@ -26,23 +22,23 @@ Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agen
 3. Confirm the workflow selected for the conversation.
 4. Start with a small request, such as “Explain the selected node” or “Add a Save Image node.”
 5. Review the response and any graph changes.
-6. Use an approval-first run setting, when that control is available.
+6. Keep the run permission set to **Ask** for your first workflow run.
 
 ## Workflow targeting
 
-Comfy Agent can use workflow context for a conversation. Confirm the workflow target shown in the beta interface before you send a message, especially when you have multiple tabs open.
+Comfy Agent works in the workflow selected for the conversation. Confirm the target before you send a message, especially when you have multiple tabs open.
 
-Do not assume that changing the visible tab changes the workflow context or edit target. Use the controls displayed in your beta build to change context.
+Changing the visible tab does not change the workflow target. Select a different workflow when you want the Agent to work there.
 
 Only approve changes that the interface identifies as editable.
 
 ## Run permissions
 
-When available, the run permission control appears next to the message box:
+Choose a run permission next to the message box:
 
-- **Ask** requests approval before a workflow runs.
-- **Auto** can allow a workflow to run without per-run approval.
-- **Limited** can add a credit limit to run approval.
+- **Ask** requests approval before each workflow run.
+- **Auto** runs workflows without asking for each run.
+- **Limited** requests approval when a run exceeds your credit limit.
 
 Run permissions apply to workflow execution. They do not replace careful review of workflow, file, or account access.
 
@@ -57,7 +53,7 @@ Run permissions apply to workflow execution. They do not replace careful review 
 
 ## What the Agent can use
 
-The Agent can use workflow context, selected nodes, attachments, and errors included in a request. Available context depends on the surface and controls in use. Check it before you send a message.
+The Agent uses your message, selected workflow, selected nodes, attachments, and workflow errors. Check that context before you send a message.
 
 For Cloud and local data flow, chat history, and privacy controls, see [Comfy Agent data and privacy](/agent-tools/in-app-agent-data-privacy).
 
@@ -69,11 +65,11 @@ Confirm the workflow context shown in the interface before you ask for an edit. 
 
 ### Does Auto mode let the Agent do anything automatically?
 
-Auto mode is a run-permission control. Review its description in your beta build before using it, and continue to review workflow changes, files, and account actions yourself.
+Auto mode runs workflows without asking for each run. It does not change what the Agent can access.
 
 ### Does local mean that no data leaves my computer?
 
-No. Do not treat local use as an offline or privacy guarantee. Review the current controls in your build and [Data and privacy](/agent-tools/in-app-agent-data-privacy).
+No. Local use works with your local ComfyUI installation, but Agent requests use Comfy services. See [Data and privacy](/agent-tools/in-app-agent-data-privacy).
 
 ### Can I stop the Agent or a workflow run?
 
@@ -86,15 +82,15 @@ No. Skills for external coding agents are separate from personal Comfy Agent ski
 ## Access and feedback
 
 <Card title="Request access" icon="list" href="https://links.comfy.org/agentalpha">
-  Request access to the Comfy Agent beta.
+  Request access to Comfy Agent.
 </Card>
 
 ## Feedback
 
-Already in the beta? Share bugs and impressions:
+Share bugs and impressions:
 
 <Card title="Send feedback" icon="message" href="https://links.comfy.org/agentalphafeedback">
-  Report bugs or share impressions from the beta.
+  Report bugs or share impressions.
 </Card>
 
 ## Related

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -34,9 +34,9 @@ Comfy Agent is separate from [Comfy MCP](/agent-tools/mcp) and [Comfy CLI](/agen
 5. Inspect the graph changes.
 6. Run the workflow when it is ready.
 
-## Workflow targeting
+## Choose which workflow to edit
 
-Each message captures the selected workflow tab when you send it. The Agent can edit only that workflow during the turn.
+Select a workflow tab before sending your message. The Agent edits that workflow until it finishes responding.
 
 The Agent cannot create or switch tabs. To work in another tab, select it and send a new message.
 
@@ -62,7 +62,7 @@ If the workflow is valid but still needs an image, video, or other input, attach
 
 ## Work with media
 
-The Agent can inspect the visible contents and dimensions of a still image. For video, it can read duration, resolution, frame rate, and codec details. For audio, it can read duration, codec, and stream details.
+The Agent can inspect the visible contents and dimensions of a still image. For video, it can read the duration, dimensions, frame rate, and format. For audio, it can read the duration, format, and audio tracks.
 
 It can also resize or trim media, extract a video frame, join video clips, and add audio to a video. These results are saved as assets that can be used in a workflow.
 
@@ -83,7 +83,7 @@ For Cloud and local data flow, chat history, and privacy controls, see [Comfy Ag
 
 ## Stop or cancel
 
-Stop an Agent turn from the chat panel. Cancel queued and active workflows from the workflow controls.
+Stop a response from the chat panel. Cancel queued and running workflows from the workflow controls.
 
 ## Related
 
@@ -95,6 +95,6 @@ Stop an Agent turn from the chat panel. Cancel queued and active workflows from 
     Create and use reusable Agent instructions.
   </Card>
   <Card title="Data and privacy" icon="shield" href="/agent-tools/in-app-agent-data-privacy">
-    Understand context, chat history, and controls.
+    See what Comfy Agent uses and where conversations are stored.
   </Card>
 </CardGroup>

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -7,8 +7,6 @@ icon: "comments"
 
 import CapabilitySummary from "/snippets/comfy-agent/capability-summary.mdx";
 
-{/* Draft terminology: Product/Brand must confirm the public name before this page ships. */}
-
 <Note>
   **Private beta.** Comfy Agent is rolling out by account and installation. If you do not see the Agent control, it is not enabled for your current setup yet.
 </Note>
@@ -36,17 +34,17 @@ Comfy Agent can use workflow context for a conversation. Confirm the workflow ta
 
 Do not assume that changing the visible tab changes the workflow context or edit target. Use the controls displayed in your beta build to change context.
 
-Workflow-reference and editing behavior can vary during the beta. Treat only changes that the interface clearly identifies as editable as safe to approve.
+Only approve changes that the interface identifies as editable.
 
 ## Run permissions
 
-Current beta builds can show run permission controls near the message box:
+When available, the run permission control appears next to the message box:
 
 - **Ask** requests approval before a workflow runs.
 - **Auto** can allow a workflow to run without per-run approval.
 - **Limited** can add a credit limit to run approval.
 
-Review the controls and their description in your build before using them. Run permission controls are about workflow execution. They are not a substitute for reviewing workflow, file, or account access.
+Run permissions apply to workflow execution. They do not replace careful review of workflow, file, or account access.
 
 ## Stay in control
 
@@ -59,9 +57,7 @@ Review the controls and their description in your build before using them. Run p
 
 ## What the Agent can use
 
-The exact context available during a beta turn depends on the interface, tools, and controls in your build. Check the workflow target, selected nodes, attachments, and permission controls before you send a request.
-
-This draft does not define the complete boundary between UI-sent context, Agent-service access, tool retrieval, model context, and stored data. That boundary is under review.
+The Agent can use workflow context, selected nodes, attachments, and errors included in a request. Available context depends on the surface and controls in use. Check it before you send a message.
 
 For Cloud and local data flow, chat history, and privacy controls, see [Comfy Agent data and privacy](/agent-tools/in-app-agent-data-privacy).
 
@@ -69,7 +65,7 @@ For Cloud and local data flow, chat history, and privacy controls, see [Comfy Ag
 
 ### Can the Agent edit more than one workflow?
 
-Confirm the workflow context shown in the interface before you ask for an edit. Beta targeting rules can vary by release, so do not assume that a visible tab is the edit target.
+Confirm the workflow context shown in the interface before you ask for an edit. Do not assume that a visible tab is the edit target.
 
 ### Does Auto mode let the Agent do anything automatically?
 
@@ -111,6 +107,6 @@ Already in the beta? Share bugs and impressions:
     Create and use reusable Agent instructions when skills are enabled.
   </Card>
   <Card title="Data and privacy" icon="shield" href="/agent-tools/in-app-agent-data-privacy">
-    Understand context, remote processing, chat history, and controls.
+    Understand context, chat history, and controls.
   </Card>
 </CardGroup>

--- a/agent-tools/in-app-agent.mdx
+++ b/agent-tools/in-app-agent.mdx
@@ -89,16 +89,15 @@ For Cloud and local data flow, chat history, and privacy controls, see [Comfy Ag
 
 Select **Stop** in the message box to stop the Agent's current response. Workflow execution has separate controls in the [run and queue area](/interface/overview); use those to manage a workflow that has already been submitted.
 
-## Related
+## Next steps
 
-<CardGroup cols={3}>
-  <Card title="Get started" icon="play" href="/agent-tools/in-app-agent-installation">
-    Get started in Comfy Cloud or Comfy Desktop.
+<CardGroup cols={2}>
+  <Card title="Make your first image" icon="play" href="/agent-tools/in-app-agent-installation#make-your-first-image">
+    Build, run, and revise an image workflow.
   </Card>
   <Card title="Agent skills" icon="wand-magic-sparkles" href="/agent-tools/in-app-agent-skills">
     Create and use reusable Agent instructions.
   </Card>
-  <Card title="Data and privacy" icon="shield" href="/agent-tools/in-app-agent-data-privacy">
-    See what Comfy Agent uses and where conversations are stored.
-  </Card>
 </CardGroup>
+
+For information about messages, files, and conversation storage, see [Data and privacy](/agent-tools/in-app-agent-data-privacy).

--- a/agent-tools/index.mdx
+++ b/agent-tools/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Tools"
-description: "Leverage AI agents to use ComfyUI smarter and faster. Comfy MCP, Comfy CLI, and the Comfy In-App Agent."
+description: "Use ComfyUI with AI agents through Comfy MCP, Comfy CLI, and Comfy Agent."
 sidebarTitle: "Overview"
 icon: "robot"
 ---
@@ -9,8 +9,8 @@ icon: "robot"
   <Card title="Comfy MCP" icon="bolt" href="/agent-tools/mcp">
     Connect any AI agent to ComfyUI, on Comfy Cloud or on your own machine. **Start here.**
   </Card>
-  <Card title="Comfy In-App Agent" icon="comments" href="/agent-tools/in-app-agent">
-    Agent experience inside Comfy Cloud (chat builds and edits your graph). *Private alpha; waitlist only for now.*
+  <Card title="Comfy Agent" icon="comments" href="/agent-tools/in-app-agent">
+    Agent experience inside ComfyUI. Ask for help building, editing, and running a workflow. *Private beta; availability varies by account and installation.*
   </Card>
   <Card title="Comfy CLI" icon="terminal" href="/agent-tools/cli">
     ComfyUI in the terminal. Install and update ComfyUI, manage models and nodes, and generate from scripts, CI, or batch jobs.
@@ -21,14 +21,14 @@ icon: "robot"
 
 ## Which one should I use?
 
-| | Comfy MCP<br />Cloud Connection | Comfy MCP<br />Local Connection | Comfy In-App Agent |
+| | Comfy MCP<br />Cloud Connection | Comfy MCP<br />Local Connection | Comfy Agent |
 |---|---|---|---|
-| **What is it** | Run Comfy Cloud workflows with your own agent. | Drive your own local ComfyUI with your own agent. | Chat with AI inside the app and watch it build and run workflows for you. |
+| **What is it** | Run Comfy Cloud workflows with your own agent. | Drive your own local ComfyUI with your own agent. | Chat with an Agent inside ComfyUI to understand, build, edit, and run a selected workflow. |
 | **Best for** | Beginners who don't want to set up ComfyUI locally.<br />People who want to share workflows. | People who have ComfyUI locally.<br />People who have private custom nodes.<br />People who need to interact with the local file system. | Everyone from beginners to advanced workflow builders.<br />People who want to see the canvas and check workflows visually. |
-| **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | No setup.<br />An active Comfy Cloud subscription. |
-| **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs (no hardware requirements) |
-| **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Comfy Cloud models.<br />You can import your own models. |
-| **Custom nodes** | The custom nodes supported on Comfy Cloud. | You can install any custom node. | The custom nodes supported on Comfy Cloud. |
+| **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | Agent access for your account and installation. Cloud, Desktop, and git-based local availability can differ. |
+| **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs in Cloud. Local hardware when local execution is available. |
+| **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Cloud or local models, depending on the surface you use. |
+| **Custom nodes** | The custom nodes supported on Comfy Cloud. | You can install any custom node. | Cloud-supported nodes in Cloud. Local nodes in a supported local setup. |
 
 Both MCP columns are the **same product and the same page**. See [Comfy MCP](/agent-tools/mcp) to pick one. You can connect both at once.
 

--- a/agent-tools/index.mdx
+++ b/agent-tools/index.mdx
@@ -27,7 +27,7 @@ icon: "robot"
 | **Best for** | Running Cloud workflows from an external agent.<br />Sharing workflows. | Using an external agent with local models, custom nodes, and files. | Building and editing workflows while viewing the canvas. |
 | **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | A Comfy account and a supported Cloud or local installation. |
 | **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs for Cloud workflows. Local hardware for local workflows. |
-| **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Cloud or local models, depending on the surface you use. |
+| **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Cloud or local models, depending on whether you use Comfy Cloud or Comfy Desktop. |
 | **Custom nodes** | The custom nodes supported on Comfy Cloud. | You can install any custom node. | Cloud-supported nodes in Cloud. Local nodes in a supported local setup. |
 
 Both connections use [Comfy MCP](/agent-tools/mcp), and you can configure them together.

--- a/agent-tools/index.mdx
+++ b/agent-tools/index.mdx
@@ -10,7 +10,7 @@ icon: "robot"
     Connect any AI agent to ComfyUI, on Comfy Cloud or on your own machine. **Start here.**
   </Card>
   <Card title="Comfy Agent" icon="comments" href="/agent-tools/in-app-agent">
-    Agent experience inside ComfyUI. Ask for help building, editing, and running a workflow.
+    Built-in ComfyUI assistant for building, editing, and running workflows.
   </Card>
   <Card title="Comfy CLI" icon="terminal" href="/agent-tools/cli">
     ComfyUI in the terminal. Install and update ComfyUI, manage models and nodes, and generate from scripts, CI, or batch jobs.
@@ -24,13 +24,13 @@ icon: "robot"
 | | Comfy MCP<br />Cloud Connection | Comfy MCP<br />Local Connection | Comfy Agent |
 |---|---|---|---|
 | **What is it** | Run Comfy Cloud workflows with your own agent. | Drive your own local ComfyUI with your own agent. | Chat with an Agent inside ComfyUI to understand, build, edit, and run a selected workflow. |
-| **Best for** | Beginners who don't want to set up ComfyUI locally.<br />People who want to share workflows. | People who have ComfyUI locally.<br />People who have private custom nodes.<br />People who need to interact with the local file system. | Everyone from beginners to advanced workflow builders.<br />People who want to see the canvas and check workflows visually. |
+| **Best for** | Running Cloud workflows from an external agent.<br />Sharing workflows. | Using an external agent with local models, custom nodes, and files. | Building and editing workflows while viewing the canvas. |
 | **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | A Comfy account and a supported Cloud or local installation. |
 | **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs for Cloud workflows. Local hardware for local workflows. |
 | **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Cloud or local models, depending on the surface you use. |
 | **Custom nodes** | The custom nodes supported on Comfy Cloud. | You can install any custom node. | Cloud-supported nodes in Cloud. Local nodes in a supported local setup. |
 
-Both MCP columns are the **same product and the same page**. See [Comfy MCP](/agent-tools/mcp) to pick one. You can connect both at once.
+Both connections use [Comfy MCP](/agent-tools/mcp), and you can configure them together.
 
 ---
 

--- a/agent-tools/index.mdx
+++ b/agent-tools/index.mdx
@@ -10,7 +10,7 @@ icon: "robot"
     Connect any AI agent to ComfyUI, on Comfy Cloud or on your own machine. **Start here.**
   </Card>
   <Card title="Comfy Agent" icon="comments" href="/agent-tools/in-app-agent">
-    Agent experience inside ComfyUI. Ask for help building, editing, and running a workflow. *Private beta; availability varies by account and installation.*
+    Agent experience inside ComfyUI. Ask for help building, editing, and running a workflow.
   </Card>
   <Card title="Comfy CLI" icon="terminal" href="/agent-tools/cli">
     ComfyUI in the terminal. Install and update ComfyUI, manage models and nodes, and generate from scripts, CI, or batch jobs.
@@ -25,8 +25,8 @@ icon: "robot"
 |---|---|---|---|
 | **What is it** | Run Comfy Cloud workflows with your own agent. | Drive your own local ComfyUI with your own agent. | Chat with an Agent inside ComfyUI to understand, build, edit, and run a selected workflow. |
 | **Best for** | Beginners who don't want to set up ComfyUI locally.<br />People who want to share workflows. | People who have ComfyUI locally.<br />People who have private custom nodes.<br />People who need to interact with the local file system. | Everyone from beginners to advanced workflow builders.<br />People who want to see the canvas and check workflows visually. |
-| **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | Agent access for your account and installation. Cloud, Desktop, and git-based local availability can differ. |
-| **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs in Cloud. Local hardware when local execution is available. |
+| **Requires** | Your own agent.<br />An active Comfy Cloud subscription. | Your own agent.<br />A local ComfyUI setup. | A Comfy account and a supported Cloud or local installation. |
+| **GPU** | Cloud GPUs (no hardware requirements) | Your local GPU | Cloud GPUs for Cloud workflows. Local hardware for local workflows. |
 | **Models** | Comfy Cloud models.<br />You can import your own models. | Local models downloaded to your machine. | Cloud or local models, depending on the surface you use. |
 | **Custom nodes** | The custom nodes supported on Comfy Cloud. | You can install any custom node. | Cloud-supported nodes in Cloud. Local nodes in a supported local setup. |
 

--- a/agent-tools/skills.mdx
+++ b/agent-tools/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Skills"
-sidebarTitle: "Skills"
+sidebarTitle: "Skills for coding agents"
 description: "Agent skills and plugins for Comfy, published through the Comfy Skills repository."
 icon: "wand-magic-sparkles"
 ---

--- a/agent-tools/skills.mdx
+++ b/agent-tools/skills.mdx
@@ -5,7 +5,7 @@ description: "Agent skills and plugins for Comfy, published through the Comfy Sk
 icon: "wand-magic-sparkles"
 ---
 
-[**Comfy Skills**](https://github.com/Comfy-Org/comfy-skills) is the home of agent skills and plugins for Comfy. Skills are packaged knowledge an agent loads on demand: model guidance, workflow patterns, and ready-made commands. Any agent gets better at ComfyUI without you writing prompts from scratch.
+[**Comfy Skills**](https://github.com/Comfy-Org/comfy-skills) contains skills and plugins for coding agents. They provide ComfyUI model guidance, workflow patterns, and ready-made commands.
 
 The repository hosts:
 

--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,15 @@
                   "agent-tools/index",
                   "agent-tools/mcp",
                   "agent-tools/cli",
-                  "agent-tools/in-app-agent",
+                  {
+                    "group": "Comfy Agent",
+                    "pages": [
+                      "agent-tools/in-app-agent",
+                      "agent-tools/in-app-agent-installation",
+                      "agent-tools/in-app-agent-skills",
+                      "agent-tools/in-app-agent-data-privacy"
+                    ]
+                  },
                   "agent-tools/skills"
                 ]
               },

--- a/snippets/comfy-agent/capability-summary.mdx
+++ b/snippets/comfy-agent/capability-summary.mdx
@@ -1,5 +1,5 @@
 | Surface | What to expect |
 | --- | --- |
-| **Comfy Cloud** | The Agent, workflows, and assets use your Comfy Cloud account. There is no local package to install. Availability is controlled by your account and rollout status. |
-| **Comfy Desktop and local ComfyUI** | The Agent can use the ComfyUI installation on your machine when the feature is available for your distribution. Local availability, supported versions, and installation steps are released separately from Cloud. |
-| **Network connection** | Local use can involve network services. The final data-flow documentation is under Privacy and Engineering review. See [Data and privacy](/agent-tools/in-app-agent-data-privacy). |
+| **Comfy Cloud** | The Agent, workflows, and assets use your Comfy Cloud account. There is no local package to install. |
+| **Comfy Desktop** | The Agent works with the ComfyUI installation on your machine, including its workflows, models, and custom nodes. |
+| **Network connection** | Agent requests use Comfy services. See [Data and privacy](/agent-tools/in-app-agent-data-privacy). |

--- a/snippets/comfy-agent/capability-summary.mdx
+++ b/snippets/comfy-agent/capability-summary.mdx
@@ -1,4 +1,4 @@
-| Surface | What to expect |
+| Where you use Comfy Agent | What to expect |
 | --- | --- |
 | **Comfy Cloud** | The Agent, workflows, and assets use your Comfy Cloud account. There is no local package to install. |
 | **Comfy Desktop** | The Agent works with the ComfyUI installation on your machine, including its workflows, models, and custom nodes. |

--- a/snippets/comfy-agent/capability-summary.mdx
+++ b/snippets/comfy-agent/capability-summary.mdx
@@ -1,0 +1,5 @@
+| Surface | What to expect |
+| --- | --- |
+| **Comfy Cloud** | The Agent, workflows, and assets use your Comfy Cloud account. There is no local package to install. Availability is controlled by your account and rollout status. |
+| **Comfy Desktop and local ComfyUI** | The Agent can use the ComfyUI installation on your machine when the feature is available for your distribution. Local availability, supported versions, and installation steps are released separately from Cloud. |
+| **Network connection** | Local use can involve network services. The final data-flow documentation is under Privacy and Engineering review. See [Data and privacy](/agent-tools/in-app-agent-data-privacy). |


### PR DESCRIPTION
Comfy Agent currently has an alpha placeholder instead of product documentation. This adds guides for getting started, building and editing workflows, working with media, managing personal skills, and understanding Cloud and local data handling.

The guides cover:

- choosing the workflow that the Agent edits
- building from templates and updating existing workflows
- validating workflows and supplying missing inputs
- inspecting and processing image, video, and audio files
- choosing Ask or Auto run permissions
- creating, using, updating, and deleting personal skills through chat
- completing a first image workflow from prompt to output
- Cloud and local conversation storage

The Agent Tools navigation groups the new guides and distinguishes Comfy Agent, Comfy MCP, and Comfy CLI.

## Validation

- `jq empty docs.json`
- `git diff --check`
- all internal links and anchors in the four Agent guides
- four local preview routes
- capability review against `Comfy-Org/cloud` and `Comfy-Org/ComfyUI_frontend`