### PR TITLE
fix(cms): drop code formatting around Cloud v0.35.0 fl2va and ref2va

### DIFF
--- a/.github/scripts/cms/published-versions.json
+++ b/.github/scripts/cms/published-versions.json
@@ -902,7 +902,7 @@
         "ru",
         "zh"
       ],
-      "published_at": "2026-09-09T12:17:49.994Z"
+      "published_at": "2026-09-11T02:27:50.819Z"
     },
     {
       "project": "comfyui",

--- a/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/en/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Added Pixal3D multi-view reconstruction
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Added SenseNova U1.5 support
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Added H3 PDD LoRA support
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Added Fun ControlNet Union support for `fl2va` and `ref2va`
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Added Fun ControlNet Union support for fl2va and ref2va
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Support DiffSynth-Studio and ModelScope trained LoRAs
 
 **Partner Node Updates**

--- a/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/es/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Se añadió la reconstrucción multivista de Pixal3D
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Se añadió soporte para SenseNova U1.5
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Se añadió soporte para H3 PDD LoRA
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Se añadió soporte para Fun ControlNet Union en `fl2va` y `ref2va`
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Se añadió soporte para Fun ControlNet Union en fl2va y ref2va
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Se añadió soporte para LoRAs entrenados con DiffSynth-Studio y ModelScope
 
 **Actualizaciones de nodos de socios**

--- a/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/fr/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Ajout de la reconstruction multi-vues Pixal3D
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Ajout de la prise en charge de SenseNova U1.5
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Ajout de la prise en charge du LoRA H3 PDD
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Ajout de la prise en charge de Fun ControlNet Union pour `fl2va` et `ref2va`
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Ajout de la prise en charge de Fun ControlNet Union pour fl2va et ref2va
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Prise en charge des LoRA entraînés avec DiffSynth-Studio et ModelScope
 
 **Mises à jour des nœuds partenaires**

--- a/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ja/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Pixal3Dのマルチビュー再構成のサポートを追加しました。
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): SenseNova U1.5のサポートを追加しました。
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3 PDD LoRAのサポートを追加しました。
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): `fl2va`と`ref2va`向けのFun ControlNet Unionサポートを追加しました。
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): fl2vaとref2va向けのFun ControlNet Unionサポートを追加しました。
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-StudioとModelScopeでトレーニングされたLoRAをサポートしました。
 
 **パートナーノードの更新**

--- a/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ko/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Pixal3D 멀티뷰 재구성 추가
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): SenseNova U1.5 지원 추가
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): H3 PDD LoRA 지원 추가
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): `fl2va` 및 `ref2va`용 Fun ControlNet Union 지원 추가
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): fl2va 및 ref2va용 Fun ControlNet Union 지원 추가
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): DiffSynth-Studio 및 ModelScope에서 학습된 LoRA 지원
 
 **파트너 노드 업데이트**

--- a/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/ru/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views): Добавлена многовидовая реконструкция Pixal3D
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922): Добавлена поддержка SenseNova U1.5
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908): Добавлена поддержка H3 PDD LoRA
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Добавлена поддержка Fun ControlNet Union для `fl2va` и `ref2va`
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union): Добавлена поддержка Fun ControlNet Union для fl2va и ref2va
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662): Поддержаны LoRA, обученные с помощью DiffSynth-Studio и ModelScope
 
 **Обновления партнёрских узлов**

--- a/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
+++ b/.github/scripts/cms/staging/cloud/zh/changelog/index.mdx
@@ -10,7 +10,7 @@ cmsStaging: true
 * [**Pixal3D Multi-View**](https://cloud.comfy.org/?template=3d_pixal3d_multi_views)：新增 Pixal3D 多视图重建
 * [**SenseNova U1.5**](https://github.com/Comfy-Org/ComfyUI/pull/15922)：新增 SenseNova U1.5 支持
 * [**MiniMax-H3 PDD LoRA**](https://github.com/Comfy-Org/ComfyUI/pull/15908)：新增 H3 PDD LoRA 支持
-* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union)：新增对 `fl2va` 和 `ref2va` 的 Fun ControlNet Union 支持
+* [**MiniMax-H3 Fun ControlNet Union**](https://cloud.comfy.org/?template=video_minimax_h3_fun_controlnet_union)：新增对 fl2va 和 ref2va 的 Fun ControlNet Union 支持
 * [**MiniMax-H3 & HiDream O1 LoRAs**](https://github.com/Comfy-Org/ComfyUI/pull/15662)：支持 DiffSynth-Studio 和 ModelScope 训练的 LoRA
 
 **合作伙伴节点更新**


### PR DESCRIPTION
## Summary
- Cloud v0.35.0 Fun ControlNet Union bullet now writes fl2va and ref2va as plain text in all CMS locales (en, zh, ja, ko, fr, ru, es).
- Refresh `published-versions.json` after republishing the Cloud v0.35.0 popup.

## Test plan
- [x] Cloud v0.35.0 already force-synced and published in Strapi for all 7 locales
- [ ] Confirm the in-app Cloud popup no longer renders fl2va / ref2va as inline code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CMS staging changelog text and publish timestamp only; no application logic or security-sensitive changes.
> 
> **Overview**
> **Cloud v0.35.0 changelog copy fix** across all seven CMS locales (en, es, fr, ja, ko, ru, zh): the MiniMax-H3 Fun ControlNet Union bullet no longer wraps **fl2va** and **ref2va** in inline code backticks, so the in-app Cloud popup should show them as plain text.
> 
> **Publish metadata**: `published-versions.json` updates the **cloud** `0.35.0` entry’s `published_at` to reflect republishing the v0.35.0 popup after this content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5244e31d291d39bfd871f308752994c71dbd72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->